### PR TITLE
feat: Argus v0.4 - Flame Graph, CLI Monitor, OTLP Export

### DIFF
--- a/argus-cli/build.gradle.kts
+++ b/argus-cli/build.gradle.kts
@@ -1,0 +1,29 @@
+plugins {
+    id("java")
+    id("application")
+}
+
+application {
+    mainClass.set("io.argus.cli.ArgusTop")
+}
+
+dependencies {
+    implementation(project(":argus-core"))
+}
+
+tasks.jar {
+    manifest {
+        attributes["Main-Class"] = "io.argus.cli.ArgusTop"
+    }
+}
+
+// Fat JAR for standalone execution
+tasks.register<Jar>("fatJar") {
+    archiveClassifier.set("all")
+    duplicatesStrategy = DuplicatesStrategy.EXCLUDE
+    manifest {
+        attributes["Main-Class"] = "io.argus.cli.ArgusTop"
+    }
+    from(configurations.runtimeClasspath.get().map { if (it.isDirectory) it else zipTree(it) })
+    with(tasks.jar.get())
+}

--- a/argus-cli/src/main/java/io/argus/cli/ArgusClient.java
+++ b/argus-cli/src/main/java/io/argus/cli/ArgusClient.java
@@ -1,0 +1,290 @@
+package io.argus.cli;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * HTTP client that polls Argus server endpoints for metrics data.
+ */
+public final class ArgusClient {
+
+    private final String baseUrl;
+    private final HttpClient httpClient;
+
+    public ArgusClient(String host, int port) {
+        this.baseUrl = "http://" + host + ":" + port;
+        this.httpClient = HttpClient.newBuilder()
+                .connectTimeout(Duration.ofSeconds(5))
+                .build();
+    }
+
+    /**
+     * Fetches all metrics from the server in parallel.
+     *
+     * @return a complete metrics snapshot
+     */
+    public MetricsSnapshot fetchAll() {
+        try {
+            // Fetch all endpoints in parallel
+            var healthFuture = fetchAsync("/health");
+            var metricsFuture = fetchAsync("/metrics");
+            var cpuFuture = fetchAsync("/cpu-metrics");
+            var gcFuture = fetchAsync("/gc-analysis");
+            var activeFuture = fetchAsync("/active-threads");
+            var pinningFuture = fetchAsync("/pinning-analysis");
+            var carrierFuture = fetchAsync("/carrier-threads");
+            var profilingFuture = fetchAsync("/method-profiling");
+            var metaspaceFuture = fetchAsync("/metaspace-metrics");
+            var contentionFuture = fetchAsync("/contention-analysis");
+
+            // Wait for all
+            CompletableFuture.allOf(healthFuture, metricsFuture, cpuFuture, gcFuture,
+                    activeFuture, pinningFuture, carrierFuture, profilingFuture,
+                    metaspaceFuture, contentionFuture).join();
+
+            String health = healthFuture.join();
+            String metrics = metricsFuture.join();
+            String cpu = cpuFuture.join();
+            String gc = gcFuture.join();
+            String active = activeFuture.join();
+            String pinning = pinningFuture.join();
+            String carrier = carrierFuture.join();
+            String profiling = profilingFuture.join();
+            String metaspace = metaspaceFuture.join();
+            String contention = contentionFuture.join();
+
+            return buildSnapshot(health, metrics, cpu, gc, active, pinning,
+                    carrier, profiling, metaspace, contention);
+        } catch (Exception e) {
+            return MetricsSnapshot.disconnected();
+        }
+    }
+
+    private CompletableFuture<String> fetchAsync(String path) {
+        HttpRequest request = HttpRequest.newBuilder()
+                .uri(URI.create(baseUrl + path))
+                .timeout(Duration.ofSeconds(3))
+                .GET()
+                .build();
+
+        return httpClient.sendAsync(request, HttpResponse.BodyHandlers.ofString())
+                .thenApply(resp -> resp.statusCode() == 200 ? resp.body() : "")
+                .exceptionally(e -> "");
+    }
+
+    private MetricsSnapshot buildSnapshot(String health, String metrics, String cpu,
+                                          String gc, String active, String pinning,
+                                          String carrier, String profiling,
+                                          String metaspace, String contention) {
+        int clientCount = jsonInt(health, "clients");
+
+        long totalEvents = jsonLong(metrics, "totalEvents");
+        long startEvents = jsonLong(metrics, "startEvents");
+        long endEvents = jsonLong(metrics, "endEvents");
+        long pinnedEvents = jsonLong(metrics, "pinnedEvents");
+        int activeThreads = countJsonArrayElements(active);
+
+        double cpuJvm = jsonDouble(cpu, "currentJvmPercent");
+        double cpuMachine = jsonDouble(cpu, "currentMachinePercent");
+        double cpuPeak = jsonDouble(cpu, "peakJvmTotal") * 100;
+
+        long gcTotal = jsonLong(gc, "totalGCEvents");
+        double gcPause = jsonDouble(gc, "totalPauseTimeMs");
+        double gcOverhead = jsonDouble(gc, "gcOverheadPercent");
+        long heapUsed = jsonLong(gc, "currentHeapUsed");
+        long heapCommitted = jsonLong(gc, "currentHeapCommitted");
+
+        double metaUsed = jsonDouble(metaspace, "currentUsedMB");
+        long classes = jsonLong(metaspace, "currentClassCount");
+
+        int carriers = jsonInt(carrier, "totalCarriers");
+        double avgVt = jsonDouble(carrier, "avgVirtualThreadsPerCarrier");
+
+        long totalPinned = jsonLong(pinning, "totalPinnedEvents");
+        int uniqueStacks = jsonInt(pinning, "uniqueStackTraces");
+
+        long samples = jsonLong(profiling, "totalSamples");
+        List<MetricsSnapshot.HotMethodInfo> hotMethods = parseHotMethods(profiling);
+
+        long contentionEvts = jsonLong(contention, "totalContentionEvents");
+        double contentionTime = jsonDouble(contention, "totalContentionTimeMs");
+        List<MetricsSnapshot.ContentionHotspot> hotspots = parseContentionHotspots(contention);
+
+        return new MetricsSnapshot(true, clientCount, totalEvents, startEvents,
+                endEvents, pinnedEvents, activeThreads, cpuJvm, cpuMachine, cpuPeak,
+                gcTotal, gcPause, gcOverhead, heapUsed, heapCommitted,
+                metaUsed, classes, carriers, avgVt, totalPinned, uniqueStacks,
+                samples, hotMethods, contentionEvts, contentionTime, hotspots);
+    }
+
+    // Simple JSON value parsers (no external library)
+
+    private static long jsonLong(String json, String key) {
+        String val = extractJsonValue(json, key);
+        if (val == null || val.isEmpty()) return 0;
+        try {
+            return Long.parseLong(val);
+        } catch (NumberFormatException e) {
+            return 0;
+        }
+    }
+
+    private static int jsonInt(String json, String key) {
+        return (int) jsonLong(json, key);
+    }
+
+    private static double jsonDouble(String json, String key) {
+        String val = extractJsonValue(json, key);
+        if (val == null || val.isEmpty()) return 0.0;
+        try {
+            return Double.parseDouble(val);
+        } catch (NumberFormatException e) {
+            return 0.0;
+        }
+    }
+
+    private static String extractJsonValue(String json, String key) {
+        if (json == null || json.isEmpty()) return null;
+        String pattern = "\"" + key + "\":";
+        int idx = json.indexOf(pattern);
+        if (idx < 0) return null;
+        int start = idx + pattern.length();
+        if (start >= json.length()) return null;
+
+        char first = json.charAt(start);
+        if (first == '"') {
+            int end = json.indexOf('"', start + 1);
+            return end > start ? json.substring(start + 1, end) : null;
+        }
+
+        int end = start;
+        while (end < json.length()) {
+            char c = json.charAt(end);
+            if (c == ',' || c == '}' || c == ']') break;
+            end++;
+        }
+        return json.substring(start, end).trim();
+    }
+
+    private static int countJsonArrayElements(String json) {
+        if (json == null || json.isEmpty() || "[]".equals(json.trim())) return 0;
+        int count = 0;
+        boolean inString = false;
+        int depth = 0;
+        for (int i = 0; i < json.length(); i++) {
+            char c = json.charAt(i);
+            if (c == '"' && (i == 0 || json.charAt(i - 1) != '\\')) {
+                inString = !inString;
+            } else if (!inString) {
+                if (c == '{') {
+                    if (depth == 1) count++;
+                    depth++;
+                } else if (c == '}') {
+                    depth--;
+                } else if (c == '[') {
+                    depth++;
+                } else if (c == ']') {
+                    depth--;
+                }
+            }
+        }
+        return count;
+    }
+
+    private static List<MetricsSnapshot.HotMethodInfo> parseHotMethods(String json) {
+        List<MetricsSnapshot.HotMethodInfo> methods = new ArrayList<>();
+        if (json == null || json.isEmpty()) return methods;
+
+        int idx = json.indexOf("\"topMethods\":[");
+        if (idx < 0) return methods;
+
+        String section = json.substring(idx);
+        int arrEnd = findMatchingBracket(section, section.indexOf('['));
+        if (arrEnd < 0) return methods;
+        String arr = section.substring(section.indexOf('['), arrEnd + 1);
+
+        int pos = 0;
+        while (pos < arr.length() && methods.size() < 5) {
+            int objStart = arr.indexOf('{', pos);
+            if (objStart < 0) break;
+            int objEnd = arr.indexOf('}', objStart);
+            if (objEnd < 0) break;
+            String obj = arr.substring(objStart, objEnd + 1);
+
+            String className = extractJsonStringValue(obj, "className");
+            String methodName = extractJsonStringValue(obj, "methodName");
+            double pct = jsonDouble(obj, "percentage");
+
+            if (className != null && methodName != null) {
+                methods.add(new MetricsSnapshot.HotMethodInfo(className, methodName, pct));
+            }
+            pos = objEnd + 1;
+        }
+        return methods;
+    }
+
+    private static List<MetricsSnapshot.ContentionHotspot> parseContentionHotspots(String json) {
+        List<MetricsSnapshot.ContentionHotspot> hotspots = new ArrayList<>();
+        if (json == null || json.isEmpty()) return hotspots;
+
+        int idx = json.indexOf("\"hotspots\":[");
+        if (idx < 0) return hotspots;
+
+        String section = json.substring(idx);
+        int arrEnd = findMatchingBracket(section, section.indexOf('['));
+        if (arrEnd < 0) return hotspots;
+        String arr = section.substring(section.indexOf('['), arrEnd + 1);
+
+        int pos = 0;
+        while (pos < arr.length() && hotspots.size() < 3) {
+            int objStart = arr.indexOf('{', pos);
+            if (objStart < 0) break;
+            int objEnd = arr.indexOf('}', objStart);
+            if (objEnd < 0) break;
+            String obj = arr.substring(objStart, objEnd + 1);
+
+            String monitor = extractJsonStringValue(obj, "monitorClass");
+            long count = jsonLong(obj, "eventCount");
+
+            if (monitor != null) {
+                hotspots.add(new MetricsSnapshot.ContentionHotspot(monitor, count));
+            }
+            pos = objEnd + 1;
+        }
+        return hotspots;
+    }
+
+    private static String extractJsonStringValue(String json, String key) {
+        String pattern = "\"" + key + "\":\"";
+        int idx = json.indexOf(pattern);
+        if (idx < 0) return null;
+        int start = idx + pattern.length();
+        int end = json.indexOf('"', start);
+        return end > start ? json.substring(start, end) : null;
+    }
+
+    private static int findMatchingBracket(String s, int openIdx) {
+        if (openIdx < 0) return -1;
+        int depth = 0;
+        boolean inString = false;
+        for (int i = openIdx; i < s.length(); i++) {
+            char c = s.charAt(i);
+            if (c == '"' && (i == 0 || s.charAt(i - 1) != '\\')) {
+                inString = !inString;
+            } else if (!inString) {
+                if (c == '[') depth++;
+                else if (c == ']') {
+                    depth--;
+                    if (depth == 0) return i;
+                }
+            }
+        }
+        return -1;
+    }
+}

--- a/argus-cli/src/main/java/io/argus/cli/ArgusTop.java
+++ b/argus-cli/src/main/java/io/argus/cli/ArgusTop.java
@@ -1,0 +1,104 @@
+package io.argus.cli;
+
+import java.io.IOException;
+
+/**
+ * Terminal-based JVM monitoring tool for Argus.
+ *
+ * <p>Connects to a running Argus server via HTTP and displays
+ * real-time metrics in an htop-like terminal interface.
+ *
+ * <p>Usage: {@code java -jar argus-cli.jar [--host HOST] [--port PORT] [--interval SECS] [--no-color]}
+ */
+public final class ArgusTop {
+
+    private static final String DEFAULT_HOST = "localhost";
+    private static final int DEFAULT_PORT = 9202;
+    private static final int DEFAULT_INTERVAL = 1;
+
+    public static void main(String[] args) {
+        String host = DEFAULT_HOST;
+        int port = DEFAULT_PORT;
+        int interval = DEFAULT_INTERVAL;
+        boolean color = true;
+
+        // Parse arguments
+        for (int i = 0; i < args.length; i++) {
+            switch (args[i]) {
+                case "--host", "-h" -> {
+                    if (i + 1 < args.length) host = args[++i];
+                }
+                case "--port", "-p" -> {
+                    if (i + 1 < args.length) port = Integer.parseInt(args[++i]);
+                }
+                case "--interval", "-i" -> {
+                    if (i + 1 < args.length) interval = Integer.parseInt(args[++i]);
+                }
+                case "--no-color" -> color = false;
+                case "--help" -> {
+                    printUsage();
+                    return;
+                }
+            }
+        }
+
+        ArgusClient client = new ArgusClient(host, port);
+        TerminalRenderer renderer = new TerminalRenderer(color, host, port, interval);
+
+        // Shutdown hook for clean exit
+        Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+            System.out.print("\033[?25h"); // Show cursor
+            System.out.println("\nArgus CLI stopped.");
+        }));
+
+        // Hide cursor
+        System.out.print("\033[?25l");
+
+        System.out.println("Connecting to Argus server at " + host + ":" + port + "...");
+
+        // Main loop
+        final long intervalMs = interval * 1000L;
+        while (!Thread.currentThread().isInterrupted()) {
+            MetricsSnapshot snapshot = client.fetchAll();
+            renderer.render(snapshot);
+
+            try {
+                // Check for 'q' key (non-blocking stdin check)
+                if (System.in.available() > 0) {
+                    int ch = System.in.read();
+                    if (ch == 'q' || ch == 'Q') {
+                        break;
+                    }
+                }
+                Thread.sleep(intervalMs);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                break;
+            } catch (IOException e) {
+                // Ignore stdin errors
+            }
+        }
+
+        System.out.print("\033[?25h"); // Show cursor
+    }
+
+    private static void printUsage() {
+        System.out.println("""
+                Argus Top - Terminal JVM Monitor
+
+                Usage: argus-top [OPTIONS]
+
+                Options:
+                  --host, -h HOST      Server host (default: localhost)
+                  --port, -p PORT      Server port (default: 9202)
+                  --interval, -i SECS  Refresh interval in seconds (default: 1)
+                  --no-color           Disable ANSI colors
+                  --help               Show this help
+
+                Examples:
+                  argus-top
+                  argus-top --port 9202 --interval 2
+                  argus-top --host 192.168.1.100 --port 9202 --no-color
+                """);
+    }
+}

--- a/argus-cli/src/main/java/io/argus/cli/MetricsSnapshot.java
+++ b/argus-cli/src/main/java/io/argus/cli/MetricsSnapshot.java
@@ -1,0 +1,62 @@
+package io.argus.cli;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Immutable snapshot of all metrics from one poll cycle.
+ */
+public record MetricsSnapshot(
+        // Connection
+        boolean connected,
+        int clientCount,
+
+        // Basic metrics
+        long totalEvents,
+        long startEvents,
+        long endEvents,
+        long pinnedEvents,
+        int activeThreads,
+
+        // CPU
+        double cpuJvmPercent,
+        double cpuMachinePercent,
+        double cpuPeakJvm,
+
+        // GC
+        long gcTotalEvents,
+        double gcTotalPauseMs,
+        double gcOverheadPercent,
+        long heapUsedBytes,
+        long heapCommittedBytes,
+
+        // Metaspace
+        double metaspaceUsedMB,
+        long classCount,
+
+        // Carrier threads
+        int carrierCount,
+        double avgVtPerCarrier,
+
+        // Pinning
+        long totalPinnedEvents,
+        int uniquePinningStacks,
+
+        // Profiling
+        long profilingSamples,
+        List<HotMethodInfo> hotMethods,
+
+        // Contention
+        long contentionEvents,
+        double contentionTimeMs,
+        List<ContentionHotspot> contentionHotspots
+) {
+    public static MetricsSnapshot disconnected() {
+        return new MetricsSnapshot(false, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                0, List.of(), 0, 0, List.of());
+    }
+
+    public record HotMethodInfo(String className, String methodName, double percentage) {}
+    public record ContentionHotspot(String monitorClass, long eventCount) {}
+}

--- a/argus-cli/src/main/java/io/argus/cli/TerminalRenderer.java
+++ b/argus-cli/src/main/java/io/argus/cli/TerminalRenderer.java
@@ -1,0 +1,240 @@
+package io.argus.cli;
+
+/**
+ * Renders metrics data to the terminal using ANSI escape codes.
+ */
+public final class TerminalRenderer {
+
+    private static final String RESET = "\033[0m";
+    private static final String BOLD = "\033[1m";
+    private static final String DIM = "\033[2m";
+    private static final String GREEN = "\033[32m";
+    private static final String YELLOW = "\033[33m";
+    private static final String RED = "\033[31m";
+    private static final String CYAN = "\033[36m";
+    private static final String WHITE = "\033[37m";
+    private static final String BG_RED = "\033[41m";
+    private static final String CLEAR_SCREEN = "\033[2J\033[H";
+
+    private final boolean useColor;
+    private final String host;
+    private final int port;
+    private final int intervalSec;
+    private long startTime;
+
+    public TerminalRenderer(boolean useColor, String host, int port, int intervalSec) {
+        this.useColor = useColor;
+        this.host = host;
+        this.port = port;
+        this.intervalSec = intervalSec;
+        this.startTime = System.currentTimeMillis();
+    }
+
+    /**
+     * Renders a full metrics snapshot to the terminal.
+     */
+    public void render(MetricsSnapshot snap) {
+        StringBuilder sb = new StringBuilder(2048);
+        sb.append(CLEAR_SCREEN);
+
+        if (!snap.connected()) {
+            renderDisconnected(sb);
+            System.out.print(sb);
+            System.out.flush();
+            return;
+        }
+
+        renderHeader(sb);
+        renderSeparator(sb);
+        renderSystemMetrics(sb, snap);
+        renderSeparator(sb);
+        renderVirtualThreads(sb, snap);
+        renderSeparator(sb);
+        renderProfilingContention(sb, snap);
+        renderSeparator(sb);
+        renderFooter(sb);
+
+        System.out.print(sb);
+        System.out.flush();
+    }
+
+    private void renderDisconnected(StringBuilder sb) {
+        renderHeader(sb);
+        sb.append('\n');
+        sb.append(color(RED, BOLD)).append("  CONNECTION FAILED")
+                .append(color(RESET)).append('\n');
+        sb.append(color(DIM)).append("  Cannot connect to Argus server at ")
+                .append(host).append(':').append(port).append(color(RESET)).append('\n');
+        sb.append(color(DIM)).append("  Retrying every ").append(intervalSec)
+                .append("s...").append(color(RESET)).append('\n');
+    }
+
+    private void renderHeader(StringBuilder sb) {
+        String uptime = formatUptime(System.currentTimeMillis() - startTime);
+        sb.append(color(BOLD, CYAN)).append(" Argus JVM Monitor")
+                .append(color(RESET, DIM)).append(" | ")
+                .append(host).append(':').append(port)
+                .append(" | uptime ").append(uptime)
+                .append(" | refresh ").append(intervalSec).append('s')
+                .append(color(RESET)).append('\n');
+    }
+
+    private void renderSeparator(StringBuilder sb) {
+        sb.append(color(DIM)).append(" ").append("─".repeat(65))
+                .append(color(RESET)).append('\n');
+    }
+
+    private void renderSystemMetrics(StringBuilder sb, MetricsSnapshot snap) {
+        // CPU
+        sb.append("  CPU   ");
+        appendProgressBar(sb, snap.cpuJvmPercent(), 16);
+        sb.append(colorByThreshold(snap.cpuJvmPercent(), 70, 90))
+                .append(String.format(" %5.1f%%", snap.cpuJvmPercent()))
+                .append(color(RESET)).append(" JVM  | ")
+                .append(String.format("%5.1f%%", snap.cpuMachinePercent()))
+                .append(" Machine\n");
+
+        // Heap
+        double heapUsedMB = snap.heapUsedBytes() / (1024.0 * 1024.0);
+        double heapCommitMB = snap.heapCommittedBytes() / (1024.0 * 1024.0);
+        double heapPct = heapCommitMB > 0 ? (heapUsedMB / heapCommitMB) * 100 : 0;
+        sb.append("  Heap  ");
+        appendProgressBar(sb, heapPct, 16);
+        sb.append(colorByThreshold(heapPct, 70, 90))
+                .append(String.format(" %s/%s", formatBytes(snap.heapUsedBytes()), formatBytes(snap.heapCommittedBytes())))
+                .append(color(RESET));
+        sb.append("  | GC: ")
+                .append(colorByThreshold(snap.gcOverheadPercent(), 2, 5))
+                .append(String.format("%.1f%%", snap.gcOverheadPercent()))
+                .append(color(RESET)).append(" overhead\n");
+
+        // Metaspace + GC
+        sb.append("  Meta  ")
+                .append(String.format("%.0fMB", snap.metaspaceUsedMB()))
+                .append(" (").append(formatNumber(snap.classCount())).append(" classes)")
+                .append("        | GC events: ")
+                .append(formatNumber(snap.gcTotalEvents()))
+                .append(" (").append(String.format("%.0fms", snap.gcTotalPauseMs())).append(" total)\n");
+    }
+
+    private void renderVirtualThreads(StringBuilder sb, MetricsSnapshot snap) {
+        sb.append("  Virtual Threads: ")
+                .append(color(BOLD)).append(formatNumber(snap.activeThreads()))
+                .append(color(RESET)).append(" active | ")
+                .append(formatNumber(snap.startEvents())).append(" total");
+
+        if (snap.totalPinnedEvents() > 0) {
+            sb.append(" | ").append(color(YELLOW))
+                    .append(formatNumber(snap.totalPinnedEvents())).append(" pinned")
+                    .append(color(RESET))
+                    .append(" (").append(snap.uniquePinningStacks()).append(" stacks)");
+        }
+        sb.append('\n');
+
+        sb.append("  Carriers: ")
+                .append(snap.carrierCount()).append(" threads")
+                .append(" | avg ").append(String.format("%.1f", snap.avgVtPerCarrier()))
+                .append(" VT/carrier\n");
+    }
+
+    private void renderProfilingContention(StringBuilder sb, MetricsSnapshot snap) {
+        // Hot Methods column
+        if (snap.profilingSamples() > 0 && !snap.hotMethods().isEmpty()) {
+            sb.append(color(BOLD)).append("  Hot Methods")
+                    .append(color(RESET, DIM))
+                    .append(" (").append(formatNumber(snap.profilingSamples())).append(" samples)")
+                    .append(color(RESET)).append('\n');
+
+            for (var m : snap.hotMethods()) {
+                String shortClass = shortenClassName(m.className());
+                sb.append(colorByThreshold(m.percentage(), 30, 60))
+                        .append(String.format("   %5.1f%%", m.percentage()))
+                        .append(color(RESET)).append(' ')
+                        .append(shortClass).append('.').append(m.methodName())
+                        .append('\n');
+            }
+        } else {
+            sb.append(color(DIM)).append("  Profiling: disabled")
+                    .append(color(RESET)).append('\n');
+        }
+
+        // Contention
+        if (snap.contentionEvents() > 0 && !snap.contentionHotspots().isEmpty()) {
+            sb.append(color(BOLD)).append("  Contention")
+                    .append(color(RESET, DIM))
+                    .append(" (").append(formatNumber(snap.contentionEvents())).append(" events, ")
+                    .append(String.format("%.0fms", snap.contentionTimeMs())).append(")")
+                    .append(color(RESET)).append('\n');
+
+            for (var h : snap.contentionHotspots()) {
+                sb.append("   ").append(shortenClassName(h.monitorClass()))
+                        .append(" (").append(h.eventCount()).append(" events)\n");
+            }
+        }
+    }
+
+    private void renderFooter(StringBuilder sb) {
+        sb.append(color(DIM))
+                .append("  q: quit | Ctrl+C: exit")
+                .append(color(RESET)).append('\n');
+    }
+
+    // --- Helpers ---
+
+    private void appendProgressBar(StringBuilder sb, double percent, int width) {
+        int filled = (int) Math.round(percent / 100.0 * width);
+        filled = Math.max(0, Math.min(width, filled));
+
+        sb.append('[');
+        sb.append(colorByThreshold(percent, 70, 90));
+        for (int i = 0; i < width; i++) {
+            sb.append(i < filled ? '\u2588' : '\u2591');
+        }
+        sb.append(color(RESET));
+        sb.append(']');
+    }
+
+    private String colorByThreshold(double value, double warn, double crit) {
+        if (!useColor) return "";
+        if (value >= crit) return RED;
+        if (value >= warn) return YELLOW;
+        return GREEN;
+    }
+
+    private String color(String... codes) {
+        if (!useColor) return "";
+        return String.join("", codes);
+    }
+
+    private static String formatUptime(long ms) {
+        long sec = ms / 1000;
+        if (sec < 60) return sec + "s";
+        long min = sec / 60;
+        sec %= 60;
+        if (min < 60) return min + "m " + sec + "s";
+        long hr = min / 60;
+        min %= 60;
+        return hr + "h " + min + "m";
+    }
+
+    private static String formatBytes(long bytes) {
+        if (bytes <= 0) return "0B";
+        double mb = bytes / (1024.0 * 1024.0);
+        if (mb >= 1024) return String.format("%.1fG", mb / 1024.0);
+        return String.format("%.0fM", mb);
+    }
+
+    private static String formatNumber(long n) {
+        if (n < 1000) return String.valueOf(n);
+        if (n < 1_000_000) return String.format("%.1fK", n / 1000.0);
+        return String.format("%.1fM", n / 1_000_000.0);
+    }
+
+    private static String shortenClassName(String className) {
+        if (className == null) return "?";
+        // Keep last 2 segments: "io.argus.server.ArgusServer" -> "server.ArgusServer"
+        String[] parts = className.split("\\.");
+        if (parts.length <= 2) return className;
+        return parts[parts.length - 2] + "." + parts[parts.length - 1];
+    }
+}

--- a/argus-frontend/src/main/resources/public/css/style.css
+++ b/argus-frontend/src/main/resources/public/css/style.css
@@ -580,6 +580,62 @@ main {
     opacity: 0.5;
 }
 
+/* Flame Graph */
+.flamegraph-section {
+    margin-bottom: 1.5rem;
+}
+
+.flamegraph-section .section-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 1rem;
+}
+
+.flamegraph-actions {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+}
+
+.flamegraph-actions .btn-small {
+    padding: 0.25rem 0.75rem;
+    font-size: 0.8rem;
+    background: var(--card-bg);
+    border: 1px solid var(--border-color);
+    color: var(--text-secondary);
+    border-radius: 4px;
+    cursor: pointer;
+    text-decoration: none;
+}
+
+.flamegraph-actions .btn-small:hover {
+    color: var(--text-primary);
+    border-color: var(--accent-blue);
+}
+
+.flamegraph-container {
+    background: var(--card-bg);
+    border: 1px solid var(--border-color);
+    border-radius: 8px;
+    padding: 1rem;
+    min-height: 300px;
+    overflow: hidden;
+}
+
+.flamegraph-placeholder {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    min-height: 280px;
+    color: var(--text-secondary);
+    font-style: italic;
+}
+
+.flamegraph-container svg {
+    width: 100% !important;
+}
+
 /* Main Tab Navigation (top-level) */
 .main-tab-nav {
     display: flex;

--- a/argus-frontend/src/main/resources/public/index.html
+++ b/argus-frontend/src/main/resources/public/index.html
@@ -6,6 +6,9 @@
     <title>Argus - Virtual Thread Profiler</title>
     <link rel="stylesheet" href="/css/style.css">
     <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/d3@7/dist/d3.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/d3-flame-graph@4/dist/d3-flamegraph.min.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/d3-flame-graph@4/dist/d3-flamegraph.css">
 </head>
 <body>
     <header>
@@ -348,6 +351,23 @@
                             <canvas id="metaspace-chart"></canvas>
                         </div>
                     </div>
+                </div>
+            </section>
+
+            <!-- Flame Graph Section -->
+            <section class="flamegraph-section">
+                <div class="section-header">
+                    <h2>Flame Graph</h2>
+                    <div class="flamegraph-actions">
+                        <span>Samples: <strong id="flamegraph-samples">0</strong></span>
+                        <span id="flamegraph-timestamp" style="color: var(--text-dim); font-size: 0.85em;"></span>
+                        <button id="flamegraph-pause" class="btn btn-small">Pause</button>
+                        <button id="flamegraph-reset" class="btn btn-small">Reset</button>
+                        <a id="flamegraph-download" class="btn btn-small" title="Download collapsed stacks">Download</a>
+                    </div>
+                </div>
+                <div id="flamegraph-container" class="flamegraph-container">
+                    <div class="flamegraph-placeholder">Enable profiling (-Dargus.profiling.enabled=true) to see flame graph</div>
                 </div>
             </section>
 

--- a/argus-server/src/main/java/io/argus/server/analysis/FlameGraphAnalyzer.java
+++ b/argus-server/src/main/java/io/argus/server/analysis/FlameGraphAnalyzer.java
@@ -1,0 +1,215 @@
+package io.argus.server.analysis;
+
+import io.argus.core.event.ExecutionSampleEvent;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * Analyzes execution sample events and builds flame graph data.
+ *
+ * <p>Aggregates stack traces into a tree structure suitable for d3-flamegraph
+ * visualization and collapsed stack format for external tools.
+ */
+public final class FlameGraphAnalyzer {
+
+    private static final long DEFAULT_WINDOW_MS = 60_000; // 60 seconds
+
+    private final AtomicLong totalSamples = new AtomicLong(0);
+    private final long windowMs;
+    private volatile long windowStartTime;
+    private FlameNode root = new FlameNode("root");
+
+    public FlameGraphAnalyzer() {
+        this(DEFAULT_WINDOW_MS);
+    }
+
+    public FlameGraphAnalyzer(long windowMs) {
+        this.windowMs = windowMs;
+        this.windowStartTime = System.currentTimeMillis();
+    }
+
+    /**
+     * Records an execution sample event for flame graph aggregation.
+     *
+     * @param event the execution sample event to record
+     */
+    public void recordSample(ExecutionSampleEvent event) {
+        if (event == null || event.stackTrace() == null || event.stackTrace().isBlank()) {
+            return;
+        }
+
+        totalSamples.incrementAndGet();
+
+        List<String> frames = parseStackTrace(event.stackTrace());
+        if (frames.isEmpty()) {
+            return;
+        }
+
+        synchronized (root) {
+            // Auto-rotate: if time window has passed, start fresh
+            if (System.currentTimeMillis() - windowStartTime > windowMs) {
+                root = new FlameNode("root");
+                windowStartTime = System.currentTimeMillis();
+            }
+
+            root.value++;
+            FlameNode current = root;
+            for (String frame : frames) {
+                current = current.children.computeIfAbsent(frame, FlameNode::new);
+                current.value++;
+            }
+        }
+    }
+
+    /**
+     * Returns the flame graph data as d3-flamegraph compatible JSON.
+     *
+     * @return JSON string for d3-flamegraph
+     */
+    public String getFlameGraphJson() {
+        synchronized (root) {
+            StringBuilder sb = new StringBuilder(4096);
+            appendNodeJson(sb, root);
+            return sb.toString();
+        }
+    }
+
+    /**
+     * Returns the flame graph data in collapsed stack format.
+     *
+     * <p>Each line: {@code frame1;frame2;frame3 count}
+     *
+     * @return collapsed stacks string
+     */
+    public String getCollapsedStacks() {
+        synchronized (root) {
+            StringBuilder sb = new StringBuilder(4096);
+            List<String> path = new ArrayList<>();
+            collectCollapsedStacks(root, path, sb);
+            return sb.toString();
+        }
+    }
+
+    /**
+     * Returns the total number of samples recorded.
+     *
+     * @return total sample count
+     */
+    public long getTotalSamples() {
+        return totalSamples.get();
+    }
+
+    /**
+     * Clears all recorded data and resets the time window.
+     */
+    public void clear() {
+        synchronized (root) {
+            totalSamples.set(0);
+            root = new FlameNode("root");
+            windowStartTime = System.currentTimeMillis();
+        }
+    }
+
+    /**
+     * Returns the remaining seconds in the current time window.
+     */
+    public int getWindowRemainingSeconds() {
+        long elapsed = System.currentTimeMillis() - windowStartTime;
+        long remaining = Math.max(0, windowMs - elapsed);
+        return (int) (remaining / 1000);
+    }
+
+    /**
+     * Parses a stack trace string into a list of frame names.
+     * JFR stack traces are top-frame-first; this reverses them so
+     * the root (entry point) is first for flame graph rendering.
+     */
+    private List<String> parseStackTrace(String stackTrace) {
+        String[] lines = stackTrace.split("\n");
+        List<String> frames = new ArrayList<>(lines.length);
+
+        for (String line : lines) {
+            String trimmed = line.trim();
+            if (trimmed.startsWith("at ")) {
+                String frame = trimmed.substring(3);
+                // Remove source info: "class.method(line:N)" -> "class.method"
+                int parenIdx = frame.indexOf('(');
+                if (parenIdx > 0) {
+                    frame = frame.substring(0, parenIdx);
+                }
+                if (!frame.isEmpty()) {
+                    frames.add(frame);
+                }
+            }
+        }
+
+        // Reverse: JFR is leaf-first, flame graph needs root-first
+        java.util.Collections.reverse(frames);
+        return frames;
+    }
+
+    private void appendNodeJson(StringBuilder sb, FlameNode node) {
+        sb.append("{\"name\":\"");
+        escapeJson(sb, node.name);
+        sb.append("\",\"value\":").append(node.value);
+
+        if (!node.children.isEmpty()) {
+            sb.append(",\"children\":[");
+            boolean first = true;
+            for (FlameNode child : node.children.values()) {
+                if (!first) sb.append(',');
+                first = false;
+                appendNodeJson(sb, child);
+            }
+            sb.append(']');
+        }
+
+        sb.append('}');
+    }
+
+    private void collectCollapsedStacks(FlameNode node, List<String> path, StringBuilder sb) {
+        if (node.children.isEmpty() && !path.isEmpty()) {
+            // Leaf node: output the path with count
+            sb.append(String.join(";", path));
+            sb.append(' ').append(node.value).append('\n');
+            return;
+        }
+
+        for (Map.Entry<String, FlameNode> entry : node.children.entrySet()) {
+            path.add(entry.getKey());
+            collectCollapsedStacks(entry.getValue(), path, sb);
+            path.remove(path.size() - 1);
+        }
+    }
+
+    private void escapeJson(StringBuilder sb, String text) {
+        for (int i = 0; i < text.length(); i++) {
+            char c = text.charAt(i);
+            switch (c) {
+                case '"' -> sb.append("\\\"");
+                case '\\' -> sb.append("\\\\");
+                case '\n' -> sb.append("\\n");
+                case '\r' -> sb.append("\\r");
+                case '\t' -> sb.append("\\t");
+                default -> sb.append(c);
+            }
+        }
+    }
+
+    /**
+     * Internal tree node for flame graph aggregation.
+     */
+    private static final class FlameNode {
+        final String name;
+        int value;
+        final Map<String, FlameNode> children = new ConcurrentHashMap<>();
+
+        FlameNode(String name) {
+            this.name = name;
+        }
+    }
+}

--- a/argus-server/src/main/java/io/argus/server/http/HttpResponseHelper.java
+++ b/argus-server/src/main/java/io/argus/server/http/HttpResponseHelper.java
@@ -83,6 +83,10 @@ public final class HttpResponseHelper {
      * @param request the original HTTP request
      * @param content the Prometheus text format content
      */
+    public static void sendPlainText(ChannelHandlerContext ctx, FullHttpRequest request, String content) {
+        send(ctx, request, HttpResponseStatus.OK, content, "text/plain; charset=utf-8");
+    }
+
     public static void sendPrometheus(ChannelHandlerContext ctx, FullHttpRequest request, String content) {
         send(ctx, request, HttpResponseStatus.OK, content, "text/plain; version=0.0.4; charset=utf-8");
     }

--- a/argus-server/src/main/java/io/argus/server/metrics/OtlpJsonBuilder.java
+++ b/argus-server/src/main/java/io/argus/server/metrics/OtlpJsonBuilder.java
@@ -1,0 +1,261 @@
+package io.argus.server.metrics;
+
+import io.argus.core.config.AgentConfig;
+import io.argus.server.analysis.*;
+import io.argus.server.state.ActiveThreadsRegistry;
+
+/**
+ * Builds OTLP JSON Protobuf encoding for metrics export.
+ *
+ * <p>Hand-coded OTLP JSON format following the OpenTelemetry specification,
+ * maintaining the project's zero-dependency philosophy.
+ */
+public final class OtlpJsonBuilder {
+
+    private final AgentConfig config;
+    private final ServerMetrics metrics;
+    private final ActiveThreadsRegistry activeThreads;
+    private final PinningAnalyzer pinningAnalyzer;
+    private final CarrierThreadAnalyzer carrierAnalyzer;
+    private final GCAnalyzer gcAnalyzer;
+    private final CPUAnalyzer cpuAnalyzer;
+    private final AllocationAnalyzer allocationAnalyzer;
+    private final MetaspaceAnalyzer metaspaceAnalyzer;
+    private final MethodProfilingAnalyzer methodProfilingAnalyzer;
+    private final ContentionAnalyzer contentionAnalyzer;
+
+    public OtlpJsonBuilder(AgentConfig config, ServerMetrics metrics,
+                           ActiveThreadsRegistry activeThreads,
+                           PinningAnalyzer pinningAnalyzer,
+                           CarrierThreadAnalyzer carrierAnalyzer,
+                           GCAnalyzer gcAnalyzer, CPUAnalyzer cpuAnalyzer,
+                           AllocationAnalyzer allocationAnalyzer,
+                           MetaspaceAnalyzer metaspaceAnalyzer,
+                           MethodProfilingAnalyzer methodProfilingAnalyzer,
+                           ContentionAnalyzer contentionAnalyzer) {
+        this.config = config;
+        this.metrics = metrics;
+        this.activeThreads = activeThreads;
+        this.pinningAnalyzer = pinningAnalyzer;
+        this.carrierAnalyzer = carrierAnalyzer;
+        this.gcAnalyzer = gcAnalyzer;
+        this.cpuAnalyzer = cpuAnalyzer;
+        this.allocationAnalyzer = allocationAnalyzer;
+        this.metaspaceAnalyzer = metaspaceAnalyzer;
+        this.methodProfilingAnalyzer = methodProfilingAnalyzer;
+        this.contentionAnalyzer = contentionAnalyzer;
+    }
+
+    /**
+     * Builds the complete OTLP JSON metrics payload.
+     *
+     * @return OTLP JSON string
+     */
+    public String build() {
+        long nowNano = System.currentTimeMillis() * 1_000_000L;
+        StringBuilder sb = new StringBuilder(4096);
+
+        sb.append("{\"resourceMetrics\":[{");
+        appendResource(sb);
+        sb.append(",\"scopeMetrics\":[{");
+        sb.append("\"scope\":{\"name\":\"io.argus.metrics\",\"version\":\"")
+                .append(getVersion()).append("\"},");
+        sb.append("\"metrics\":[");
+
+        boolean first = true;
+        first = appendVirtualThreadMetrics(sb, nowNano, first);
+        first = appendGcMetrics(sb, nowNano, first);
+        first = appendCpuMetrics(sb, nowNano, first);
+        first = appendAllocationMetrics(sb, nowNano, first);
+        first = appendMetaspaceMetrics(sb, nowNano, first);
+        first = appendProfilingMetrics(sb, nowNano, first);
+        appendContentionMetrics(sb, nowNano, first);
+
+        sb.append("]}]}]}");
+        return sb.toString();
+    }
+
+    private void appendResource(StringBuilder sb) {
+        sb.append("\"resource\":{\"attributes\":[");
+        appendStringAttribute(sb, "service.name", config.getOtlpServiceName());
+        sb.append(',');
+        appendStringAttribute(sb, "service.version", getVersion());
+        sb.append(',');
+        appendStringAttribute(sb, "telemetry.sdk.name", "argus");
+        sb.append(',');
+        appendStringAttribute(sb, "telemetry.sdk.language", "java");
+        sb.append("]}");
+    }
+
+    // --- Virtual Thread Metrics (always enabled) ---
+
+    private boolean appendVirtualThreadMetrics(StringBuilder sb, long nowNano, boolean first) {
+        first = appendGauge(sb, first, "argus_virtual_threads_active",
+                "Currently active virtual threads", nowNano, activeThreads.size());
+        first = appendSum(sb, first, "argus_virtual_threads_started_total",
+                "Total virtual threads started", nowNano, metrics.getStartEvents());
+        first = appendSum(sb, first, "argus_virtual_threads_ended_total",
+                "Total virtual threads ended", nowNano, metrics.getEndEvents());
+        first = appendSum(sb, first, "argus_virtual_threads_pinned_total",
+                "Total pinning events", nowNano, metrics.getPinnedEvents());
+        first = appendSum(sb, first, "argus_virtual_threads_submit_failed_total",
+                "Total submit failures", nowNano, metrics.getSubmitFailedEvents());
+
+        var pinAnalysis = pinningAnalyzer.getAnalysis();
+        first = appendGauge(sb, first, "argus_virtual_threads_pinned_unique_stacks",
+                "Unique pinning stack traces", nowNano, pinAnalysis.uniqueStackTraces());
+
+        var carrierAnalysis = carrierAnalyzer.getAnalysis();
+        first = appendGauge(sb, first, "argus_carrier_threads_total",
+                "Total carrier threads", nowNano, carrierAnalysis.totalCarriers());
+        first = appendGaugeDouble(sb, first, "argus_carrier_threads_avg_per_carrier",
+                "Average virtual threads per carrier", nowNano, carrierAnalysis.avgVirtualThreadsPerCarrier());
+        return first;
+    }
+
+    // --- GC Metrics ---
+
+    private boolean appendGcMetrics(StringBuilder sb, long nowNano, boolean first) {
+        if (!config.isGcEnabled()) return first;
+
+        var analysis = gcAnalyzer.getAnalysis();
+        first = appendSum(sb, first, "argus_gc_events_total",
+                "Total GC events", nowNano, analysis.totalGCEvents());
+        first = appendSumDouble(sb, first, "argus_gc_pause_time_seconds_total",
+                "Total GC pause time in seconds", nowNano, analysis.totalPauseTimeMs() / 1000.0);
+        first = appendGaugeDouble(sb, first, "argus_gc_pause_time_seconds_max",
+                "Maximum GC pause time", nowNano, analysis.maxPauseTimeMs() / 1000.0);
+        first = appendGaugeDouble(sb, first, "argus_gc_overhead_ratio",
+                "GC overhead percentage", nowNano, analysis.gcOverheadPercent());
+        first = appendGauge(sb, first, "argus_heap_used_bytes",
+                "Current heap used", nowNano, analysis.currentHeapUsed());
+        first = appendGauge(sb, first, "argus_heap_committed_bytes",
+                "Current heap committed", nowNano, analysis.currentHeapCommitted());
+        return first;
+    }
+
+    // --- CPU Metrics ---
+
+    private boolean appendCpuMetrics(StringBuilder sb, long nowNano, boolean first) {
+        if (!config.isCpuEnabled()) return first;
+
+        var analysis = cpuAnalyzer.getAnalysis();
+        first = appendGaugeDouble(sb, first, "argus_cpu_jvm_user_ratio",
+                "JVM user CPU ratio", nowNano, analysis.currentJvmUser());
+        first = appendGaugeDouble(sb, first, "argus_cpu_jvm_system_ratio",
+                "JVM system CPU ratio", nowNano, analysis.currentJvmSystem());
+        first = appendGaugeDouble(sb, first, "argus_cpu_machine_total_ratio",
+                "Machine total CPU ratio", nowNano, analysis.currentMachineTotal());
+        return first;
+    }
+
+    // --- Allocation Metrics ---
+
+    private boolean appendAllocationMetrics(StringBuilder sb, long nowNano, boolean first) {
+        if (allocationAnalyzer == null) return first;
+
+        var analysis = allocationAnalyzer.getAnalysis();
+        first = appendSum(sb, first, "argus_allocation_total",
+                "Total allocations", nowNano, analysis.totalAllocations());
+        first = appendSum(sb, first, "argus_allocation_bytes_total",
+                "Total bytes allocated", nowNano, analysis.totalBytesAllocated());
+        first = appendGaugeDouble(sb, first, "argus_allocation_rate_bytes_per_second",
+                "Allocation rate", nowNano, analysis.allocationRateBytesPerSec());
+        return first;
+    }
+
+    // --- Metaspace Metrics ---
+
+    private boolean appendMetaspaceMetrics(StringBuilder sb, long nowNano, boolean first) {
+        if (metaspaceAnalyzer == null) return first;
+
+        var analysis = metaspaceAnalyzer.getAnalysis();
+        first = appendGauge(sb, first, "argus_metaspace_used_bytes",
+                "Metaspace used", nowNano, analysis.currentUsed());
+        first = appendGauge(sb, first, "argus_metaspace_committed_bytes",
+                "Metaspace committed", nowNano, analysis.currentCommitted());
+        first = appendGauge(sb, first, "argus_metaspace_classes_loaded",
+                "Loaded classes", nowNano, analysis.currentClassCount());
+        return first;
+    }
+
+    // --- Profiling Metrics ---
+
+    private boolean appendProfilingMetrics(StringBuilder sb, long nowNano, boolean first) {
+        if (methodProfilingAnalyzer == null) return first;
+
+        var analysis = methodProfilingAnalyzer.getAnalysis();
+        first = appendSum(sb, first, "argus_profiling_samples_total",
+                "Total profiling samples", nowNano, analysis.totalSamples());
+        return first;
+    }
+
+    // --- Contention Metrics ---
+
+    private boolean appendContentionMetrics(StringBuilder sb, long nowNano, boolean first) {
+        if (contentionAnalyzer == null) return first;
+
+        var analysis = contentionAnalyzer.getAnalysis();
+        first = appendSum(sb, first, "argus_contention_events_total",
+                "Total contention events", nowNano, analysis.totalContentionEvents());
+        appendSumDouble(sb, first, "argus_contention_time_seconds_total",
+                "Total contention time", nowNano, analysis.totalContentionTimeMs() / 1000.0);
+        return first;
+    }
+
+    // --- Helper methods for OTLP JSON metric types ---
+
+    private boolean appendGauge(StringBuilder sb, boolean first, String name,
+                                String description, long nowNano, long value) {
+        if (!first) sb.append(',');
+        sb.append("{\"name\":\"").append(name).append("\",");
+        sb.append("\"description\":\"").append(description).append("\",");
+        sb.append("\"gauge\":{\"dataPoints\":[{");
+        sb.append("\"timeUnixNano\":\"").append(nowNano).append("\",");
+        sb.append("\"asInt\":\"").append(value).append("\"}]}}");
+        return false;
+    }
+
+    private boolean appendGaugeDouble(StringBuilder sb, boolean first, String name,
+                                      String description, long nowNano, double value) {
+        if (!first) sb.append(',');
+        sb.append("{\"name\":\"").append(name).append("\",");
+        sb.append("\"description\":\"").append(description).append("\",");
+        sb.append("\"gauge\":{\"dataPoints\":[{");
+        sb.append("\"timeUnixNano\":\"").append(nowNano).append("\",");
+        sb.append("\"asDouble\":").append(value).append("}]}}");
+        return false;
+    }
+
+    private boolean appendSum(StringBuilder sb, boolean first, String name,
+                              String description, long nowNano, long value) {
+        if (!first) sb.append(',');
+        sb.append("{\"name\":\"").append(name).append("\",");
+        sb.append("\"description\":\"").append(description).append("\",");
+        sb.append("\"sum\":{\"dataPoints\":[{");
+        sb.append("\"timeUnixNano\":\"").append(nowNano).append("\",");
+        sb.append("\"asInt\":\"").append(value).append("\"}],");
+        sb.append("\"aggregationTemporality\":2,\"isMonotonic\":true}}");
+        return false;
+    }
+
+    private boolean appendSumDouble(StringBuilder sb, boolean first, String name,
+                                    String description, long nowNano, double value) {
+        if (!first) sb.append(',');
+        sb.append("{\"name\":\"").append(name).append("\",");
+        sb.append("\"description\":\"").append(description).append("\",");
+        sb.append("\"sum\":{\"dataPoints\":[{");
+        sb.append("\"timeUnixNano\":\"").append(nowNano).append("\",");
+        sb.append("\"asDouble\":").append(value).append("}],");
+        sb.append("\"aggregationTemporality\":2,\"isMonotonic\":true}}");
+        return false;
+    }
+
+    private void appendStringAttribute(StringBuilder sb, String key, String value) {
+        sb.append("{\"key\":\"").append(key).append("\",\"value\":{\"stringValue\":\"").append(value).append("\"}}");
+    }
+
+    private String getVersion() {
+        return "0.4.0";
+    }
+}

--- a/argus-server/src/main/java/io/argus/server/metrics/OtlpMetricsExporter.java
+++ b/argus-server/src/main/java/io/argus/server/metrics/OtlpMetricsExporter.java
@@ -1,0 +1,102 @@
+package io.argus.server.metrics;
+
+import io.argus.core.config.AgentConfig;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Pushes metrics to an OpenTelemetry collector in OTLP JSON format.
+ *
+ * <p>Uses {@link java.net.http.HttpClient} (JDK built-in) to POST metrics
+ * at a configurable interval. No external SDK dependency required.
+ */
+public final class OtlpMetricsExporter {
+
+    private static final System.Logger LOG = System.getLogger(OtlpMetricsExporter.class.getName());
+
+    private final AgentConfig config;
+    private final OtlpJsonBuilder jsonBuilder;
+    private final HttpClient httpClient;
+    private final ScheduledExecutorService scheduler;
+
+    public OtlpMetricsExporter(AgentConfig config, OtlpJsonBuilder jsonBuilder) {
+        this.config = config;
+        this.jsonBuilder = jsonBuilder;
+        this.httpClient = HttpClient.newBuilder()
+                .connectTimeout(Duration.ofSeconds(10))
+                .build();
+        this.scheduler = Executors.newSingleThreadScheduledExecutor(
+                r -> Thread.ofPlatform().name("argus-otlp-exporter").daemon(true).unstarted(r)
+        );
+    }
+
+    /**
+     * Starts the periodic OTLP metrics push.
+     */
+    public void start() {
+        long intervalMs = config.getOtlpIntervalMs();
+        scheduler.scheduleAtFixedRate(this::pushMetrics, intervalMs, intervalMs, TimeUnit.MILLISECONDS);
+        LOG.log(System.Logger.Level.INFO, "OTLP exporter started (endpoint: {0}, interval: {1}ms)",
+                config.getOtlpEndpoint(), intervalMs);
+    }
+
+    /**
+     * Stops the OTLP metrics exporter.
+     */
+    public void stop() {
+        scheduler.shutdown();
+        try {
+            if (!scheduler.awaitTermination(5, TimeUnit.SECONDS)) {
+                scheduler.shutdownNow();
+            }
+        } catch (InterruptedException e) {
+            scheduler.shutdownNow();
+            Thread.currentThread().interrupt();
+        }
+        LOG.log(System.Logger.Level.INFO, "OTLP exporter stopped");
+    }
+
+    private void pushMetrics() {
+        try {
+            String json = jsonBuilder.build();
+
+            HttpRequest.Builder requestBuilder = HttpRequest.newBuilder()
+                    .uri(URI.create(config.getOtlpEndpoint()))
+                    .header("Content-Type", "application/json")
+                    .timeout(Duration.ofSeconds(10))
+                    .POST(HttpRequest.BodyPublishers.ofString(json));
+
+            // Add custom headers (e.g., auth tokens)
+            String headers = config.getOtlpHeaders();
+            if (headers != null && !headers.isBlank()) {
+                for (String header : headers.split(",")) {
+                    int eq = header.indexOf('=');
+                    if (eq > 0) {
+                        String key = header.substring(0, eq).trim();
+                        String value = header.substring(eq + 1).trim();
+                        requestBuilder.header(key, value);
+                    }
+                }
+            }
+
+            HttpResponse<String> response = httpClient.send(
+                    requestBuilder.build(), HttpResponse.BodyHandlers.ofString());
+
+            if (response.statusCode() >= 400) {
+                LOG.log(System.Logger.Level.WARNING,
+                        "OTLP push failed: HTTP {0} - {1}", response.statusCode(), response.body());
+            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        } catch (Exception e) {
+            LOG.log(System.Logger.Level.WARNING, "OTLP push error: {0}", e.getMessage());
+        }
+    }
+}

--- a/argus-server/src/main/java/io/argus/server/websocket/EventBroadcaster.java
+++ b/argus-server/src/main/java/io/argus/server/websocket/EventBroadcaster.java
@@ -15,6 +15,7 @@ import io.argus.server.analysis.CorrelationAnalyzer;
 import io.argus.server.analysis.CPUAnalyzer;
 import io.argus.server.analysis.GCAnalyzer;
 import io.argus.server.analysis.MetaspaceAnalyzer;
+import io.argus.server.analysis.FlameGraphAnalyzer;
 import io.argus.server.analysis.MethodProfilingAnalyzer;
 import io.argus.server.analysis.PinningAnalyzer;
 import io.argus.server.metrics.ServerMetrics;
@@ -67,6 +68,7 @@ public final class EventBroadcaster {
     private final AllocationAnalyzer allocationAnalyzer;
     private final MetaspaceAnalyzer metaspaceAnalyzer;
     private final MethodProfilingAnalyzer methodProfilingAnalyzer;
+    private final FlameGraphAnalyzer flameGraphAnalyzer;
     private final ContentionAnalyzer contentionAnalyzer;
     private final CorrelationAnalyzer correlationAnalyzer;
     private final ThreadStateManager threadStateManager;
@@ -96,6 +98,7 @@ public final class EventBroadcaster {
      * @param allocationAnalyzer        the allocation analyzer (can be null)
      * @param metaspaceAnalyzer         the metaspace analyzer (can be null)
      * @param methodProfilingAnalyzer   the method profiling analyzer (can be null)
+     * @param flameGraphAnalyzer        the flame graph analyzer (can be null)
      * @param contentionAnalyzer        the contention analyzer (can be null)
      * @param correlationAnalyzer       the correlation analyzer (can be null)
      * @param threadStateManager        the thread state manager for real-time state tracking
@@ -121,6 +124,7 @@ public final class EventBroadcaster {
             AllocationAnalyzer allocationAnalyzer,
             MetaspaceAnalyzer metaspaceAnalyzer,
             MethodProfilingAnalyzer methodProfilingAnalyzer,
+            FlameGraphAnalyzer flameGraphAnalyzer,
             ContentionAnalyzer contentionAnalyzer,
             CorrelationAnalyzer correlationAnalyzer,
             ThreadStateManager threadStateManager,
@@ -144,6 +148,7 @@ public final class EventBroadcaster {
         this.allocationAnalyzer = allocationAnalyzer;
         this.metaspaceAnalyzer = metaspaceAnalyzer;
         this.methodProfilingAnalyzer = methodProfilingAnalyzer;
+        this.flameGraphAnalyzer = flameGraphAnalyzer;
         this.contentionAnalyzer = contentionAnalyzer;
         this.correlationAnalyzer = correlationAnalyzer;
         this.threadStateManager = threadStateManager;
@@ -295,6 +300,9 @@ public final class EventBroadcaster {
         if (executionSampleEventBuffer != null && methodProfilingAnalyzer != null) {
             executionSampleEventBuffer.drain(event -> {
                 methodProfilingAnalyzer.recordExecutionSample(event);
+                if (flameGraphAnalyzer != null) {
+                    flameGraphAnalyzer.recordSample(event);
+                }
             });
         }
 

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,171 @@
+#!/usr/bin/env bash
+#
+# Argus Installer
+#
+# Downloads argus-agent and argus-cli from GitHub releases,
+# installs them to ~/.argus/, and creates the 'argus' command.
+#
+# Usage:
+#   curl -fsSL https://raw.githubusercontent.com/rlaope/argus/master/install.sh | bash
+#
+# Or with a specific version:
+#   curl -fsSL https://raw.githubusercontent.com/rlaope/argus/master/install.sh | bash -s -- v0.3.0
+#
+
+set -euo pipefail
+
+REPO="rlaope/argus"
+INSTALL_DIR="$HOME/.argus"
+BIN_DIR="$INSTALL_DIR/bin"
+VERSION="${1:-latest}"
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[0;33m'
+CYAN='\033[0;36m'
+BOLD='\033[1m'
+RESET='\033[0m'
+
+info()  { echo -e "${CYAN}[INFO]${RESET}  $*"; }
+ok()    { echo -e "${GREEN}[OK]${RESET}    $*"; }
+warn()  { echo -e "${YELLOW}[WARN]${RESET}  $*"; }
+error() { echo -e "${RED}[ERROR]${RESET} $*" >&2; }
+
+# --- Pre-flight checks ---
+
+if ! command -v java &>/dev/null; then
+    error "Java is not installed. Argus requires Java 21+."
+    exit 1
+fi
+
+JAVA_VER=$(java -version 2>&1 | head -1 | sed 's/.*"\([0-9]*\).*/\1/')
+if [ "$JAVA_VER" -lt 21 ] 2>/dev/null; then
+    warn "Java $JAVA_VER detected. Argus requires Java 21+."
+fi
+
+if ! command -v curl &>/dev/null; then
+    error "curl is required to download Argus."
+    exit 1
+fi
+
+# --- Resolve version ---
+
+if [ "$VERSION" = "latest" ]; then
+    info "Resolving latest release..."
+    VERSION=$(curl -fsSL "https://api.github.com/repos/$REPO/releases/latest" \
+        | grep '"tag_name"' | head -1 | sed 's/.*"tag_name"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/')
+
+    if [ -z "$VERSION" ]; then
+        warn "Could not resolve latest release. Using 'v0.3.0' as fallback."
+        VERSION="v0.3.0"
+    fi
+fi
+
+# Strip 'v' prefix for JAR filenames
+VER_NUM="${VERSION#v}"
+
+echo ""
+echo -e "${BOLD}  Argus Installer${RESET}"
+echo -e "  Version: ${CYAN}${VERSION}${RESET}"
+echo -e "  Install: ${CYAN}${INSTALL_DIR}${RESET}"
+echo ""
+
+# --- Download ---
+
+mkdir -p "$INSTALL_DIR" "$BIN_DIR"
+
+DOWNLOAD_BASE="https://github.com/$REPO/releases/download/$VERSION"
+
+info "Downloading argus-agent-${VER_NUM}.jar ..."
+curl -fSL "$DOWNLOAD_BASE/argus-agent-${VER_NUM}.jar" -o "$INSTALL_DIR/argus-agent.jar" \
+    || { error "Failed to download argus-agent. Check version: $VERSION"; exit 1; }
+ok "argus-agent.jar"
+
+info "Downloading argus-cli-${VER_NUM}-all.jar ..."
+curl -fSL "$DOWNLOAD_BASE/argus-cli-${VER_NUM}-all.jar" -o "$INSTALL_DIR/argus-cli.jar" \
+    || { warn "argus-cli not found in release. CLI may not be available in $VERSION."; }
+ok "argus-cli.jar"
+
+# --- Create wrapper scripts ---
+
+# argus - CLI monitor (argus top)
+cat > "$BIN_DIR/argus" << 'WRAPPER'
+#!/usr/bin/env bash
+java -jar "$HOME/.argus/argus-cli.jar" "$@"
+WRAPPER
+chmod +x "$BIN_DIR/argus"
+
+# argus-agent - prints the agent JAR path (for -javaagent)
+cat > "$BIN_DIR/argus-agent" << 'WRAPPER'
+#!/usr/bin/env bash
+if [ "$1" = "--path" ] || [ "$1" = "-p" ]; then
+    echo "$HOME/.argus/argus-agent.jar"
+else
+    echo "Argus Agent JAR: $HOME/.argus/argus-agent.jar"
+    echo ""
+    echo "Usage:"
+    echo "  java -javaagent:\$(argus-agent --path) -jar your-app.jar"
+    echo ""
+    echo "  Or directly:"
+    echo "  java -javaagent:$HOME/.argus/argus-agent.jar -jar your-app.jar"
+fi
+WRAPPER
+chmod +x "$BIN_DIR/argus-agent"
+
+# --- Add to PATH ---
+
+SHELL_NAME=$(basename "$SHELL" 2>/dev/null || echo "bash")
+PROFILE=""
+
+case "$SHELL_NAME" in
+    zsh)  PROFILE="$HOME/.zshrc" ;;
+    bash)
+        if [ -f "$HOME/.bash_profile" ]; then
+            PROFILE="$HOME/.bash_profile"
+        else
+            PROFILE="$HOME/.bashrc"
+        fi
+        ;;
+    fish) PROFILE="$HOME/.config/fish/config.fish" ;;
+    *)    PROFILE="$HOME/.profile" ;;
+esac
+
+PATH_LINE="export PATH=\"\$HOME/.argus/bin:\$PATH\""
+
+if [ "$SHELL_NAME" = "fish" ]; then
+    PATH_LINE="set -gx PATH \$HOME/.argus/bin \$PATH"
+fi
+
+if [ -n "$PROFILE" ] && ! grep -q '.argus/bin' "$PROFILE" 2>/dev/null; then
+    echo "" >> "$PROFILE"
+    echo "# Argus JVM Monitor" >> "$PROFILE"
+    echo "$PATH_LINE" >> "$PROFILE"
+    ok "Added to PATH in $PROFILE"
+else
+    ok "PATH already configured in $PROFILE"
+fi
+
+# --- Done ---
+
+echo ""
+echo -e "${GREEN}${BOLD}  Argus installed successfully!${RESET}"
+echo ""
+echo -e "  ${BOLD}Quick Start:${RESET}"
+echo ""
+echo -e "  1. Restart your terminal or run:"
+echo -e "     ${CYAN}source $PROFILE${RESET}"
+echo ""
+echo -e "  2. Attach to your Java app:"
+echo -e "     ${CYAN}java -javaagent:\$(argus-agent --path) -jar your-app.jar${RESET}"
+echo ""
+echo -e "  3. Open the dashboard:"
+echo -e "     ${CYAN}http://localhost:9202/${RESET}"
+echo ""
+echo -e "  4. Or use the CLI monitor:"
+echo -e "     ${CYAN}argus${RESET}"
+echo -e "     ${CYAN}argus --port 9202 --interval 2${RESET}"
+echo ""
+echo -e "  ${BOLD}Uninstall:${RESET}"
+echo -e "     ${CYAN}rm -rf ~/.argus${RESET}  and remove the PATH line from $PROFILE"
+echo ""

--- a/samples/virtual-thread-simulation/build.gradle.kts
+++ b/samples/virtual-thread-simulation/build.gradle.kts
@@ -45,19 +45,13 @@ tasks.register<JavaExec>("runSimulation") {
         languageVersion.set(JavaLanguageVersion.of(21))
     })
 
-    // Pass duration property if provided: -Dduration=10
-    val duration = System.getProperty("duration")
-
     jvmArgs(
         "--enable-preview",
         "-javaagent:${rootProject.projectDir}/argus-agent/build/libs/argus-agent-${rootProject.property("argusVersion")}.jar",
         "-Dargus.server.enabled=true",
-        "-Dargus.server.port=9202"
+        "-Dargus.server.port=9202",
+        "-Dduration=${System.getProperty("duration") ?: "300"}"
     )
-
-    if (duration != null) {
-        jvmArgs("-Dduration=$duration")
-    }
 }
 
 // Run metrics demo with GC/CPU activity
@@ -72,9 +66,6 @@ tasks.register<JavaExec>("runMetricsDemo") {
         languageVersion.set(JavaLanguageVersion.of(21))
     })
 
-    // Duration in seconds (default: 60)
-    val duration = System.getProperty("duration")
-
     jvmArgs(
         "--enable-preview",
         "-Xmx512m",  // Enough heap for JFR + Netty + app
@@ -84,12 +75,9 @@ tasks.register<JavaExec>("runMetricsDemo") {
         "-Dargus.server.enabled=true",
         "-Dargus.server.port=9202",
         "-Dargus.gc.enabled=true",
-        "-Dargus.cpu.enabled=true"
+        "-Dargus.cpu.enabled=true",
+        "-Dduration=${System.getProperty("duration") ?: "300"}"
     )
-
-    if (duration != null) {
-        jvmArgs("-Dduration=$duration")
-    }
 }
 
 // Run metrics demo with ALL features enabled (including high-overhead ones)
@@ -103,8 +91,6 @@ tasks.register<JavaExec>("runMetricsDemoFull") {
     javaLauncher.set(javaToolchains.launcherFor {
         languageVersion.set(JavaLanguageVersion.of(21))
     })
-
-    val duration = System.getProperty("duration")
 
     jvmArgs(
         "--enable-preview",
@@ -125,10 +111,8 @@ tasks.register<JavaExec>("runMetricsDemoFull") {
         "-Dargus.profiling.interval=50",  // 50ms interval (lower overhead)
         "-Dargus.contention.enabled=true",
         "-Dargus.contention.threshold=20",  // 20ms threshold
-        "-Dargus.correlation.enabled=true"
+        "-Dargus.correlation.enabled=true",
+        // Default: 5 minutes (override with -Dduration=N)
+        "-Dduration=${System.getProperty("duration") ?: "300"}"
     )
-
-    if (duration != null) {
-        jvmArgs("-Dduration=$duration")
-    }
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -8,6 +8,7 @@ include("argus-core")
 include("argus-agent")
 include("argus-server")
 include("argus-frontend")
+include("argus-cli")
 
 // Sample projects
 include("samples:virtual-thread-demo")


### PR DESCRIPTION
## Summary

Argus v0.4 pivots from VT-focused profiler to a **lightweight, zero-dependency JVM monitoring tool** (JDK 24+ eliminates VT pinning via JEP 491).

### New Features

- **Flame Graph**: Interactive d3-flamegraph visualization from JFR `ExecutionSample` data with 60s auto-reset window, pause/resume, and server-side reset
- **CLI Monitor (`argus top`)**: htop-style terminal UI in new `argus-cli` module — CPU, heap, GC, virtual threads, hot methods, contention. Zero external dependencies
- **OTLP Export**: Push-based metrics to OpenTelemetry collectors via hand-coded JSON (no SDK). Configurable via `-Dargus.otlp.*` system properties
- **Install Script**: One-line `curl | bash` installer with `argus` command PATH setup

### Bug Fixes

- Fix d3-flamegraph CDN URL (package name `d3-flame-graph`, not `d3-flamegraph`)
- Fix demo duration passthrough in Gradle tasks (default 5 minutes)

### Files Changed

| Category | Details |
|----------|---------|
| **New module** | `argus-cli/` (5 Java files + build.gradle.kts) |
| **New classes** | `FlameGraphAnalyzer`, `OtlpJsonBuilder`, `OtlpMetricsExporter` |
| **New script** | `install.sh` |
| **Modified** | `AgentConfig` (OTLP config), `ArgusServer`, `ArgusChannelHandler`, `EventBroadcaster` |
| **Frontend** | `index.html` (CDN fix + flame graph UI), `app.js` (pause/resume/reset), `style.css` |
| **Docs** | `README.md` (full rewrite: features, install, quick start, config) |

### Configuration (New)

```
-Dargus.otlp.enabled=false
-Dargus.otlp.endpoint=http://localhost:4318/v1/metrics
-Dargus.otlp.interval=15000
-Dargus.otlp.headers=
-Dargus.otlp.service.name=argus
```

## Test plan

- [x] `./gradlew build` passes (33 tasks, all green)
- [x] Flame graph renders with profiling enabled (`-Dargus.profiling.enabled=true`)
- [x] CLI connects and displays live metrics from running server
- [x] `/flame-graph` endpoint returns d3-compatible JSON
- [x] `/flame-graph?format=collapsed` returns collapsed stack format
- [x] `/flame-graph?reset=true` clears server data
- [x] Pause/Resume button freezes flame graph updates with timestamp
- [x] `install.sh` creates wrapper scripts and configures PATH
- [x] OTLP config fields added to AgentConfig with system property parsing

🤖 Generated with [Claude Code](https://claude.com/claude-code)