### PR TITLE
feat(server): add web dashboard for real-time virtual thread monitoring

### DIFF
--- a/argus-server/src/main/resources/public/css/style.css
+++ b/argus-server/src/main/resources/public/css/style.css
@@ -1,0 +1,298 @@
+* {
+    margin: 0;
+    padding: 0;
+    box-sizing: border-box;
+}
+
+:root {
+    --bg-primary: #0d1117;
+    --bg-secondary: #161b22;
+    --bg-tertiary: #21262d;
+    --text-primary: #c9d1d9;
+    --text-secondary: #8b949e;
+    --accent-blue: #58a6ff;
+    --accent-green: #3fb950;
+    --accent-red: #f85149;
+    --accent-orange: #d29922;
+    --accent-purple: #a371f7;
+    --border-color: #30363d;
+}
+
+body {
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif;
+    background-color: var(--bg-primary);
+    color: var(--text-primary);
+    line-height: 1.6;
+    min-height: 100vh;
+    display: flex;
+    flex-direction: column;
+}
+
+header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 1rem 2rem;
+    background-color: var(--bg-secondary);
+    border-bottom: 1px solid var(--border-color);
+}
+
+.logo {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+}
+
+.logo-icon {
+    font-size: 2rem;
+}
+
+.logo h1 {
+    font-size: 1.5rem;
+    font-weight: 600;
+    color: var(--text-primary);
+}
+
+.status {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.5rem 1rem;
+    border-radius: 2rem;
+    font-size: 0.875rem;
+    font-weight: 500;
+}
+
+.status-dot {
+    width: 10px;
+    height: 10px;
+    border-radius: 50%;
+}
+
+.status.connected {
+    background-color: rgba(63, 185, 80, 0.15);
+    color: var(--accent-green);
+}
+
+.status.connected .status-dot {
+    background-color: var(--accent-green);
+    box-shadow: 0 0 8px var(--accent-green);
+}
+
+.status.disconnected {
+    background-color: rgba(248, 81, 73, 0.15);
+    color: var(--accent-red);
+}
+
+.status.disconnected .status-dot {
+    background-color: var(--accent-red);
+}
+
+main {
+    flex: 1;
+    padding: 2rem;
+    max-width: 1400px;
+    margin: 0 auto;
+    width: 100%;
+}
+
+.metrics {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+    gap: 1.5rem;
+    margin-bottom: 2rem;
+}
+
+.metric-card {
+    background-color: var(--bg-secondary);
+    border: 1px solid var(--border-color);
+    border-radius: 8px;
+    padding: 1.5rem;
+    text-align: center;
+}
+
+.metric-card h3 {
+    font-size: 0.875rem;
+    font-weight: 500;
+    color: var(--text-secondary);
+    margin-bottom: 0.5rem;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+}
+
+.metric-value {
+    font-size: 2.5rem;
+    font-weight: 700;
+    color: var(--accent-blue);
+    font-family: 'SF Mono', SFMono-Regular, Consolas, monospace;
+}
+
+.metric-card.alert .metric-value {
+    color: var(--accent-orange);
+}
+
+.metric-card.alert.has-pinned {
+    border-color: var(--accent-orange);
+    background-color: rgba(210, 153, 34, 0.1);
+}
+
+.metric-card.alert.has-pinned .metric-value {
+    color: var(--accent-red);
+    animation: pulse 2s infinite;
+}
+
+@keyframes pulse {
+    0%, 100% { opacity: 1; }
+    50% { opacity: 0.6; }
+}
+
+.events-section {
+    background-color: var(--bg-secondary);
+    border: 1px solid var(--border-color);
+    border-radius: 8px;
+    overflow: hidden;
+}
+
+.events-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 1rem 1.5rem;
+    border-bottom: 1px solid var(--border-color);
+}
+
+.events-header h2 {
+    font-size: 1rem;
+    font-weight: 600;
+}
+
+.events-controls {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+}
+
+.btn {
+    background-color: var(--bg-tertiary);
+    border: 1px solid var(--border-color);
+    color: var(--text-primary);
+    padding: 0.5rem 1rem;
+    border-radius: 6px;
+    cursor: pointer;
+    font-size: 0.875rem;
+    transition: background-color 0.2s;
+}
+
+.btn:hover {
+    background-color: var(--border-color);
+}
+
+.checkbox-label {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    font-size: 0.875rem;
+    color: var(--text-secondary);
+    cursor: pointer;
+}
+
+.checkbox-label input[type="checkbox"] {
+    cursor: pointer;
+}
+
+.events-log {
+    height: 500px;
+    overflow-y: auto;
+    padding: 0.5rem;
+    font-family: 'SF Mono', SFMono-Regular, Consolas, monospace;
+    font-size: 0.8125rem;
+}
+
+.event-placeholder {
+    color: var(--text-secondary);
+    text-align: center;
+    padding: 2rem;
+}
+
+.event-item {
+    display: flex;
+    gap: 1rem;
+    padding: 0.5rem 1rem;
+    border-radius: 4px;
+    margin-bottom: 2px;
+    background-color: var(--bg-tertiary);
+}
+
+.event-item:hover {
+    background-color: var(--border-color);
+}
+
+.event-time {
+    color: var(--text-secondary);
+    flex-shrink: 0;
+    width: 100px;
+}
+
+.event-type {
+    flex-shrink: 0;
+    width: 80px;
+    font-weight: 600;
+    text-transform: uppercase;
+}
+
+.event-type.start {
+    color: var(--accent-green);
+}
+
+.event-type.end {
+    color: var(--accent-blue);
+}
+
+.event-type.pinned {
+    color: var(--accent-red);
+}
+
+.event-type.submit_failed {
+    color: var(--accent-orange);
+}
+
+.event-details {
+    color: var(--text-primary);
+    flex: 1;
+    word-break: break-word;
+}
+
+.event-item.pinned {
+    background-color: rgba(248, 81, 73, 0.15);
+    border-left: 3px solid var(--accent-red);
+}
+
+.event-item.pinned .event-details {
+    color: var(--accent-red);
+}
+
+footer {
+    text-align: center;
+    padding: 1rem;
+    color: var(--text-secondary);
+    font-size: 0.75rem;
+    border-top: 1px solid var(--border-color);
+}
+
+/* Scrollbar styling */
+::-webkit-scrollbar {
+    width: 8px;
+}
+
+::-webkit-scrollbar-track {
+    background: var(--bg-primary);
+}
+
+::-webkit-scrollbar-thumb {
+    background: var(--border-color);
+    border-radius: 4px;
+}
+
+::-webkit-scrollbar-thumb:hover {
+    background: var(--text-secondary);
+}

--- a/argus-server/src/main/resources/public/index.html
+++ b/argus-server/src/main/resources/public/index.html
@@ -1,0 +1,64 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Argus - Virtual Thread Profiler</title>
+    <link rel="stylesheet" href="/css/style.css">
+</head>
+<body>
+    <header>
+        <div class="logo">
+            <span class="logo-icon">&#x1F441;</span>
+            <h1>Argus</h1>
+        </div>
+        <div id="connection-status" class="status disconnected">
+            <span class="status-dot"></span>
+            <span class="status-text">Disconnected</span>
+        </div>
+    </header>
+
+    <main>
+        <section class="metrics">
+            <div class="metric-card">
+                <h3>Total Events</h3>
+                <div class="metric-value" id="total-events">0</div>
+            </div>
+            <div class="metric-card">
+                <h3>Thread Starts</h3>
+                <div class="metric-value" id="start-events">0</div>
+            </div>
+            <div class="metric-card">
+                <h3>Thread Ends</h3>
+                <div class="metric-value" id="end-events">0</div>
+            </div>
+            <div class="metric-card alert">
+                <h3>Pinned Threads</h3>
+                <div class="metric-value" id="pinned-events">0</div>
+            </div>
+        </section>
+
+        <section class="events-section">
+            <div class="events-header">
+                <h2>Live Event Stream</h2>
+                <div class="events-controls">
+                    <button id="clear-events" class="btn">Clear</button>
+                    <label class="checkbox-label">
+                        <input type="checkbox" id="auto-scroll" checked>
+                        Auto-scroll
+                    </label>
+                </div>
+            </div>
+            <div id="events-log" class="events-log">
+                <div class="event-placeholder">Waiting for events...</div>
+            </div>
+        </section>
+    </main>
+
+    <footer>
+        <p>Argus Virtual Thread Profiler - Real-time JFR Event Monitoring</p>
+    </footer>
+
+    <script src="/js/app.js"></script>
+</body>
+</html>

--- a/argus-server/src/main/resources/public/js/app.js
+++ b/argus-server/src/main/resources/public/js/app.js
@@ -1,0 +1,218 @@
+(function() {
+    'use strict';
+
+    // DOM elements
+    const connectionStatus = document.getElementById('connection-status');
+    const statusText = connectionStatus.querySelector('.status-text');
+    const totalEventsEl = document.getElementById('total-events');
+    const startEventsEl = document.getElementById('start-events');
+    const endEventsEl = document.getElementById('end-events');
+    const pinnedEventsEl = document.getElementById('pinned-events');
+    const eventsLog = document.getElementById('events-log');
+    const clearBtn = document.getElementById('clear-events');
+    const autoScrollCheckbox = document.getElementById('auto-scroll');
+    const pinnedCard = pinnedEventsEl.closest('.metric-card');
+
+    // State
+    let ws = null;
+    let reconnectAttempts = 0;
+    const maxReconnectAttempts = 10;
+    const reconnectDelay = 2000;
+    const maxEvents = 500;
+
+    const counts = {
+        total: 0,
+        START: 0,
+        END: 0,
+        PINNED: 0,
+        SUBMIT_FAILED: 0
+    };
+
+    function connect() {
+        const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
+        const wsUrl = `${protocol}//${window.location.host}/events`;
+
+        ws = new WebSocket(wsUrl);
+
+        ws.onopen = function() {
+            console.log('[Argus] WebSocket connected');
+            reconnectAttempts = 0;
+            setConnected(true);
+        };
+
+        ws.onclose = function() {
+            console.log('[Argus] WebSocket disconnected');
+            setConnected(false);
+            scheduleReconnect();
+        };
+
+        ws.onerror = function(error) {
+            console.error('[Argus] WebSocket error:', error);
+        };
+
+        ws.onmessage = function(event) {
+            try {
+                const data = JSON.parse(event.data);
+                handleEvent(data);
+            } catch (e) {
+                console.error('[Argus] Failed to parse event:', e);
+            }
+        };
+    }
+
+    function setConnected(connected) {
+        if (connected) {
+            connectionStatus.classList.remove('disconnected');
+            connectionStatus.classList.add('connected');
+            statusText.textContent = 'Connected';
+        } else {
+            connectionStatus.classList.remove('connected');
+            connectionStatus.classList.add('disconnected');
+            statusText.textContent = 'Disconnected';
+        }
+    }
+
+    function scheduleReconnect() {
+        if (reconnectAttempts >= maxReconnectAttempts) {
+            console.log('[Argus] Max reconnect attempts reached');
+            statusText.textContent = 'Connection Failed';
+            return;
+        }
+
+        reconnectAttempts++;
+        statusText.textContent = `Reconnecting (${reconnectAttempts}/${maxReconnectAttempts})...`;
+
+        setTimeout(connect, reconnectDelay);
+    }
+
+    function handleEvent(event) {
+        counts.total++;
+        counts[event.type] = (counts[event.type] || 0) + 1;
+
+        updateCounters();
+        addEventToLog(event);
+    }
+
+    function updateCounters() {
+        totalEventsEl.textContent = formatNumber(counts.total);
+        startEventsEl.textContent = formatNumber(counts.START);
+        endEventsEl.textContent = formatNumber(counts.END);
+        pinnedEventsEl.textContent = formatNumber(counts.PINNED);
+
+        if (counts.PINNED > 0) {
+            pinnedCard.classList.add('has-pinned');
+        }
+    }
+
+    function formatNumber(num) {
+        if (num >= 1000000) {
+            return (num / 1000000).toFixed(1) + 'M';
+        }
+        if (num >= 1000) {
+            return (num / 1000).toFixed(1) + 'K';
+        }
+        return num.toString();
+    }
+
+    function addEventToLog(event) {
+        // Remove placeholder if exists
+        const placeholder = eventsLog.querySelector('.event-placeholder');
+        if (placeholder) {
+            placeholder.remove();
+        }
+
+        const item = document.createElement('div');
+        item.className = 'event-item ' + event.type.toLowerCase();
+
+        const time = formatTimestamp(event.timestamp);
+        const details = formatEventDetails(event);
+
+        item.innerHTML = `
+            <span class="event-time">${time}</span>
+            <span class="event-type ${event.type.toLowerCase()}">${event.type}</span>
+            <span class="event-details">${details}</span>
+        `;
+
+        eventsLog.appendChild(item);
+
+        // Limit events
+        while (eventsLog.children.length > maxEvents) {
+            eventsLog.removeChild(eventsLog.firstChild);
+        }
+
+        // Auto-scroll
+        if (autoScrollCheckbox.checked) {
+            eventsLog.scrollTop = eventsLog.scrollHeight;
+        }
+    }
+
+    function formatTimestamp(timestamp) {
+        if (!timestamp) return '--:--:--';
+
+        try {
+            const date = new Date(timestamp);
+            return date.toLocaleTimeString('en-US', {
+                hour12: false,
+                hour: '2-digit',
+                minute: '2-digit',
+                second: '2-digit'
+            });
+        } catch (e) {
+            return timestamp.substring(11, 19) || '--:--:--';
+        }
+    }
+
+    function formatEventDetails(event) {
+        const parts = [];
+
+        if (event.threadName) {
+            parts.push(`Thread: ${escapeHtml(event.threadName)}`);
+        } else if (event.threadId) {
+            parts.push(`Thread ID: ${event.threadId}`);
+        }
+
+        if (event.carrierThread) {
+            parts.push(`Carrier: ${event.carrierThread}`);
+        }
+
+        if (event.duration && event.duration > 0) {
+            parts.push(`Duration: ${formatDuration(event.duration)}`);
+        }
+
+        if (event.stackTrace) {
+            parts.push(`Stack: ${escapeHtml(event.stackTrace.substring(0, 100))}...`);
+        }
+
+        return parts.join(' | ') || 'No details';
+    }
+
+    function formatDuration(nanos) {
+        if (nanos < 1000) return nanos + 'ns';
+        if (nanos < 1000000) return (nanos / 1000).toFixed(2) + 'us';
+        if (nanos < 1000000000) return (nanos / 1000000).toFixed(2) + 'ms';
+        return (nanos / 1000000000).toFixed(2) + 's';
+    }
+
+    function escapeHtml(text) {
+        const div = document.createElement('div');
+        div.textContent = text;
+        return div.innerHTML;
+    }
+
+    function clearEvents() {
+        eventsLog.innerHTML = '<div class="event-placeholder">Waiting for events...</div>';
+        counts.total = 0;
+        counts.START = 0;
+        counts.END = 0;
+        counts.PINNED = 0;
+        counts.SUBMIT_FAILED = 0;
+        updateCounters();
+        pinnedCard.classList.remove('has-pinned');
+    }
+
+    // Event listeners
+    clearBtn.addEventListener('click', clearEvents);
+
+    // Initialize
+    connect();
+})();


### PR DESCRIPTION
Add static file serving to ArgusServer and create a web dashboard that displays real-time virtual thread events. Dashboard features connection status indicator, event counters, and live scrolling event log with special highlighting for pinned thread events.

  ## Description

  Add a web-based dashboard to Argus that provides real-time monitoring of
  virtual thread events. When users access `http://localhost:8080/`, they can
  view live JFR event data streamed via WebSocket.

  ## Type of Change

  - [ ] Bug fix (non-breaking change which fixes an issue)
  - [x] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality
  to not work as expected)
  - [ ] Documentation update
  - [ ] Refactoring (no functional changes)

  ## Changes Made

  - Added static file serving capability to `ArgusServerHandler` for `/`,
  `/index.html`, `/css/*`, `/js/*` paths
  - Created `public/index.html` - Dashboard UI with connection status, metric
  cards, and event log
  - Created `public/css/style.css` - Dark theme styling optimized for profiler
  aesthetics
  - Created `public/js/app.js` - WebSocket client with auto-reconnect, real-time
  event counters, and live event stream

## How Has This Been Tested?

- [ ] Unit tests
- [ ] Integration tests
- [x] Manual testing

**Test Configuration:**
- Java Version: 21
- OS: macOS

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature
works
- [x] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)

Dashboard displays:
- Connection status indicator (green when connected, red when disconnected)
- Event counters for Total Events, Thread Starts, Thread Ends, and Pinned
Threads
- Live scrolling event log with color-coded event types
- Pinned thread events highlighted in red with pulsing alert

## Additional Notes

To test the dashboard:
```bash
# Build and run
./gradlew :samples:virtual-thread-demo:runServerDemo
```
# Open browser
open http://localhost:8080/

<img width="1923" height="1080" alt="image" src="https://github.com/user-attachments/assets/162714dc-1e19-44b9-8ab8-18013c984285" />
