### PR TITLE
test: add unit tests for micrometer and spring-boot-starter

### DIFF
--- a/argus-frontend/src/main/resources/public/css/style.css
+++ b/argus-frontend/src/main/resources/public/css/style.css
@@ -45,7 +45,7 @@
     /* Layout */
     --page-max:        1800px;
     --page-pad:        2.5rem;
-    --section-gap:     2.5rem;
+    --section-gap:     3.5rem;
 
     /* Type */
     --font-sans:       -apple-system, BlinkMacSystemFont, 'Helvetica Neue', Helvetica, Arial, sans-serif;

--- a/argus-micrometer/src/test/java/io/argus/micrometer/ArgusMeterBinderTest.java
+++ b/argus-micrometer/src/test/java/io/argus/micrometer/ArgusMeterBinderTest.java
@@ -1,0 +1,201 @@
+package io.argus.micrometer;
+
+import io.argus.core.config.AgentConfig;
+import io.argus.server.analysis.AllocationAnalyzer;
+import io.argus.server.analysis.CarrierThreadAnalyzer;
+import io.argus.server.analysis.ContentionAnalyzer;
+import io.argus.server.analysis.CPUAnalyzer;
+import io.argus.server.analysis.GCAnalyzer;
+import io.argus.server.analysis.MetaspaceAnalyzer;
+import io.argus.server.analysis.MethodProfilingAnalyzer;
+import io.argus.server.analysis.PinningAnalyzer;
+import io.argus.server.metrics.ServerMetrics;
+import io.argus.server.state.ActiveThreadsRegistry;
+
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.Meter;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests for {@link ArgusMeterBinder}.
+ */
+class ArgusMeterBinderTest {
+
+    private MeterRegistry registry;
+    private ServerMetrics serverMetrics;
+    private ActiveThreadsRegistry activeThreads;
+    private AgentConfig config;
+
+    @BeforeEach
+    void setUp() {
+        registry = new SimpleMeterRegistry();
+        serverMetrics = new ServerMetrics();
+        activeThreads = new ActiveThreadsRegistry();
+        config = AgentConfig.builder()
+                .gcEnabled(true)
+                .cpuEnabled(true)
+                .metaspaceEnabled(true)
+                .allocationEnabled(true)
+                .contentionEnabled(true)
+                .profilingEnabled(true)
+                .build();
+    }
+
+    @Test
+    void bindsVirtualThreadMetrics() {
+        ArgusMeterBinder binder = new ArgusMeterBinder(
+                serverMetrics, activeThreads,
+                new PinningAnalyzer(), new CarrierThreadAnalyzer(),
+                new GCAnalyzer(), new CPUAnalyzer(),
+                new AllocationAnalyzer(), new MetaspaceAnalyzer(),
+                new MethodProfilingAnalyzer(), new ContentionAnalyzer(),
+                config);
+
+        binder.bindTo(registry);
+
+        assertNotNull(registry.find("argus.virtual.threads.started").functionCounter());
+        assertNotNull(registry.find("argus.virtual.threads.ended").functionCounter());
+        assertNotNull(registry.find("argus.virtual.threads.active").gauge());
+        assertNotNull(registry.find("argus.virtual.threads.submit.failed").functionCounter());
+        assertNotNull(registry.find("argus.virtual.threads.pinned").functionCounter());
+        assertNotNull(registry.find("argus.virtual.threads.pinned.unique.stacks").gauge());
+        assertNotNull(registry.find("argus.carrier.threads.total").gauge());
+    }
+
+    @Test
+    void bindsGCMetrics() {
+        ArgusMeterBinder binder = new ArgusMeterBinder(
+                serverMetrics, activeThreads,
+                new PinningAnalyzer(), new CarrierThreadAnalyzer(),
+                new GCAnalyzer(), new CPUAnalyzer(),
+                null, null, null, null,
+                config);
+
+        binder.bindTo(registry);
+
+        assertNotNull(registry.find("argus.gc.events").functionCounter());
+        assertNotNull(registry.find("argus.gc.pause.time.seconds").gauge());
+        assertNotNull(registry.find("argus.gc.pause.time.max.seconds").gauge());
+        assertNotNull(registry.find("argus.gc.overhead.ratio").gauge());
+        assertNotNull(registry.find("argus.heap.used.bytes").gauge());
+        assertNotNull(registry.find("argus.heap.committed.bytes").gauge());
+    }
+
+    @Test
+    void bindsCPUMetrics() {
+        ArgusMeterBinder binder = new ArgusMeterBinder(
+                serverMetrics, activeThreads,
+                new PinningAnalyzer(), new CarrierThreadAnalyzer(),
+                new GCAnalyzer(), new CPUAnalyzer(),
+                null, null, null, null,
+                config);
+
+        binder.bindTo(registry);
+
+        assertNotNull(registry.find("argus.cpu.jvm.user.ratio").gauge());
+        assertNotNull(registry.find("argus.cpu.jvm.system.ratio").gauge());
+        assertNotNull(registry.find("argus.cpu.machine.total.ratio").gauge());
+    }
+
+    @Test
+    void bindsAllMetricsWhenAllEnabled() {
+        ArgusMeterBinder binder = new ArgusMeterBinder(
+                serverMetrics, activeThreads,
+                new PinningAnalyzer(), new CarrierThreadAnalyzer(),
+                new GCAnalyzer(), new CPUAnalyzer(),
+                new AllocationAnalyzer(), new MetaspaceAnalyzer(),
+                new MethodProfilingAnalyzer(), new ContentionAnalyzer(),
+                config);
+
+        binder.bindTo(registry);
+
+        // Count all registered meters
+        List<Meter> meters = registry.getMeters();
+        assertTrue(meters.size() >= 25, "Expected at least 25 meters, got " + meters.size());
+    }
+
+    @Test
+    void skipsDisabledCategories() {
+        AgentConfig disabledConfig = AgentConfig.builder()
+                .gcEnabled(false)
+                .cpuEnabled(false)
+                .metaspaceEnabled(false)
+                .allocationEnabled(false)
+                .contentionEnabled(false)
+                .profilingEnabled(false)
+                .build();
+
+        ArgusMeterBinder binder = new ArgusMeterBinder(
+                serverMetrics, activeThreads,
+                new PinningAnalyzer(), new CarrierThreadAnalyzer(),
+                new GCAnalyzer(), new CPUAnalyzer(),
+                null, null, null, null,
+                disabledConfig);
+
+        binder.bindTo(registry);
+
+        // Virtual thread metrics always present
+        assertNotNull(registry.find("argus.virtual.threads.active").gauge());
+
+        // GC/CPU/etc should not be present
+        assertNull(registry.find("argus.gc.events").functionCounter());
+        assertNull(registry.find("argus.cpu.jvm.user.ratio").gauge());
+        assertNull(registry.find("argus.metaspace.used.bytes").gauge());
+    }
+
+    @Test
+    void metricsReflectLiveData() {
+        ArgusMeterBinder binder = new ArgusMeterBinder(
+                serverMetrics, activeThreads,
+                new PinningAnalyzer(), new CarrierThreadAnalyzer(),
+                new GCAnalyzer(), new CPUAnalyzer(),
+                null, null, null, null,
+                config);
+
+        binder.bindTo(registry);
+
+        // Initial values should be 0
+        Gauge activeGauge = registry.find("argus.virtual.threads.active").gauge();
+        assertNotNull(activeGauge);
+        assertEquals(0.0, activeGauge.value());
+
+        // Increment server metrics
+        serverMetrics.incrementStart();
+        serverMetrics.incrementStart();
+        serverMetrics.incrementStart();
+
+        double startCount = registry.find("argus.virtual.threads.started").functionCounter().count();
+        assertEquals(3.0, startCount);
+    }
+
+    @Test
+    void respectsMetricsConfig() {
+        ArgusMetricsConfig metricsConfig = ArgusMetricsConfig.builder()
+                .gcMetrics(false)
+                .cpuMetrics(true)
+                .build();
+
+        ArgusMeterBinder binder = new ArgusMeterBinder(
+                serverMetrics, activeThreads,
+                new PinningAnalyzer(), new CarrierThreadAnalyzer(),
+                new GCAnalyzer(), new CPUAnalyzer(),
+                null, null, null, null,
+                config, metricsConfig);
+
+        binder.bindTo(registry);
+
+        // GC disabled via metricsConfig
+        assertNull(registry.find("argus.gc.events").functionCounter());
+
+        // CPU still enabled
+        assertNotNull(registry.find("argus.cpu.jvm.user.ratio").gauge());
+    }
+}

--- a/argus-spring-boot-starter/src/test/java/io/argus/spring/ArgusAutoConfigurationTest.java
+++ b/argus-spring-boot-starter/src/test/java/io/argus/spring/ArgusAutoConfigurationTest.java
@@ -1,0 +1,125 @@
+package io.argus.spring;
+
+import io.argus.core.config.AgentConfig;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests for {@link ArgusAutoConfiguration} properties-to-config mapping.
+ */
+class ArgusAutoConfigurationTest {
+
+    @Test
+    void propertiesToAgentConfigMapping() {
+        ArgusProperties props = new ArgusProperties();
+        props.setBufferSize(131072);
+        props.getServer().setPort(8080);
+        props.getServer().setEnabled(false);
+        props.getGc().setEnabled(true);
+        props.getCpu().setEnabled(true);
+        props.getCpu().setIntervalMs(500);
+        props.getAllocation().setEnabled(true);
+        props.getAllocation().setThreshold(524288);
+        props.getMetaspace().setEnabled(false);
+        props.getProfiling().setEnabled(true);
+        props.getProfiling().setIntervalMs(10);
+        props.getContention().setEnabled(true);
+        props.getContention().setThresholdMs(25);
+        props.getCorrelation().setEnabled(false);
+        props.getMetrics().getPrometheus().setEnabled(false);
+        props.getMetrics().getOtlp().setEnabled(true);
+        props.getMetrics().getOtlp().setEndpoint("http://otel:4318/v1/metrics");
+        props.getMetrics().getOtlp().setIntervalMs(5000);
+        props.getMetrics().getOtlp().setHeaders("Authorization=Bearer xxx");
+        props.getMetrics().getOtlp().setServiceName("my-app");
+
+        // Use the same mapping logic as ArgusAutoConfiguration.argusAgentConfig()
+        AgentConfig config = AgentConfig.builder()
+                .bufferSize(props.getBufferSize())
+                .serverPort(props.getServer().getPort())
+                .serverEnabled(props.getServer().isEnabled())
+                .gcEnabled(props.getGc().isEnabled())
+                .cpuEnabled(props.getCpu().isEnabled())
+                .cpuIntervalMs(props.getCpu().getIntervalMs())
+                .allocationEnabled(props.getAllocation().isEnabled())
+                .allocationThreshold(props.getAllocation().getThreshold())
+                .metaspaceEnabled(props.getMetaspace().isEnabled())
+                .profilingEnabled(props.getProfiling().isEnabled())
+                .profilingIntervalMs(props.getProfiling().getIntervalMs())
+                .contentionEnabled(props.getContention().isEnabled())
+                .contentionThresholdMs(props.getContention().getThresholdMs())
+                .correlationEnabled(props.getCorrelation().isEnabled())
+                .prometheusEnabled(props.getMetrics().getPrometheus().isEnabled())
+                .otlpEnabled(props.getMetrics().getOtlp().isEnabled())
+                .otlpEndpoint(props.getMetrics().getOtlp().getEndpoint())
+                .otlpIntervalMs(props.getMetrics().getOtlp().getIntervalMs())
+                .otlpHeaders(props.getMetrics().getOtlp().getHeaders())
+                .otlpServiceName(props.getMetrics().getOtlp().getServiceName())
+                .build();
+
+        assertEquals(131072, config.getBufferSize());
+        assertEquals(8080, config.getServerPort());
+        assertFalse(config.isServerEnabled());
+        assertTrue(config.isGcEnabled());
+        assertTrue(config.isCpuEnabled());
+        assertEquals(500, config.getCpuIntervalMs());
+        assertTrue(config.isAllocationEnabled());
+        assertEquals(524288, config.getAllocationThreshold());
+        assertFalse(config.isMetaspaceEnabled());
+        assertTrue(config.isProfilingEnabled());
+        assertEquals(10, config.getProfilingIntervalMs());
+        assertTrue(config.isContentionEnabled());
+        assertEquals(25, config.getContentionThresholdMs());
+        assertFalse(config.isCorrelationEnabled());
+        assertFalse(config.isPrometheusEnabled());
+        assertTrue(config.isOtlpEnabled());
+        assertEquals("http://otel:4318/v1/metrics", config.getOtlpEndpoint());
+        assertEquals(5000, config.getOtlpIntervalMs());
+        assertEquals("Authorization=Bearer xxx", config.getOtlpHeaders());
+        assertEquals("my-app", config.getOtlpServiceName());
+    }
+
+    @Test
+    void defaultPropertiesMatchDefaultConfig() {
+        ArgusProperties props = new ArgusProperties();
+        AgentConfig defaults = AgentConfig.defaults();
+
+        AgentConfig fromProps = AgentConfig.builder()
+                .bufferSize(props.getBufferSize())
+                .serverPort(props.getServer().getPort())
+                .serverEnabled(props.getServer().isEnabled())
+                .gcEnabled(props.getGc().isEnabled())
+                .cpuEnabled(props.getCpu().isEnabled())
+                .cpuIntervalMs(props.getCpu().getIntervalMs())
+                .allocationEnabled(props.getAllocation().isEnabled())
+                .allocationThreshold(props.getAllocation().getThreshold())
+                .metaspaceEnabled(props.getMetaspace().isEnabled())
+                .profilingEnabled(props.getProfiling().isEnabled())
+                .profilingIntervalMs(props.getProfiling().getIntervalMs())
+                .contentionEnabled(props.getContention().isEnabled())
+                .contentionThresholdMs(props.getContention().getThresholdMs())
+                .correlationEnabled(props.getCorrelation().isEnabled())
+                .prometheusEnabled(props.getMetrics().getPrometheus().isEnabled())
+                .otlpEnabled(props.getMetrics().getOtlp().isEnabled())
+                .otlpEndpoint(props.getMetrics().getOtlp().getEndpoint())
+                .otlpIntervalMs(props.getMetrics().getOtlp().getIntervalMs())
+                .otlpHeaders(props.getMetrics().getOtlp().getHeaders())
+                .otlpServiceName(props.getMetrics().getOtlp().getServiceName())
+                .build();
+
+        assertEquals(defaults.getBufferSize(), fromProps.getBufferSize());
+        assertEquals(defaults.getServerPort(), fromProps.getServerPort());
+        assertEquals(defaults.isServerEnabled(), fromProps.isServerEnabled());
+        assertEquals(defaults.isGcEnabled(), fromProps.isGcEnabled());
+        assertEquals(defaults.isCpuEnabled(), fromProps.isCpuEnabled());
+        assertEquals(defaults.getCpuIntervalMs(), fromProps.getCpuIntervalMs());
+        assertEquals(defaults.isAllocationEnabled(), fromProps.isAllocationEnabled());
+        assertEquals(defaults.isMetaspaceEnabled(), fromProps.isMetaspaceEnabled());
+        assertEquals(defaults.isProfilingEnabled(), fromProps.isProfilingEnabled());
+        assertEquals(defaults.isContentionEnabled(), fromProps.isContentionEnabled());
+        assertEquals(defaults.isPrometheusEnabled(), fromProps.isPrometheusEnabled());
+        assertEquals(defaults.isOtlpEnabled(), fromProps.isOtlpEnabled());
+    }
+}

--- a/argus-spring-boot-starter/src/test/java/io/argus/spring/ArgusPropertiesTest.java
+++ b/argus-spring-boot-starter/src/test/java/io/argus/spring/ArgusPropertiesTest.java
@@ -1,0 +1,82 @@
+package io.argus.spring;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests for {@link ArgusProperties} defaults and configuration mapping.
+ */
+class ArgusPropertiesTest {
+
+    @Test
+    void defaultsMatchAgentConfigDefaults() {
+        ArgusProperties props = new ArgusProperties();
+
+        assertTrue(props.isEnabled());
+        assertEquals(65536, props.getBufferSize());
+        assertTrue(props.getServer().isEnabled());
+        assertEquals(9202, props.getServer().getPort());
+        assertTrue(props.getGc().isEnabled());
+        assertTrue(props.getCpu().isEnabled());
+        assertEquals(1000, props.getCpu().getIntervalMs());
+        assertFalse(props.getAllocation().isEnabled());
+        assertEquals(1048576, props.getAllocation().getThreshold());
+        assertTrue(props.getMetaspace().isEnabled());
+        assertFalse(props.getProfiling().isEnabled());
+        assertEquals(20, props.getProfiling().getIntervalMs());
+        assertFalse(props.getContention().isEnabled());
+        assertEquals(50, props.getContention().getThresholdMs());
+        assertTrue(props.getCorrelation().isEnabled());
+        assertTrue(props.getMetrics().getPrometheus().isEnabled());
+        assertFalse(props.getMetrics().getOtlp().isEnabled());
+        assertEquals("http://localhost:4318/v1/metrics", props.getMetrics().getOtlp().getEndpoint());
+        assertEquals(15000, props.getMetrics().getOtlp().getIntervalMs());
+        assertEquals("argus", props.getMetrics().getOtlp().getServiceName());
+        assertTrue(props.getMetrics().getMicrometer().isEnabled());
+    }
+
+    @Test
+    void settersWorkCorrectly() {
+        ArgusProperties props = new ArgusProperties();
+
+        props.setEnabled(false);
+        assertFalse(props.isEnabled());
+
+        props.setBufferSize(131072);
+        assertEquals(131072, props.getBufferSize());
+
+        props.getServer().setPort(8080);
+        assertEquals(8080, props.getServer().getPort());
+
+        props.getGc().setEnabled(false);
+        assertFalse(props.getGc().isEnabled());
+
+        props.getCpu().setIntervalMs(500);
+        assertEquals(500, props.getCpu().getIntervalMs());
+
+        props.getAllocation().setEnabled(true);
+        assertTrue(props.getAllocation().isEnabled());
+
+        props.getAllocation().setThreshold(524288);
+        assertEquals(524288, props.getAllocation().getThreshold());
+    }
+
+    @Test
+    void nestedObjectsAreNeverNull() {
+        ArgusProperties props = new ArgusProperties();
+
+        assertNotNull(props.getServer());
+        assertNotNull(props.getGc());
+        assertNotNull(props.getCpu());
+        assertNotNull(props.getAllocation());
+        assertNotNull(props.getMetaspace());
+        assertNotNull(props.getProfiling());
+        assertNotNull(props.getContention());
+        assertNotNull(props.getCorrelation());
+        assertNotNull(props.getMetrics());
+        assertNotNull(props.getMetrics().getPrometheus());
+        assertNotNull(props.getMetrics().getOtlp());
+        assertNotNull(props.getMetrics().getMicrometer());
+    }
+}


### PR DESCRIPTION
## Summary
- ArgusMeterBinderTest (7 tests): metric binding, live data, disabled categories, config filtering
- ArgusPropertiesTest (3 tests): defaults, setters, null safety
- ArgusAutoConfigurationTest (2 tests): properties-to-config mapping, default parity
- Section gap increased (2.5rem → 3.5rem) for better visual separation

## Test plan
- [x] `./gradlew :argus-micrometer:test` — 7/7 pass
- [x] `./gradlew :argus-spring-boot-starter:test` — 5/5 pass