### PR TITLE
feat: add event export functionality

### DIFF
--- a/argus-frontend/src/main/resources/public/css/style.css
+++ b/argus-frontend/src/main/resources/public/css/style.css
@@ -1291,6 +1291,132 @@ main {
     padding-left: 1rem;
 }
 
+/* Export Modal */
+.export-modal {
+    max-width: 500px;
+    width: 90%;
+}
+
+.export-section {
+    margin-bottom: 1.5rem;
+}
+
+.export-section:last-of-type {
+    margin-bottom: 1rem;
+}
+
+.export-section h3 {
+    font-size: 0.875rem;
+    font-weight: 600;
+    color: var(--text-primary);
+    margin: 0 0 0.75rem 0;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+}
+
+.export-format-options {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+}
+
+.export-format-options .radio-label {
+    display: flex;
+    align-items: flex-start;
+    gap: 0.75rem;
+    padding: 0.75rem 1rem;
+    background-color: var(--bg-tertiary);
+    border-radius: 8px;
+    cursor: pointer;
+    transition: background-color 0.2s;
+}
+
+.export-format-options .radio-label:hover {
+    background-color: var(--border-color);
+}
+
+.export-format-options .radio-label input[type="radio"] {
+    margin-top: 0.25rem;
+    flex-shrink: 0;
+}
+
+.export-format-options .radio-label span {
+    font-weight: 500;
+    color: var(--text-primary);
+}
+
+.export-format-options .radio-label small {
+    display: block;
+    color: var(--text-secondary);
+    font-size: 0.75rem;
+    margin-top: 0.125rem;
+}
+
+.export-type-filters {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+}
+
+.export-type-filters .checkbox-label {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.5rem 0.75rem;
+    background-color: var(--bg-tertiary);
+    border-radius: 6px;
+    cursor: pointer;
+    transition: background-color 0.2s;
+}
+
+.export-type-filters .checkbox-label:hover {
+    background-color: var(--border-color);
+}
+
+.export-type-filters .checkbox-label span {
+    font-size: 0.875rem;
+    color: var(--text-primary);
+}
+
+.export-time-range {
+    display: flex;
+    gap: 1rem;
+}
+
+.export-time-range .time-input-group {
+    flex: 1;
+}
+
+.export-time-range .time-input-group label {
+    display: block;
+    font-size: 0.75rem;
+    color: var(--text-secondary);
+    margin-bottom: 0.25rem;
+}
+
+.export-time-range input[type="datetime-local"] {
+    width: 100%;
+    padding: 0.5rem;
+    background-color: var(--bg-tertiary);
+    border: 1px solid var(--border-color);
+    border-radius: 6px;
+    color: var(--text-primary);
+    font-size: 0.875rem;
+}
+
+.export-time-range input[type="datetime-local"]:focus {
+    outline: none;
+    border-color: var(--accent-blue);
+}
+
+.export-actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: 0.75rem;
+    padding-top: 1rem;
+    border-top: 1px solid var(--border-color);
+}
+
 /* Footer */
 footer {
     text-align: center;

--- a/argus-frontend/src/main/resources/public/index.html
+++ b/argus-frontend/src/main/resources/public/index.html
@@ -14,6 +14,7 @@
             <h1>Argus</h1>
         </div>
         <div class="header-actions">
+            <button id="export-btn" class="btn" title="Export Events">Export</button>
             <button id="thread-dump-btn" class="btn" title="Capture Thread Dump">Thread Dump</button>
             <button id="help-btn" class="btn btn-icon" title="Help">?</button>
             <div id="connection-status" class="status disconnected">
@@ -272,6 +273,80 @@
                 </div>
                 <div class="dump-content">
                     <pre id="dump-output">Loading...</pre>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <!-- Export Modal -->
+    <div id="export-modal" class="modal hidden">
+        <div class="modal-backdrop"></div>
+        <div class="modal-content export-modal">
+            <div class="modal-header">
+                <h2>Export Events</h2>
+                <button class="modal-close">&times;</button>
+            </div>
+            <div class="modal-body">
+                <div class="export-section">
+                    <h3>Format</h3>
+                    <div class="export-format-options">
+                        <label class="radio-label">
+                            <input type="radio" name="export-format" value="json" checked>
+                            <span>JSON</span>
+                            <small>Structured format with metadata</small>
+                        </label>
+                        <label class="radio-label">
+                            <input type="radio" name="export-format" value="csv">
+                            <span>CSV</span>
+                            <small>Compatible with Excel/spreadsheets</small>
+                        </label>
+                        <label class="radio-label">
+                            <input type="radio" name="export-format" value="jsonl">
+                            <span>JSON Lines</span>
+                            <small>One JSON object per line</small>
+                        </label>
+                    </div>
+                </div>
+
+                <div class="export-section">
+                    <h3>Event Types</h3>
+                    <div class="export-type-filters">
+                        <label class="checkbox-label">
+                            <input type="checkbox" id="export-type-start" checked>
+                            <span>START</span>
+                        </label>
+                        <label class="checkbox-label">
+                            <input type="checkbox" id="export-type-end" checked>
+                            <span>END</span>
+                        </label>
+                        <label class="checkbox-label">
+                            <input type="checkbox" id="export-type-pinned" checked>
+                            <span>PINNED</span>
+                        </label>
+                        <label class="checkbox-label">
+                            <input type="checkbox" id="export-type-submit-failed" checked>
+                            <span>SUBMIT_FAILED</span>
+                        </label>
+                    </div>
+                </div>
+
+                <div class="export-section">
+                    <h3>Time Range (Optional)</h3>
+                    <div class="export-time-range">
+                        <div class="time-input-group">
+                            <label for="export-time-from">From</label>
+                            <input type="datetime-local" id="export-time-from">
+                        </div>
+                        <div class="time-input-group">
+                            <label for="export-time-to">To</label>
+                            <input type="datetime-local" id="export-time-to">
+                        </div>
+                    </div>
+                </div>
+
+                <div class="export-actions">
+                    <button id="export-download-btn" class="btn btn-primary">Download</button>
+                    <button id="export-cancel-btn" class="btn">Cancel</button>
                 </div>
             </div>
         </div>

--- a/argus-server/src/main/java/io/argus/server/http/HttpResponseHelper.java
+++ b/argus-server/src/main/java/io/argus/server/http/HttpResponseHelper.java
@@ -64,4 +64,40 @@ public final class HttpResponseHelper {
     public static void sendNotFound(ChannelHandlerContext ctx, FullHttpRequest request) {
         send(ctx, request, HttpResponseStatus.NOT_FOUND, "Not Found", "text/plain");
     }
+
+    /**
+     * Sends a 400 Bad Request response.
+     *
+     * @param ctx     the channel handler context
+     * @param request the original HTTP request
+     * @param message the error message
+     */
+    public static void sendBadRequest(ChannelHandlerContext ctx, FullHttpRequest request, String message) {
+        send(ctx, request, HttpResponseStatus.BAD_REQUEST, message, "text/plain");
+    }
+
+    /**
+     * Sends a downloadable file response.
+     *
+     * @param ctx         the channel handler context
+     * @param request     the original HTTP request
+     * @param content     the file content
+     * @param contentType the content type
+     * @param filename    the suggested filename
+     */
+    public static void sendDownload(ChannelHandlerContext ctx, FullHttpRequest request,
+                                    String content, String contentType, String filename) {
+        ByteBuf buf = Unpooled.copiedBuffer(content, CharsetUtil.UTF_8);
+        FullHttpResponse response = new DefaultFullHttpResponse(
+                HttpVersion.HTTP_1_1, HttpResponseStatus.OK, buf);
+        response.headers()
+                .set(HttpHeaderNames.CONTENT_TYPE, contentType)
+                .setInt(HttpHeaderNames.CONTENT_LENGTH, buf.readableBytes())
+                .set(HttpHeaderNames.CONTENT_DISPOSITION, "attachment; filename=\"" + filename + "\"");
+
+        ChannelFuture future = ctx.writeAndFlush(response);
+        if (!HttpUtil.isKeepAlive(request)) {
+            future.addListener(ChannelFutureListener.CLOSE);
+        }
+    }
 }


### PR DESCRIPTION
## Summary

- Add `/export` API endpoint with filtering support (format, event types, time range)
- Add Export button in dashboard header with modal dialog for export options
- Support CSV, JSON, and JSON Lines export formats
- Store recent events (up to 10,000) in EventBroadcaster for export

## Changes

### Backend
- `ArgusChannelHandler.java`: Add `/export` endpoint with CSV/JSON/JSONL export
- `HttpResponseHelper.java`: Add `sendDownload()` and `sendBadRequest()` helpers
- `EventBroadcaster.java`: Store events for export with `getRecentEvents()` method

### Frontend
- `index.html`: Add Export button and modal with format/type/time options
- `app.js`: Add export modal handlers and download logic
- `style.css`: Add export modal styles

## Test plan

- [ ] Click Export button in header - modal should open
- [ ] Select JSON format, download - verify valid JSON with events
- [ ] Select CSV format, download - verify spreadsheet-compatible format
- [ ] Select JSON Lines format, download - verify one JSON object per line
- [ ] Filter by event type - verify only selected types exported
- [ ] Set time range - verify events filtered by time
- [ ] Verify downloaded filename matches format (argus-events.json/csv/jsonl)

Closes #12

---
Generated with [Claude Code](https://claude.com/claude-code)