### PR TITLE
fix: code review fixes (deprecated API, resource leak)

### DIFF
--- a/argus-cli/src/main/java/io/argus/cli/command/FlameCommand.java
+++ b/argus-cli/src/main/java/io/argus/cli/command/FlameCommand.java
@@ -130,7 +130,9 @@ public final class FlameCommand implements Command {
                 } else {
                     pb = new ProcessBuilder("xdg-open", outputPath);
                 }
-                pb.start();
+                pb.redirectErrorStream(true);
+                Process proc = pb.start();
+                proc.getInputStream().close(); // prevent resource leak
                 System.out.println("  " + AnsiStyle.style(useColor, AnsiStyle.CYAN)
                         + "\u2192 Opened in browser"
                         + AnsiStyle.style(useColor, AnsiStyle.RESET));

--- a/argus-cli/src/main/java/io/argus/cli/command/WatchCommand.java
+++ b/argus-cli/src/main/java/io/argus/cli/command/WatchCommand.java
@@ -246,11 +246,11 @@ public final class WatchCommand implements Command {
 
     private static void setRawMode(boolean raw) {
         try {
-            if (raw) {
-                Runtime.getRuntime().exec(new String[]{"/bin/sh", "-c", "stty raw -echo < /dev/tty"}).waitFor();
-            } else {
-                Runtime.getRuntime().exec(new String[]{"/bin/sh", "-c", "stty cooked echo < /dev/tty"}).waitFor();
-            }
+            String sttyCmd = raw ? "stty raw -echo < /dev/tty" : "stty cooked echo < /dev/tty";
+            new ProcessBuilder("/bin/sh", "-c", sttyCmd)
+                    .inheritIO()
+                    .start()
+                    .waitFor();
         } catch (Exception ignored) {}
     }
 }


### PR DESCRIPTION
## Summary
- WatchCommand: `Runtime.exec()` → `ProcessBuilder` (deprecated in Java 18+)
- FlameCommand: close browser process InputStream to prevent resource leak