### PR TITLE
refactor: bridge CLI commands with core CommandGroup SPI

### DIFF
--- a/argus-cli/src/main/java/io/argus/cli/ArgusCli.java
+++ b/argus-cli/src/main/java/io/argus/cli/ArgusCli.java
@@ -194,45 +194,32 @@ public final class ArgusCli {
 
     private static void printUsage(Map<String, Command> commands, Messages messages) {
         System.out.println();
-        System.out.println("  \033[1m\033[36margus\033[0m - JVM Diagnostic Tool  \033[2mv" + VERSION + "\033[0m");
+        System.out.println("  \033[1m\033[36margus\033[0m - JVM Diagnostic Toolkit  \033[2mv" + VERSION + "\033[0m");
+        System.out.println("  " + commands.size() + " commands | Java 11+ CLI | Java 17+ Dashboard | Java 21+ Full");
         System.out.println();
         System.out.println("  \033[1mUsage:\033[0m argus <command> [<pid>] [options]");
         System.out.println();
-        System.out.println("  \033[1mCommands:\033[0m");
-        System.out.println("    init             Initialize CLI configuration");
-        System.out.println("    ps               List running JVM processes");
-        System.out.println("    histo  \033[2m<pid>\033[0m     Heap object histogram");
-        System.out.println("    threads \033[2m<pid>\033[0m    Thread dump summary");
-        System.out.println("    gc     \033[2m<pid>\033[0m     GC statistics");
-        System.out.println("    gcutil \033[2m<pid>\033[0m     GC generation utilization (like jstat)");
-        System.out.println("    heap     \033[2m<pid>\033[0m   Heap memory usage");
-        System.out.println("    sysprops \033[2m<pid>\033[0m   JVM system properties");
-        System.out.println("    vmflag   \033[2m<pid>\033[0m   Show or set VM flags");
-        System.out.println("    nmt      \033[2m<pid>\033[0m   Native memory tracking");
-        System.out.println("    classloader \033[2m<pid>\033[0m Class loader hierarchy");
-        System.out.println("    profile  \033[2m<pid>\033[0m   CPU/allocation/lock profiling");
-    System.out.println("    jfr      \033[2m<pid>\033[0m   Flight Recorder control");
-        System.out.println("    diff \033[2m<pid>\033[0m     Heap snapshot diff (leak detection)");
-        System.out.println("    report \033[2m<pid>\033[0m   Comprehensive diagnostic report");
-        System.out.println("    info     \033[2m<pid>\033[0m   JVM information");
-        System.out.println("    heapdump \033[2m<pid>\033[0m   Generate heap dump (with STW warning)");
-        System.out.println("    deadlock \033[2m<pid>\033[0m   Detect Java-level deadlocks");
-        System.out.println("    env      \033[2m<pid>\033[0m   JVM launch environment");
-        System.out.println("    compiler \033[2m<pid>\033[0m   JIT compiler and code cache stats");
-        System.out.println("    finalizer \033[2m<pid>\033[0m  Finalizer queue status");
-        System.out.println("    stringtable \033[2m<pid>\033[0m String table statistics");
-        System.out.println("    pool     \033[2m<pid>\033[0m   Thread pool analysis");
-        System.out.println("    gccause  \033[2m<pid>\033[0m   GC cause with utilization stats");
-        System.out.println("    metaspace \033[2m<pid>\033[0m  Detailed metaspace breakdown");
-        System.out.println("    dynlibs  \033[2m<pid>\033[0m   Loaded native libraries");
-        System.out.println("    vmset  \033[2m<pid> Flag=val\033[0m  Set VM flag at runtime");
-        System.out.println("    vmlog    \033[2m<pid>\033[0m   JVM unified logging control");
-        System.out.println("    jmx    \033[2m<pid> [cmd]\033[0m  JMX agent control");
-        System.out.println("    classstat \033[2m<pid>\033[0m  Class loading statistics");
-        System.out.println("    gcnew    \033[2m<pid>\033[0m   Young generation GC detail");
-        System.out.println("    symboltable \033[2m<pid>\033[0m Symbol table statistics");
-        System.out.println("    top              Real-time monitoring (agent required)");
-        System.out.println();
+
+        // Group commands by CommandGroup
+        var grouped = new java.util.LinkedHashMap<io.argus.core.command.CommandGroup,
+                java.util.List<Command>>();
+        for (io.argus.core.command.CommandGroup g : io.argus.core.command.CommandGroup.values()) {
+            grouped.put(g, new java.util.ArrayList<>());
+        }
+        for (Command cmd : commands.values()) {
+            grouped.computeIfAbsent(cmd.group(), k -> new java.util.ArrayList<>()).add(cmd);
+        }
+
+        for (var entry : grouped.entrySet()) {
+            if (entry.getValue().isEmpty()) continue;
+            System.out.println("  \033[1m" + entry.getKey().displayName() + ":\033[0m");
+            for (Command cmd : entry.getValue()) {
+                String desc = cmd.description(messages);
+                System.out.printf("    \033[36m%-18s\033[0m %s%n", cmd.name(), desc);
+            }
+            System.out.println();
+        }
+
         System.out.println("  \033[1mGlobal Options:\033[0m");
         System.out.println("    --source=auto|agent|jdk   Data source (default: auto)");
         System.out.println("    --no-color                Disable colors");
@@ -244,12 +231,12 @@ public final class ArgusCli {
         System.out.println("    --version, -v             Show version");
         System.out.println();
         System.out.println("  \033[1mExamples:\033[0m");
-        System.out.println("    \033[36margus ps\033[0m");
-        System.out.println("    \033[36margus histo 12345\033[0m");
-        System.out.println("    \033[36margus histo 12345 --top 50\033[0m");
-        System.out.println("    \033[36margus threads 12345 --source=agent\033[0m");
-        System.out.println("    \033[36margus gc 12345 --format=json\033[0m");
-        System.out.println("    \033[36margus top --port 9202\033[0m");
+        System.out.println("    \033[36margus ps\033[0m                          List JVM processes");
+        System.out.println("    \033[36margus info 12345\033[0m                  JVM info with CPU%");
+        System.out.println("    \033[36margus threaddump 12345\033[0m            Full thread dump");
+        System.out.println("    \033[36margus sc 12345 \"*.UserService\"\033[0m    Search loaded classes");
+        System.out.println("    \033[36margus jfranalyze recording.jfr\033[0m    Analyze JFR file");
+        System.out.println("    \033[36margus gc 12345 --format=json\033[0m      JSON output");
         System.out.println();
     }
 }

--- a/argus-cli/src/main/java/io/argus/cli/command/BuffersCommand.java
+++ b/argus-cli/src/main/java/io/argus/cli/command/BuffersCommand.java
@@ -8,6 +8,7 @@ import io.argus.cli.provider.BuffersProvider;
 import io.argus.cli.provider.ProviderRegistry;
 import io.argus.cli.render.AnsiStyle;
 import io.argus.cli.render.RichRenderer;
+import io.argus.core.command.CommandGroup;
 
 /**
  * Displays NIO buffer pool statistics (direct, mapped) for a given PID.
@@ -21,6 +22,8 @@ public final class BuffersCommand implements Command {
     public String name() {
         return "buffers";
     }
+
+    @Override public CommandGroup group() { return CommandGroup.MEMORY; }
 
     @Override
     public String description(Messages messages) {

--- a/argus-cli/src/main/java/io/argus/cli/command/ClassLoaderCommand.java
+++ b/argus-cli/src/main/java/io/argus/cli/command/ClassLoaderCommand.java
@@ -8,6 +8,7 @@ import io.argus.cli.provider.ClassLoaderProvider;
 import io.argus.cli.provider.ProviderRegistry;
 import io.argus.cli.render.AnsiStyle;
 import io.argus.cli.render.RichRenderer;
+import io.argus.core.command.CommandGroup;
 
 /**
  * Shows the classloader hierarchy and total loaded class count.
@@ -20,6 +21,8 @@ public final class ClassLoaderCommand implements Command {
     public String name() {
         return "classloader";
     }
+
+    @Override public CommandGroup group() { return CommandGroup.RUNTIME; }
 
     @Override
     public String description(Messages messages) {

--- a/argus-cli/src/main/java/io/argus/cli/command/ClassStatCommand.java
+++ b/argus-cli/src/main/java/io/argus/cli/command/ClassStatCommand.java
@@ -7,6 +7,7 @@ import io.argus.cli.provider.ClassStatProvider;
 import io.argus.cli.provider.ProviderRegistry;
 import io.argus.cli.render.AnsiStyle;
 import io.argus.cli.render.RichRenderer;
+import io.argus.core.command.CommandGroup;
 
 /**
  * Shows class loading statistics: loaded/unloaded counts, bytes, and time.
@@ -17,6 +18,8 @@ public final class ClassStatCommand implements Command {
 
     @Override
     public String name() { return "classstat"; }
+
+    @Override public CommandGroup group() { return CommandGroup.RUNTIME; }
 
     @Override
     public String description(Messages messages) {

--- a/argus-cli/src/main/java/io/argus/cli/command/Command.java
+++ b/argus-cli/src/main/java/io/argus/cli/command/Command.java
@@ -3,9 +3,13 @@ package io.argus.cli.command;
 import io.argus.cli.config.CliConfig;
 import io.argus.cli.config.Messages;
 import io.argus.cli.provider.ProviderRegistry;
+import io.argus.core.command.CommandGroup;
 
 /**
  * Base interface for all Argus CLI commands.
+ *
+ * <p>Each command declares its {@link CommandGroup} for categorized help output
+ * and shared metadata with the server's SPI-based command system.
  */
 public interface Command {
 
@@ -15,17 +19,18 @@ public interface Command {
     String name();
 
     /**
+     * Logical group for categorized help output. Shared with server SPI via
+     * {@link io.argus.core.command.CommandGroup}.
+     */
+    default CommandGroup group() { return CommandGroup.MONITORING; }
+
+    /**
      * Short description shown in the help/usage output.
      */
     String description(Messages messages);
 
     /**
      * Executes the command with the provided args, config, registry, and messages.
-     *
-     * @param args     command-specific arguments (everything after the command name)
-     * @param config   resolved CLI configuration (may include flag overrides)
-     * @param registry provider registry for obtaining data providers
-     * @param messages i18n message bundle
      */
     void execute(String[] args, CliConfig config, ProviderRegistry registry, Messages messages);
 }

--- a/argus-cli/src/main/java/io/argus/cli/command/CompilerCommand.java
+++ b/argus-cli/src/main/java/io/argus/cli/command/CompilerCommand.java
@@ -7,6 +7,7 @@ import io.argus.cli.provider.CompilerProvider;
 import io.argus.cli.provider.ProviderRegistry;
 import io.argus.cli.render.AnsiStyle;
 import io.argus.cli.render.RichRenderer;
+import io.argus.core.command.CommandGroup;
 
 /**
  * Shows JIT compiler statistics and code cache usage.
@@ -18,6 +19,8 @@ public final class CompilerCommand implements Command {
 
     @Override
     public String name() { return "compiler"; }
+
+    @Override public CommandGroup group() { return CommandGroup.RUNTIME; }
 
     @Override
     public String description(Messages messages) {

--- a/argus-cli/src/main/java/io/argus/cli/command/CompilerQueueCommand.java
+++ b/argus-cli/src/main/java/io/argus/cli/command/CompilerQueueCommand.java
@@ -6,6 +6,7 @@ import io.argus.cli.provider.ProviderRegistry;
 import io.argus.cli.provider.jdk.JcmdExecutor;
 import io.argus.cli.render.AnsiStyle;
 import io.argus.cli.render.RichRenderer;
+import io.argus.core.command.CommandGroup;
 
 /**
  * Shows the current JIT compilation queue.
@@ -19,6 +20,8 @@ public final class CompilerQueueCommand implements Command {
     public String name() {
         return "compilerqueue";
     }
+
+    @Override public CommandGroup group() { return CommandGroup.RUNTIME; }
 
     @Override
     public String description(Messages messages) {

--- a/argus-cli/src/main/java/io/argus/cli/command/DeadlockCommand.java
+++ b/argus-cli/src/main/java/io/argus/cli/command/DeadlockCommand.java
@@ -7,6 +7,7 @@ import io.argus.cli.provider.DeadlockProvider;
 import io.argus.cli.provider.ProviderRegistry;
 import io.argus.cli.render.AnsiStyle;
 import io.argus.cli.render.RichRenderer;
+import io.argus.core.command.CommandGroup;
 
 /**
  * Detects and displays Java-level deadlocks for a given PID.
@@ -19,6 +20,8 @@ public final class DeadlockCommand implements Command {
     public String name() {
         return "deadlock";
     }
+
+    @Override public CommandGroup group() { return CommandGroup.THREADS; }
 
     @Override
     public String description(Messages messages) {

--- a/argus-cli/src/main/java/io/argus/cli/command/DiffCommand.java
+++ b/argus-cli/src/main/java/io/argus/cli/command/DiffCommand.java
@@ -7,6 +7,7 @@ import io.argus.cli.provider.HistoProvider;
 import io.argus.cli.provider.ProviderRegistry;
 import io.argus.cli.render.AnsiStyle;
 import io.argus.cli.render.RichRenderer;
+import io.argus.core.command.CommandGroup;
 
 import java.util.ArrayList;
 import java.util.Comparator;
@@ -32,6 +33,8 @@ public final class DiffCommand implements Command {
     public String name() {
         return "diff";
     }
+
+    @Override public CommandGroup group() { return CommandGroup.MEMORY; }
 
     @Override
     public String description(Messages messages) {

--- a/argus-cli/src/main/java/io/argus/cli/command/DynLibsCommand.java
+++ b/argus-cli/src/main/java/io/argus/cli/command/DynLibsCommand.java
@@ -7,6 +7,7 @@ import io.argus.cli.provider.DynLibsProvider;
 import io.argus.cli.provider.ProviderRegistry;
 import io.argus.cli.render.AnsiStyle;
 import io.argus.cli.render.RichRenderer;
+import io.argus.core.command.CommandGroup;
 
 /**
  * Shows native libraries loaded in the JVM.
@@ -17,6 +18,8 @@ public final class DynLibsCommand implements Command {
 
     @Override
     public String name() { return "dynlibs"; }
+
+    @Override public CommandGroup group() { return CommandGroup.RUNTIME; }
 
     @Override
     public String description(Messages messages) {

--- a/argus-cli/src/main/java/io/argus/cli/command/EnvCommand.java
+++ b/argus-cli/src/main/java/io/argus/cli/command/EnvCommand.java
@@ -7,6 +7,7 @@ import io.argus.cli.provider.EnvProvider;
 import io.argus.cli.provider.ProviderRegistry;
 import io.argus.cli.render.AnsiStyle;
 import io.argus.cli.render.RichRenderer;
+import io.argus.core.command.CommandGroup;
 
 /**
  * Shows JVM launch environment: command line, java home, classpath, VM args.
@@ -17,6 +18,8 @@ public final class EnvCommand implements Command {
 
     @Override
     public String name() { return "env"; }
+
+    @Override public CommandGroup group() { return CommandGroup.PROCESS; }
 
     @Override
     public String description(Messages messages) {

--- a/argus-cli/src/main/java/io/argus/cli/command/EventsCommand.java
+++ b/argus-cli/src/main/java/io/argus/cli/command/EventsCommand.java
@@ -6,6 +6,7 @@ import io.argus.cli.provider.ProviderRegistry;
 import io.argus.cli.provider.jdk.JcmdExecutor;
 import io.argus.cli.render.AnsiStyle;
 import io.argus.cli.render.RichRenderer;
+import io.argus.core.command.CommandGroup;
 
 /**
  * Displays VM internal event log (safepoints, deoptimizations, GC phases).
@@ -19,6 +20,8 @@ public final class EventsCommand implements Command {
     public String name() {
         return "events";
     }
+
+    @Override public CommandGroup group() { return CommandGroup.PROFILING; }
 
     @Override
     public String description(Messages messages) {

--- a/argus-cli/src/main/java/io/argus/cli/command/FinalizerCommand.java
+++ b/argus-cli/src/main/java/io/argus/cli/command/FinalizerCommand.java
@@ -7,6 +7,7 @@ import io.argus.cli.provider.FinalizerProvider;
 import io.argus.cli.provider.ProviderRegistry;
 import io.argus.cli.render.AnsiStyle;
 import io.argus.cli.render.RichRenderer;
+import io.argus.core.command.CommandGroup;
 
 /**
  * Shows finalizer queue status.
@@ -17,6 +18,8 @@ public final class FinalizerCommand implements Command {
 
     @Override
     public String name() { return "finalizer"; }
+
+    @Override public CommandGroup group() { return CommandGroup.MEMORY; }
 
     @Override
     public String description(Messages messages) {

--- a/argus-cli/src/main/java/io/argus/cli/command/GcCauseCommand.java
+++ b/argus-cli/src/main/java/io/argus/cli/command/GcCauseCommand.java
@@ -7,6 +7,7 @@ import io.argus.cli.provider.GcCauseProvider;
 import io.argus.cli.provider.ProviderRegistry;
 import io.argus.cli.render.AnsiStyle;
 import io.argus.cli.render.RichRenderer;
+import io.argus.core.command.CommandGroup;
 
 /**
  * Shows GC cause information alongside gcutil stats.
@@ -18,6 +19,8 @@ public final class GcCauseCommand implements Command {
 
     @Override
     public String name() { return "gccause"; }
+
+    @Override public CommandGroup group() { return CommandGroup.MEMORY; }
 
     @Override
     public String description(Messages messages) {

--- a/argus-cli/src/main/java/io/argus/cli/command/GcCommand.java
+++ b/argus-cli/src/main/java/io/argus/cli/command/GcCommand.java
@@ -6,6 +6,7 @@ import io.argus.cli.model.GcResult;
 import io.argus.cli.provider.GcProvider;
 import io.argus.cli.provider.ProviderRegistry;
 import io.argus.cli.render.RichRenderer;
+import io.argus.core.command.CommandGroup;
 
 /**
  * Shows GC statistics for a given PID.
@@ -19,6 +20,8 @@ public final class GcCommand implements Command {
     public String name() {
         return "gc";
     }
+
+    @Override public CommandGroup group() { return CommandGroup.MEMORY; }
 
     @Override
     public String description(Messages messages) {

--- a/argus-cli/src/main/java/io/argus/cli/command/GcNewCommand.java
+++ b/argus-cli/src/main/java/io/argus/cli/command/GcNewCommand.java
@@ -7,6 +7,7 @@ import io.argus.cli.provider.GcNewProvider;
 import io.argus.cli.provider.ProviderRegistry;
 import io.argus.cli.render.AnsiStyle;
 import io.argus.cli.render.RichRenderer;
+import io.argus.core.command.CommandGroup;
 
 /**
  * Shows young generation GC detail: survivor spaces, tenuring threshold, eden.
@@ -18,6 +19,8 @@ public final class GcNewCommand implements Command {
 
     @Override
     public String name() { return "gcnew"; }
+
+    @Override public CommandGroup group() { return CommandGroup.MEMORY; }
 
     @Override
     public String description(Messages messages) {

--- a/argus-cli/src/main/java/io/argus/cli/command/GcRunCommand.java
+++ b/argus-cli/src/main/java/io/argus/cli/command/GcRunCommand.java
@@ -6,6 +6,7 @@ import io.argus.cli.provider.ProviderRegistry;
 import io.argus.cli.provider.jdk.JcmdExecutor;
 import io.argus.cli.render.AnsiStyle;
 import io.argus.cli.render.RichRenderer;
+import io.argus.core.command.CommandGroup;
 
 /**
  * Triggers System.gc() on the target JVM via jcmd GC.run.
@@ -19,6 +20,8 @@ public final class GcRunCommand implements Command {
     public String name() {
         return "gcrun";
     }
+
+    @Override public CommandGroup group() { return CommandGroup.MEMORY; }
 
     @Override
     public String description(Messages messages) {

--- a/argus-cli/src/main/java/io/argus/cli/command/GcUtilCommand.java
+++ b/argus-cli/src/main/java/io/argus/cli/command/GcUtilCommand.java
@@ -7,6 +7,7 @@ import io.argus.cli.provider.GcUtilProvider;
 import io.argus.cli.provider.ProviderRegistry;
 import io.argus.cli.render.AnsiStyle;
 import io.argus.cli.render.RichRenderer;
+import io.argus.core.command.CommandGroup;
 
 import java.io.IOException;
 
@@ -22,6 +23,8 @@ public final class GcUtilCommand implements Command {
     public String name() {
         return "gcutil";
     }
+
+    @Override public CommandGroup group() { return CommandGroup.MEMORY; }
 
     @Override
     public String description(Messages messages) {

--- a/argus-cli/src/main/java/io/argus/cli/command/HeapCommand.java
+++ b/argus-cli/src/main/java/io/argus/cli/command/HeapCommand.java
@@ -9,6 +9,7 @@ import io.argus.cli.provider.HeapProvider;
 import io.argus.cli.provider.ProviderRegistry;
 import io.argus.cli.render.AnsiStyle;
 import io.argus.cli.render.RichRenderer;
+import io.argus.core.command.CommandGroup;
 
 import java.util.Map;
 
@@ -24,6 +25,8 @@ public final class HeapCommand implements Command {
     public String name() {
         return "heap";
     }
+
+    @Override public CommandGroup group() { return CommandGroup.MEMORY; }
 
     @Override
     public String description(Messages messages) {

--- a/argus-cli/src/main/java/io/argus/cli/command/HeapDumpCommand.java
+++ b/argus-cli/src/main/java/io/argus/cli/command/HeapDumpCommand.java
@@ -7,6 +7,7 @@ import io.argus.cli.provider.HeapDumpProvider;
 import io.argus.cli.provider.ProviderRegistry;
 import io.argus.cli.render.AnsiStyle;
 import io.argus.cli.render.RichRenderer;
+import io.argus.core.command.CommandGroup;
 
 import java.io.BufferedReader;
 import java.io.InputStreamReader;
@@ -25,6 +26,8 @@ public final class HeapDumpCommand implements Command {
     public String name() {
         return "heapdump";
     }
+
+    @Override public CommandGroup group() { return CommandGroup.MEMORY; }
 
     @Override
     public String description(Messages messages) {

--- a/argus-cli/src/main/java/io/argus/cli/command/HistoCommand.java
+++ b/argus-cli/src/main/java/io/argus/cli/command/HistoCommand.java
@@ -6,6 +6,7 @@ import io.argus.cli.model.HistoResult;
 import io.argus.cli.provider.HistoProvider;
 import io.argus.cli.provider.ProviderRegistry;
 import io.argus.cli.render.RichRenderer;
+import io.argus.core.command.CommandGroup;
 
 /**
  * Shows heap object histogram for a given PID.
@@ -19,6 +20,8 @@ public final class HistoCommand implements Command {
     public String name() {
         return "histo";
     }
+
+    @Override public CommandGroup group() { return CommandGroup.MEMORY; }
 
     @Override
     public String description(Messages messages) {

--- a/argus-cli/src/main/java/io/argus/cli/command/InfoCommand.java
+++ b/argus-cli/src/main/java/io/argus/cli/command/InfoCommand.java
@@ -7,6 +7,7 @@ import io.argus.cli.provider.InfoProvider;
 import io.argus.cli.provider.ProviderRegistry;
 import io.argus.cli.render.AnsiStyle;
 import io.argus.cli.render.RichRenderer;
+import io.argus.core.command.CommandGroup;
 
 import java.util.Map;
 
@@ -21,6 +22,8 @@ public final class InfoCommand implements Command {
     public String name() {
         return "info";
     }
+
+    @Override public CommandGroup group() { return CommandGroup.PROCESS; }
 
     @Override
     public String description(Messages messages) {

--- a/argus-cli/src/main/java/io/argus/cli/command/InitCommand.java
+++ b/argus-cli/src/main/java/io/argus/cli/command/InitCommand.java
@@ -3,6 +3,7 @@ package io.argus.cli.command;
 import io.argus.cli.config.CliConfig;
 import io.argus.cli.config.Messages;
 import io.argus.cli.provider.ProviderRegistry;
+import io.argus.core.command.CommandGroup;
 
 import java.io.IOException;
 import java.nio.file.Path;
@@ -20,6 +21,8 @@ public final class InitCommand implements Command {
     public String name() {
         return "init";
     }
+
+    @Override public CommandGroup group() { return CommandGroup.MONITORING; }
 
     @Override
     public String description(Messages messages) {

--- a/argus-cli/src/main/java/io/argus/cli/command/JfrAnalyzeCommand.java
+++ b/argus-cli/src/main/java/io/argus/cli/command/JfrAnalyzeCommand.java
@@ -10,6 +10,7 @@ import io.argus.cli.model.JfrAnalyzeResult.HotMethod;
 import io.argus.cli.provider.ProviderRegistry;
 import io.argus.cli.render.AnsiStyle;
 import io.argus.cli.render.RichRenderer;
+import io.argus.core.command.CommandGroup;
 
 import java.io.IOException;
 import java.nio.file.Files;
@@ -28,6 +29,8 @@ public final class JfrAnalyzeCommand implements Command {
     public String name() {
         return "jfranalyze";
     }
+
+    @Override public CommandGroup group() { return CommandGroup.PROFILING; }
 
     @Override
     public String description(Messages messages) {

--- a/argus-cli/src/main/java/io/argus/cli/command/JfrCommand.java
+++ b/argus-cli/src/main/java/io/argus/cli/command/JfrCommand.java
@@ -7,6 +7,7 @@ import io.argus.cli.provider.JfrProvider;
 import io.argus.cli.provider.ProviderRegistry;
 import io.argus.cli.render.AnsiStyle;
 import io.argus.cli.render.RichRenderer;
+import io.argus.core.command.CommandGroup;
 
 /**
  * Controls JFR Flight Recorder on a target JVM process.
@@ -20,6 +21,8 @@ public final class JfrCommand implements Command {
     public String name() {
         return "jfr";
     }
+
+    @Override public CommandGroup group() { return CommandGroup.PROFILING; }
 
     @Override
     public String description(Messages messages) {

--- a/argus-cli/src/main/java/io/argus/cli/command/JmxCommand.java
+++ b/argus-cli/src/main/java/io/argus/cli/command/JmxCommand.java
@@ -6,6 +6,7 @@ import io.argus.cli.provider.ProviderRegistry;
 import io.argus.cli.provider.jdk.JcmdExecutor;
 import io.argus.cli.render.AnsiStyle;
 import io.argus.cli.render.RichRenderer;
+import io.argus.core.command.CommandGroup;
 
 /**
  * Controls JMX Management Agent via jcmd ManagementAgent commands.
@@ -17,6 +18,8 @@ public final class JmxCommand implements Command {
 
     @Override
     public String name() { return "jmx"; }
+
+    @Override public CommandGroup group() { return CommandGroup.PROCESS; }
 
     @Override
     public String description(Messages messages) {

--- a/argus-cli/src/main/java/io/argus/cli/command/LoggerCommand.java
+++ b/argus-cli/src/main/java/io/argus/cli/command/LoggerCommand.java
@@ -8,6 +8,7 @@ import io.argus.cli.provider.LoggerProvider;
 import io.argus.cli.provider.ProviderRegistry;
 import io.argus.cli.render.AnsiStyle;
 import io.argus.cli.render.RichRenderer;
+import io.argus.core.command.CommandGroup;
 
 /**
  * View and change log levels at runtime.
@@ -26,6 +27,8 @@ public final class LoggerCommand implements Command {
     public String name() {
         return "logger";
     }
+
+    @Override public CommandGroup group() { return CommandGroup.PROFILING; }
 
     @Override
     public String description(Messages messages) {

--- a/argus-cli/src/main/java/io/argus/cli/command/MetaspaceCommand.java
+++ b/argus-cli/src/main/java/io/argus/cli/command/MetaspaceCommand.java
@@ -7,6 +7,7 @@ import io.argus.cli.provider.MetaspaceProvider;
 import io.argus.cli.provider.ProviderRegistry;
 import io.argus.cli.render.AnsiStyle;
 import io.argus.cli.render.RichRenderer;
+import io.argus.core.command.CommandGroup;
 
 /**
  * Shows detailed metaspace statistics.
@@ -18,6 +19,8 @@ public final class MetaspaceCommand implements Command {
 
     @Override
     public String name() { return "metaspace"; }
+
+    @Override public CommandGroup group() { return CommandGroup.MEMORY; }
 
     @Override
     public String description(Messages messages) {

--- a/argus-cli/src/main/java/io/argus/cli/command/NmtCommand.java
+++ b/argus-cli/src/main/java/io/argus/cli/command/NmtCommand.java
@@ -7,6 +7,7 @@ import io.argus.cli.provider.NmtProvider;
 import io.argus.cli.provider.ProviderRegistry;
 import io.argus.cli.render.AnsiStyle;
 import io.argus.cli.render.RichRenderer;
+import io.argus.core.command.CommandGroup;
 
 import java.util.List;
 
@@ -22,6 +23,8 @@ public final class NmtCommand implements Command {
     public String name() {
         return "nmt";
     }
+
+    @Override public CommandGroup group() { return CommandGroup.MEMORY; }
 
     @Override
     public String description(Messages messages) {

--- a/argus-cli/src/main/java/io/argus/cli/command/PoolCommand.java
+++ b/argus-cli/src/main/java/io/argus/cli/command/PoolCommand.java
@@ -7,6 +7,7 @@ import io.argus.cli.provider.PoolProvider;
 import io.argus.cli.provider.ProviderRegistry;
 import io.argus.cli.render.AnsiStyle;
 import io.argus.cli.render.RichRenderer;
+import io.argus.core.command.CommandGroup;
 
 import java.util.Map;
 
@@ -20,6 +21,8 @@ public final class PoolCommand implements Command {
 
     @Override
     public String name() { return "pool"; }
+
+    @Override public CommandGroup group() { return CommandGroup.THREADS; }
 
     @Override
     public String description(Messages messages) {

--- a/argus-cli/src/main/java/io/argus/cli/command/ProfileCommand.java
+++ b/argus-cli/src/main/java/io/argus/cli/command/ProfileCommand.java
@@ -8,6 +8,7 @@ import io.argus.cli.provider.ProfileProvider;
 import io.argus.cli.provider.ProviderRegistry;
 import io.argus.cli.render.AnsiStyle;
 import io.argus.cli.render.RichRenderer;
+import io.argus.core.command.CommandGroup;
 
 import java.util.List;
 
@@ -24,6 +25,8 @@ public final class ProfileCommand implements Command {
     public String name() {
         return "profile";
     }
+
+    @Override public CommandGroup group() { return CommandGroup.PROFILING; }
 
     @Override
     public String description(Messages messages) {

--- a/argus-cli/src/main/java/io/argus/cli/command/PsCommand.java
+++ b/argus-cli/src/main/java/io/argus/cli/command/PsCommand.java
@@ -6,6 +6,7 @@ import io.argus.cli.model.ProcessInfo;
 import io.argus.cli.provider.ProcessProvider;
 import io.argus.cli.provider.ProviderRegistry;
 import io.argus.cli.render.RichRenderer;
+import io.argus.core.command.CommandGroup;
 
 import java.util.List;
 
@@ -20,6 +21,8 @@ public final class PsCommand implements Command {
     public String name() {
         return "ps";
     }
+
+    @Override public CommandGroup group() { return CommandGroup.PROCESS; }
 
     @Override
     public String description(Messages messages) {

--- a/argus-cli/src/main/java/io/argus/cli/command/ReportCommand.java
+++ b/argus-cli/src/main/java/io/argus/cli/command/ReportCommand.java
@@ -17,6 +17,7 @@ import io.argus.cli.provider.ProviderRegistry;
 import io.argus.cli.provider.ThreadProvider;
 import io.argus.cli.render.AnsiStyle;
 import io.argus.cli.render.RichRenderer;
+import io.argus.core.command.CommandGroup;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -35,6 +36,8 @@ public final class ReportCommand implements Command {
     public String name() {
         return "report";
     }
+
+    @Override public CommandGroup group() { return CommandGroup.PROFILING; }
 
     @Override
     public String description(Messages messages) {

--- a/argus-cli/src/main/java/io/argus/cli/command/SearchClassCommand.java
+++ b/argus-cli/src/main/java/io/argus/cli/command/SearchClassCommand.java
@@ -8,6 +8,7 @@ import io.argus.cli.provider.ProviderRegistry;
 import io.argus.cli.provider.SearchClassProvider;
 import io.argus.cli.render.AnsiStyle;
 import io.argus.cli.render.RichRenderer;
+import io.argus.core.command.CommandGroup;
 
 /**
  * Search loaded classes by pattern. Useful for diagnosing classpath conflicts
@@ -27,6 +28,8 @@ public final class SearchClassCommand implements Command {
     public String name() {
         return "sc";
     }
+
+    @Override public CommandGroup group() { return CommandGroup.RUNTIME; }
 
     @Override
     public String description(Messages messages) {

--- a/argus-cli/src/main/java/io/argus/cli/command/StringTableCommand.java
+++ b/argus-cli/src/main/java/io/argus/cli/command/StringTableCommand.java
@@ -7,6 +7,7 @@ import io.argus.cli.provider.ProviderRegistry;
 import io.argus.cli.provider.StringTableProvider;
 import io.argus.cli.render.AnsiStyle;
 import io.argus.cli.render.RichRenderer;
+import io.argus.core.command.CommandGroup;
 
 /**
  * Shows interned string table statistics.
@@ -17,6 +18,8 @@ public final class StringTableCommand implements Command {
 
     @Override
     public String name() { return "stringtable"; }
+
+    @Override public CommandGroup group() { return CommandGroup.RUNTIME; }
 
     @Override
     public String description(Messages messages) {

--- a/argus-cli/src/main/java/io/argus/cli/command/SymbolTableCommand.java
+++ b/argus-cli/src/main/java/io/argus/cli/command/SymbolTableCommand.java
@@ -7,6 +7,7 @@ import io.argus.cli.provider.ProviderRegistry;
 import io.argus.cli.provider.SymbolTableProvider;
 import io.argus.cli.render.AnsiStyle;
 import io.argus.cli.render.RichRenderer;
+import io.argus.core.command.CommandGroup;
 
 /**
  * Shows symbol table statistics.
@@ -17,6 +18,8 @@ public final class SymbolTableCommand implements Command {
 
     @Override
     public String name() { return "symboltable"; }
+
+    @Override public CommandGroup group() { return CommandGroup.RUNTIME; }
 
     @Override
     public String description(Messages messages) {

--- a/argus-cli/src/main/java/io/argus/cli/command/SysPropsCommand.java
+++ b/argus-cli/src/main/java/io/argus/cli/command/SysPropsCommand.java
@@ -7,6 +7,7 @@ import io.argus.cli.provider.ProviderRegistry;
 import io.argus.cli.provider.SysPropsProvider;
 import io.argus.cli.render.AnsiStyle;
 import io.argus.cli.render.RichRenderer;
+import io.argus.core.command.CommandGroup;
 
 import java.util.Map;
 
@@ -22,6 +23,8 @@ public final class SysPropsCommand implements Command {
     public String name() {
         return "sysprops";
     }
+
+    @Override public CommandGroup group() { return CommandGroup.PROCESS; }
 
     @Override
     public String description(Messages messages) {

--- a/argus-cli/src/main/java/io/argus/cli/command/ThreadDumpCommand.java
+++ b/argus-cli/src/main/java/io/argus/cli/command/ThreadDumpCommand.java
@@ -8,6 +8,7 @@ import io.argus.cli.provider.ProviderRegistry;
 import io.argus.cli.provider.ThreadDumpProvider;
 import io.argus.cli.render.AnsiStyle;
 import io.argus.cli.render.RichRenderer;
+import io.argus.core.command.CommandGroup;
 
 import java.util.Map;
 import java.util.TreeMap;
@@ -25,6 +26,8 @@ public final class ThreadDumpCommand implements Command {
     public String name() {
         return "threaddump";
     }
+
+    @Override public CommandGroup group() { return CommandGroup.THREADS; }
 
     @Override
     public String description(Messages messages) {

--- a/argus-cli/src/main/java/io/argus/cli/command/ThreadsCommand.java
+++ b/argus-cli/src/main/java/io/argus/cli/command/ThreadsCommand.java
@@ -7,6 +7,7 @@ import io.argus.cli.provider.ProviderRegistry;
 import io.argus.cli.provider.ThreadProvider;
 import io.argus.cli.render.AnsiStyle;
 import io.argus.cli.render.RichRenderer;
+import io.argus.core.command.CommandGroup;
 
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -23,6 +24,8 @@ public final class ThreadsCommand implements Command {
     public String name() {
         return "threads";
     }
+
+    @Override public CommandGroup group() { return CommandGroup.THREADS; }
 
     @Override
     public String description(Messages messages) {

--- a/argus-cli/src/main/java/io/argus/cli/command/TopCommand.java
+++ b/argus-cli/src/main/java/io/argus/cli/command/TopCommand.java
@@ -7,6 +7,7 @@ import io.argus.cli.config.CliConfig;
 import io.argus.cli.config.Messages;
 import io.argus.cli.provider.ProviderRegistry;
 
+import io.argus.core.command.CommandGroup;
 import java.io.IOException;
 
 /**
@@ -22,6 +23,8 @@ public final class TopCommand implements Command {
     public String name() {
         return "top";
     }
+
+    @Override public CommandGroup group() { return CommandGroup.MONITORING; }
 
     @Override
     public String description(Messages messages) {

--- a/argus-cli/src/main/java/io/argus/cli/command/VmFlagCommand.java
+++ b/argus-cli/src/main/java/io/argus/cli/command/VmFlagCommand.java
@@ -7,6 +7,7 @@ import io.argus.cli.provider.ProviderRegistry;
 import io.argus.cli.provider.VmFlagProvider;
 import io.argus.cli.render.AnsiStyle;
 import io.argus.cli.render.RichRenderer;
+import io.argus.core.command.CommandGroup;
 
 import java.util.List;
 
@@ -25,6 +26,8 @@ public final class VmFlagCommand implements Command {
     public String name() {
         return "vmflag";
     }
+
+    @Override public CommandGroup group() { return CommandGroup.PROCESS; }
 
     @Override
     public String description(Messages messages) {

--- a/argus-cli/src/main/java/io/argus/cli/command/VmLogCommand.java
+++ b/argus-cli/src/main/java/io/argus/cli/command/VmLogCommand.java
@@ -6,6 +6,7 @@ import io.argus.cli.provider.ProviderRegistry;
 import io.argus.cli.provider.jdk.JcmdExecutor;
 import io.argus.cli.render.AnsiStyle;
 import io.argus.cli.render.RichRenderer;
+import io.argus.core.command.CommandGroup;
 
 /**
  * Controls JVM unified logging via jcmd VM.log.
@@ -16,6 +17,8 @@ public final class VmLogCommand implements Command {
 
     @Override
     public String name() { return "vmlog"; }
+
+    @Override public CommandGroup group() { return CommandGroup.PROCESS; }
 
     @Override
     public String description(Messages messages) {

--- a/argus-cli/src/main/java/io/argus/cli/command/VmSetCommand.java
+++ b/argus-cli/src/main/java/io/argus/cli/command/VmSetCommand.java
@@ -6,6 +6,7 @@ import io.argus.cli.provider.ProviderRegistry;
 import io.argus.cli.provider.jdk.JcmdExecutor;
 import io.argus.cli.render.AnsiStyle;
 import io.argus.cli.render.RichRenderer;
+import io.argus.core.command.CommandGroup;
 
 import java.io.Console;
 
@@ -18,6 +19,8 @@ public final class VmSetCommand implements Command {
 
     @Override
     public String name() { return "vmset"; }
+
+    @Override public CommandGroup group() { return CommandGroup.PROCESS; }
 
     @Override
     public String description(Messages messages) {


### PR DESCRIPTION
## Summary
- CLI `Command` interface gains `group()` method from core `CommandGroup` enum
- All 41 command classes override with correct category (PROCESS/MEMORY/THREADS/RUNTIME/PROFILING/MONITORING)
- `argus --help` now shows categorized output instead of flat list
- CLI and server share the same `CommandGroup` enum — single source of truth for categories

## Test plan
- [ ] `./gradlew build -x test` passes
- [ ] `argus --help` shows commands grouped by category