### PR TITLE
refactor: introduce DiagnosticCommand SPI for pluggable command architecture

### DIFF
--- a/argus-core/src/main/java/io/argus/core/command/CommandContext.java
+++ b/argus-core/src/main/java/io/argus/core/command/CommandContext.java
@@ -1,0 +1,39 @@
+package io.argus.core.command;
+
+/**
+ * Execution context for diagnostic commands.
+ *
+ * <p>Sealed to exactly two variants:
+ * <ul>
+ *   <li>{@link InProcess} — command runs inside the target JVM (MXBeans, direct API access)</li>
+ *   <li>{@link External} — command runs from outside, targeting a remote JVM by PID</li>
+ * </ul>
+ *
+ * <p>Command implementations use pattern matching to handle each context:
+ * <pre>
+ * switch (ctx) {
+ *     case InProcess ip -> ip.getBufferPoolMXBeans();
+ *     case External ex  -> JcmdExecutor.execute(ex.pid(), "VM.info");
+ * }
+ * </pre>
+ */
+public sealed interface CommandContext permits CommandContext.InProcess, CommandContext.External {
+
+    /**
+     * In-process context: the command executes inside the monitored JVM.
+     * Has direct access to MXBeans, Runtime APIs, and the current JVM state.
+     */
+    non-sealed interface InProcess extends CommandContext {
+        /** Current JVM PID. */
+        long pid();
+    }
+
+    /**
+     * External context: the command targets a remote JVM by PID.
+     * Uses jcmd, jstat, or attach API to gather data.
+     */
+    non-sealed interface External extends CommandContext {
+        /** Target JVM PID. */
+        long pid();
+    }
+}

--- a/argus-core/src/main/java/io/argus/core/command/CommandGroup.java
+++ b/argus-core/src/main/java/io/argus/core/command/CommandGroup.java
@@ -1,0 +1,22 @@
+package io.argus.core.command;
+
+/**
+ * Logical grouping for diagnostic commands.
+ * Used by UI to organize command buttons and by help output for categorization.
+ */
+public enum CommandGroup {
+    PROCESS("Process & System"),
+    MEMORY("Memory & GC"),
+    THREADS("Threads"),
+    RUNTIME("Runtime & Class Loading"),
+    PROFILING("Profiling & Diagnostics"),
+    MONITORING("Monitoring");
+
+    private final String displayName;
+
+    CommandGroup(String displayName) {
+        this.displayName = displayName;
+    }
+
+    public String displayName() { return displayName; }
+}

--- a/argus-core/src/main/java/io/argus/core/command/CommandRegistry.java
+++ b/argus-core/src/main/java/io/argus/core/command/CommandRegistry.java
@@ -1,0 +1,97 @@
+package io.argus.core.command;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.ServiceLoader;
+
+/**
+ * Central registry for diagnostic commands. Discovers commands via {@link ServiceLoader}
+ * and provides lookup by id, group, or execution capability.
+ *
+ * <p>Usage:
+ * <pre>
+ * CommandRegistry registry = CommandRegistry.load();
+ * String result = registry.execute("buffers", context);
+ * </pre>
+ *
+ * <p>Thread-safe after construction. Commands are loaded once and cached.
+ */
+public final class CommandRegistry {
+
+    private final Map<String, DiagnosticCommand> commands;
+
+    private CommandRegistry(Map<String, DiagnosticCommand> commands) {
+        this.commands = commands;
+    }
+
+    /**
+     * Load all commands via ServiceLoader discovery.
+     * Scans the classpath for {@code META-INF/services/io.argus.core.command.DiagnosticCommand}.
+     */
+    public static CommandRegistry load() {
+        Map<String, DiagnosticCommand> map = new LinkedHashMap<>();
+        for (DiagnosticCommand cmd : ServiceLoader.load(DiagnosticCommand.class)) {
+            map.put(cmd.id(), cmd);
+        }
+        return new CommandRegistry(Collections.unmodifiableMap(map));
+    }
+
+    /**
+     * Create a registry from explicitly provided commands (for testing or manual registration).
+     */
+    public static CommandRegistry of(DiagnosticCommand... commands) {
+        Map<String, DiagnosticCommand> map = new LinkedHashMap<>();
+        for (DiagnosticCommand cmd : commands) {
+            map.put(cmd.id(), cmd);
+        }
+        return new CommandRegistry(Collections.unmodifiableMap(map));
+    }
+
+    /** Find a command by id, or null if not found. */
+    public DiagnosticCommand find(String id) {
+        return commands.get(id);
+    }
+
+    /** Execute a command by id. Returns the output string. */
+    public String execute(String id, CommandContext ctx) {
+        DiagnosticCommand cmd = commands.get(id);
+        if (cmd == null) {
+            return "Unknown command: " + id;
+        }
+        return cmd.execute(ctx);
+    }
+
+    /** All registered commands. */
+    public Collection<DiagnosticCommand> all() {
+        return commands.values();
+    }
+
+    /** Commands filtered by group. */
+    public List<DiagnosticCommand> byGroup(CommandGroup group) {
+        return commands.values().stream()
+                .filter(cmd -> cmd.group() == group)
+                .toList();
+    }
+
+    /** Commands that support in-process execution. */
+    public List<DiagnosticCommand> inProcessCommands() {
+        return commands.values().stream()
+                .filter(DiagnosticCommand::supportsInProcess)
+                .toList();
+    }
+
+    /** Commands that support external execution. */
+    public List<DiagnosticCommand> externalCommands() {
+        return commands.values().stream()
+                .filter(DiagnosticCommand::supportsExternal)
+                .toList();
+    }
+
+    /** Number of registered commands. */
+    public int size() {
+        return commands.size();
+    }
+}

--- a/argus-core/src/main/java/io/argus/core/command/DiagnosticCommand.java
+++ b/argus-core/src/main/java/io/argus/core/command/DiagnosticCommand.java
@@ -1,0 +1,60 @@
+package io.argus.core.command;
+
+/**
+ * Service Provider Interface for diagnostic commands.
+ *
+ * <p>Each command is a single class that declares its metadata (id, group, description)
+ * and knows how to execute in a given {@link CommandContext}. Commands are discovered
+ * automatically via {@link java.util.ServiceLoader}.
+ *
+ * <p>Implementations should be stateless and thread-safe. The {@link #execute} method
+ * returns a plain text result string; JSON formatting is handled by the caller.
+ *
+ * <p>Example:
+ * <pre>
+ * public final class BuffersCommand implements DiagnosticCommand {
+ *     public String id()          { return "buffers"; }
+ *     public CommandGroup group() { return CommandGroup.MEMORY; }
+ *     public String description() { return "NIO buffer pool statistics"; }
+ *
+ *     public String execute(CommandContext ctx) {
+ *         // implementation
+ *     }
+ * }
+ * </pre>
+ *
+ * @see CommandRegistry
+ * @see CommandContext
+ */
+public interface DiagnosticCommand {
+
+    /** Unique command identifier (lowercase, no spaces). Used in CLI and API routing. */
+    String id();
+
+    /** Logical group for UI categorization. */
+    CommandGroup group();
+
+    /** One-line description shown in help and command listings. */
+    String description();
+
+    /**
+     * Execute the command in the given context.
+     *
+     * @param ctx execution context (in-process or external)
+     * @return command output as plain text
+     * @throws UnsupportedOperationException if this command doesn't support the given context type
+     */
+    String execute(CommandContext ctx);
+
+    /**
+     * Whether this command supports in-process execution (agent/server mode).
+     * Default: true.
+     */
+    default boolean supportsInProcess() { return true; }
+
+    /**
+     * Whether this command supports external execution (CLI mode).
+     * Default: true.
+     */
+    default boolean supportsExternal() { return true; }
+}

--- a/argus-server/src/main/java/io/argus/server/command/ServerCommandExecutor.java
+++ b/argus-server/src/main/java/io/argus/server/command/ServerCommandExecutor.java
@@ -1,5 +1,8 @@
 package io.argus.server.command;
 
+import io.argus.core.command.CommandRegistry;
+import io.argus.core.command.DiagnosticCommand;
+
 import java.lang.management.ClassLoadingMXBean;
 import java.lang.management.GarbageCollectorMXBean;
 import java.lang.management.ManagementFactory;
@@ -25,6 +28,8 @@ import java.util.Properties;
 public final class ServerCommandExecutor {
 
     private static final Map<String, CommandInfo> COMMANDS = new LinkedHashMap<>();
+    private static final CommandRegistry SPI_REGISTRY = CommandRegistry.load();
+    private static final ServerContext SPI_CONTEXT = new ServerContext();
 
     private static final java.util.Set<String> SENSITIVE_KEYS = java.util.Set.of(
             "PASSWORD", "SECRET", "KEY", "TOKEN", "CREDENTIAL", "AUTH", "PRIVATE");
@@ -62,10 +67,22 @@ public final class ServerCommandExecutor {
     }
 
     public static Map<String, CommandInfo> getAvailableCommands() {
-        return COMMANDS;
+        Map<String, CommandInfo> all = new LinkedHashMap<>(COMMANDS);
+        for (DiagnosticCommand cmd : SPI_REGISTRY.all()) {
+            if (!all.containsKey(cmd.id())) {
+                all.put(cmd.id(), new CommandInfo(
+                        cmd.id(), cmd.group().displayName().toLowerCase(), cmd.description()));
+            }
+        }
+        return all;
     }
 
     public static String execute(String command) {
+        // Try SPI commands first (new pluggable commands)
+        DiagnosticCommand spiCmd = SPI_REGISTRY.find(command);
+        if (spiCmd != null) {
+            return spiCmd.execute(SPI_CONTEXT);
+        }
         if (!COMMANDS.containsKey(command)) {
             return "Unknown command: " + command + "\nType 'help' to see available commands.";
         }

--- a/argus-server/src/main/java/io/argus/server/command/ServerContext.java
+++ b/argus-server/src/main/java/io/argus/server/command/ServerContext.java
@@ -1,0 +1,17 @@
+package io.argus.server.command;
+
+import io.argus.core.command.CommandContext;
+
+/**
+ * In-process command context for the Argus server.
+ * Commands executed here run inside the monitored JVM with direct MXBean access.
+ */
+public final class ServerContext implements CommandContext.InProcess {
+
+    private static final long PID = ProcessHandle.current().pid();
+
+    @Override
+    public long pid() {
+        return PID;
+    }
+}

--- a/argus-server/src/main/java/io/argus/server/command/impl/BuffersDiagnosticCommand.java
+++ b/argus-server/src/main/java/io/argus/server/command/impl/BuffersDiagnosticCommand.java
@@ -1,0 +1,37 @@
+package io.argus.server.command.impl;
+
+import io.argus.core.command.CommandContext;
+import io.argus.core.command.CommandGroup;
+import io.argus.core.command.DiagnosticCommand;
+
+import java.lang.management.BufferPoolMXBean;
+import java.lang.management.ManagementFactory;
+
+public final class BuffersDiagnosticCommand implements DiagnosticCommand {
+
+    @Override public String id() { return "buffers"; }
+    @Override public CommandGroup group() { return CommandGroup.MEMORY; }
+    @Override public String description() { return "NIO buffer pool statistics (direct, mapped)"; }
+    @Override public boolean supportsExternal() { return false; }
+
+    @Override
+    public String execute(CommandContext ctx) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("Pool                      Count      Capacity        Used\n");
+        sb.append("─────────────────────────────────────────────────────────\n");
+
+        long totalCount = 0, totalCap = 0, totalUsed = 0;
+        for (BufferPoolMXBean pool : ManagementFactory.getPlatformMXBeans(BufferPoolMXBean.class)) {
+            long count = pool.getCount();
+            long cap = pool.getTotalCapacity();
+            long used = pool.getMemoryUsed();
+            sb.append(String.format("%-25s %,6d  %,12d  %,12d\n", pool.getName(), count, cap, used));
+            totalCount += count;
+            totalCap += cap;
+            totalUsed += used;
+        }
+        sb.append("─────────────────────────────────────────────────────────\n");
+        sb.append(String.format("%-25s %,6d  %,12d  %,12d", "Total", totalCount, totalCap, totalUsed));
+        return sb.toString();
+    }
+}

--- a/argus-server/src/main/java/io/argus/server/command/impl/CompilerQueueDiagnosticCommand.java
+++ b/argus-server/src/main/java/io/argus/server/command/impl/CompilerQueueDiagnosticCommand.java
@@ -1,0 +1,28 @@
+package io.argus.server.command.impl;
+
+import io.argus.core.command.CommandContext;
+import io.argus.core.command.CommandGroup;
+import io.argus.core.command.DiagnosticCommand;
+
+public final class CompilerQueueDiagnosticCommand implements DiagnosticCommand {
+
+    @Override public String id() { return "compilerqueue"; }
+    @Override public CommandGroup group() { return CommandGroup.RUNTIME; }
+    @Override public String description() { return "JIT compilation queue"; }
+    @Override public boolean supportsExternal() { return false; }
+
+    @Override
+    public String execute(CommandContext ctx) {
+        try {
+            long pid = ((CommandContext.InProcess) ctx).pid();
+            ProcessBuilder pb = new ProcessBuilder("jcmd", String.valueOf(pid), "Compiler.queue");
+            pb.redirectErrorStream(true);
+            Process proc = pb.start();
+            String output = new String(proc.getInputStream().readAllBytes());
+            proc.waitFor();
+            return output.isBlank() ? "Compilation queue is empty" : output;
+        } catch (Exception e) {
+            return "Error: " + e.getMessage();
+        }
+    }
+}

--- a/argus-server/src/main/java/io/argus/server/command/impl/EventsDiagnosticCommand.java
+++ b/argus-server/src/main/java/io/argus/server/command/impl/EventsDiagnosticCommand.java
@@ -1,0 +1,28 @@
+package io.argus.server.command.impl;
+
+import io.argus.core.command.CommandContext;
+import io.argus.core.command.CommandGroup;
+import io.argus.core.command.DiagnosticCommand;
+
+public final class EventsDiagnosticCommand implements DiagnosticCommand {
+
+    @Override public String id() { return "events"; }
+    @Override public CommandGroup group() { return CommandGroup.PROFILING; }
+    @Override public String description() { return "VM internal event log (safepoints, deopt, GC)"; }
+    @Override public boolean supportsExternal() { return false; }
+
+    @Override
+    public String execute(CommandContext ctx) {
+        try {
+            long pid = ((CommandContext.InProcess) ctx).pid();
+            ProcessBuilder pb = new ProcessBuilder("jcmd", String.valueOf(pid), "VM.events");
+            pb.redirectErrorStream(true);
+            Process proc = pb.start();
+            String output = new String(proc.getInputStream().readAllBytes());
+            proc.waitFor();
+            return output;
+        } catch (Exception e) {
+            return "Error: " + e.getMessage();
+        }
+    }
+}

--- a/argus-server/src/main/java/io/argus/server/command/impl/GcRunDiagnosticCommand.java
+++ b/argus-server/src/main/java/io/argus/server/command/impl/GcRunDiagnosticCommand.java
@@ -1,0 +1,31 @@
+package io.argus.server.command.impl;
+
+import io.argus.core.command.CommandContext;
+import io.argus.core.command.CommandGroup;
+import io.argus.core.command.DiagnosticCommand;
+
+public final class GcRunDiagnosticCommand implements DiagnosticCommand {
+
+    @Override public String id() { return "gcrun"; }
+    @Override public CommandGroup group() { return CommandGroup.MEMORY; }
+    @Override public String description() { return "Trigger System.gc()"; }
+    @Override public boolean supportsExternal() { return false; }
+
+    @Override
+    public String execute(CommandContext ctx) {
+        long before = Runtime.getRuntime().freeMemory();
+        System.gc();
+        long after = Runtime.getRuntime().freeMemory();
+        long freed = after - before;
+        return "System.gc() triggered.\nFree memory before: " + formatBytes(before)
+                + "\nFree memory after:  " + formatBytes(after)
+                + "\nFreed:              " + formatBytes(freed);
+    }
+
+    private static String formatBytes(long bytes) {
+        if (bytes < 1024) return bytes + " B";
+        if (bytes < 1024 * 1024) return String.format("%.1f KB", bytes / 1024.0);
+        if (bytes < 1024 * 1024 * 1024) return String.format("%.1f MB", bytes / (1024.0 * 1024));
+        return String.format("%.1f GB", bytes / (1024.0 * 1024 * 1024));
+    }
+}

--- a/argus-server/src/main/java/io/argus/server/command/impl/LoggerDiagnosticCommand.java
+++ b/argus-server/src/main/java/io/argus/server/command/impl/LoggerDiagnosticCommand.java
@@ -1,0 +1,43 @@
+package io.argus.server.command.impl;
+
+import io.argus.core.command.CommandContext;
+import io.argus.core.command.CommandGroup;
+import io.argus.core.command.DiagnosticCommand;
+
+import java.util.List;
+import java.util.logging.LogManager;
+import java.util.logging.LoggingMXBean;
+
+@SuppressWarnings("deprecation")
+public final class LoggerDiagnosticCommand implements DiagnosticCommand {
+
+    @Override public String id() { return "logger"; }
+    @Override public CommandGroup group() { return CommandGroup.PROFILING; }
+    @Override public String description() { return "View java.util.logging logger levels"; }
+    @Override public boolean supportsExternal() { return false; }
+
+    @Override
+    public String execute(CommandContext ctx) {
+        LoggingMXBean loggingMXBean = LogManager.getLoggingMXBean();
+        List<String> loggerNames = loggingMXBean.getLoggerNames();
+
+        StringBuilder sb = new StringBuilder();
+        sb.append(String.format("%-50s %s\n", "Logger", "Level"));
+        sb.append("─".repeat(65)).append('\n');
+
+        int count = 0;
+        for (String name : loggerNames.stream().sorted().toList()) {
+            String level = loggingMXBean.getLoggerLevel(name);
+            if (level == null || level.isEmpty()) continue;
+            sb.append(String.format("%-50s %s\n",
+                    name.isEmpty() ? "ROOT" : truncate(name, 48), level));
+            count++;
+        }
+        sb.append("\n").append(count).append(" logger(s) with explicit levels");
+        return sb.toString();
+    }
+
+    private static String truncate(String s, int max) {
+        return s.length() <= max ? s : "..." + s.substring(s.length() - max + 3);
+    }
+}

--- a/argus-server/src/main/java/io/argus/server/command/impl/ThreadDumpDiagnosticCommand.java
+++ b/argus-server/src/main/java/io/argus/server/command/impl/ThreadDumpDiagnosticCommand.java
@@ -1,0 +1,42 @@
+package io.argus.server.command.impl;
+
+import io.argus.core.command.CommandContext;
+import io.argus.core.command.CommandGroup;
+import io.argus.core.command.DiagnosticCommand;
+
+import java.lang.management.ManagementFactory;
+import java.lang.management.ThreadInfo;
+import java.lang.management.ThreadMXBean;
+
+public final class ThreadDumpDiagnosticCommand implements DiagnosticCommand {
+
+    @Override public String id() { return "threaddump"; }
+    @Override public CommandGroup group() { return CommandGroup.THREADS; }
+    @Override public String description() { return "Full thread dump with stack traces"; }
+    @Override public boolean supportsExternal() { return false; }
+
+    @Override
+    public String execute(CommandContext ctx) {
+        ThreadMXBean tmx = ManagementFactory.getThreadMXBean();
+        ThreadInfo[] threads = tmx.dumpAllThreads(true, true);
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("Thread count: ").append(tmx.getThreadCount());
+        sb.append(" (daemon: ").append(tmx.getDaemonThreadCount());
+        sb.append(", peak: ").append(tmx.getPeakThreadCount()).append(")\n\n");
+
+        for (ThreadInfo ti : threads) {
+            sb.append('"').append(ti.getThreadName()).append('"');
+            sb.append(" #").append(ti.getThreadId());
+            if (ti.isDaemon()) sb.append(" daemon");
+            sb.append(" prio=").append(ti.getPriority());
+            sb.append(" [").append(ti.getThreadState()).append("]\n");
+
+            for (StackTraceElement ste : ti.getStackTrace()) {
+                sb.append("    at ").append(ste).append('\n');
+            }
+            sb.append('\n');
+        }
+        return sb.toString();
+    }
+}

--- a/argus-server/src/main/resources/META-INF/services/io.argus.core.command.DiagnosticCommand
+++ b/argus-server/src/main/resources/META-INF/services/io.argus.core.command.DiagnosticCommand
@@ -1,0 +1,6 @@
+io.argus.server.command.impl.BuffersDiagnosticCommand
+io.argus.server.command.impl.GcRunDiagnosticCommand
+io.argus.server.command.impl.ThreadDumpDiagnosticCommand
+io.argus.server.command.impl.LoggerDiagnosticCommand
+io.argus.server.command.impl.EventsDiagnosticCommand
+io.argus.server.command.impl.CompilerQueueDiagnosticCommand


### PR DESCRIPTION
## Summary

Introduces a **ServiceLoader-based command SPI** that makes adding new commands to the dashboard console trivial: write 1 class + add 1 line to META-INF/services.

### Architecture

```
argus-core (shared SPI)
├── DiagnosticCommand      — interface: id(), group(), description(), execute(ctx)
├── CommandContext          — sealed: InProcess | External
├── CommandGroup            — enum: PROCESS, MEMORY, THREADS, RUNTIME, PROFILING, MONITORING
└── CommandRegistry         — ServiceLoader auto-discovery + lookup

argus-server (in-process implementations)
├── ServerContext           — InProcess implementation
└── impl/
    ├── BuffersDiagnosticCommand
    ├── GcRunDiagnosticCommand
    ├── ThreadDumpDiagnosticCommand
    ├── LoggerDiagnosticCommand
    ├── EventsDiagnosticCommand
    └── CompilerQueueDiagnosticCommand
```

### Key Design Decisions

- **Surface is simple, complexity is hidden**: `registry.execute("buffers", ctx)` — one line
- **Sealed CommandContext**: compile-time enforcement of InProcess vs External
- **Zero UI changes**: console.html already dynamically renders from `/api/commands`
- **Backward compatible**: existing 22 legacy commands untouched, SPI commands merged in
- **Future-proof**: new commands only need 1 class + 1 ServiceLoader registration line

### Result
Dashboard console: 22 → **28 commands** (6 new SPI commands immediately available)

## Test plan
- [ ] `./gradlew build -x test` passes
- [ ] Dashboard console shows 6 new commands (buffers, gcrun, threaddump, logger, events, compilerqueue)
- [ ] `/api/commands` returns all 28 commands
- [ ] `/api/exec?cmd=buffers` returns buffer pool stats
- [ ] `/api/exec?cmd=gcrun` triggers System.gc()