### PR TITLE
docs: sync to 47 commands + killer features in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 Two independent tools in one package:
 
-- **`argus` CLI** — 42 diagnostic commands that work on any running JVM via `jcmd`/`jstat`
+- **`argus` CLI** — 47 diagnostic commands that work on any running JVM via `jcmd`/`jstat`
 - **Argus Agent** — Real-time web dashboard with JFR streaming, flame graphs, and metric export
 
 ```bash
@@ -73,8 +73,13 @@ Diagnose any running JVM process directly from the terminal. No agent, no instru
 | `argus logger <pid>` | View and change log levels at runtime |
 | `argus events <pid>` | VM internal event log (safepoints, deopt, GC) |
 | `argus report <pid>` | Comprehensive diagnostic report |
+| `argus doctor` | One-click JVM health diagnosis with tuning recommendations |
+| `argus gclog <file>` | GC log analysis with pause distribution and tuning (GCEasy alternative) |
+| `argus flame <pid>` | One-shot flame graph — profiles, generates HTML, opens browser |
+| `argus suggest` | JVM flag optimization based on workload analysis |
 | **Monitoring** | |
 | `argus top` | Real-time monitoring (agent required) |
+| `argus watch` | Real-time terminal dashboard (htop for JVM) |
 | `argus init` | First-time setup (language selection) |
 
 ### `argus report` — Comprehensive Diagnostic
@@ -227,7 +232,7 @@ $ argus --lang=ko report 39113
 --version, -v             Show version
 ```
 
-> See [CLI Command Reference](docs/cli-commands.md) for all 42 commands with full output examples.
+> See [CLI Command Reference](docs/cli-commands.md) for all 47 commands with full output examples.
 
 ---
 
@@ -368,7 +373,7 @@ Argus adapts its capabilities based on the target JVM version at runtime:
 
 | Feature | Java 11+ | Java 17+ | Java 21+ |
 |---------|:--------:|:--------:|:--------:|
-| CLI (42 commands) | ✅ | ✅ | ✅ |
+| CLI (47 commands) | ✅ | ✅ | ✅ |
 | Dashboard & Web UI | — | ✅ | ✅ |
 | GC Analysis | CLI only | ✅ MXBean | ✅ JFR |
 | CPU Monitoring | CLI only | ✅ MXBean | ✅ JFR |
@@ -426,7 +431,7 @@ rm -rf ~/.argus
 | **argus-agent** | Java agent with JFR streaming engine |
 | **argus-server** | Netty HTTP/WS server, 10 analyzers, Prometheus + OTLP |
 | **argus-frontend** | Static dashboard with Chart.js and d3-flamegraph |
-| **argus-cli** | 42 diagnostic commands, auto source detection, i18n |
+| **argus-cli** | 47 diagnostic commands, auto source detection, i18n |
 | **argus-micrometer** | Micrometer MeterBinder exposing ~25 JVM metrics |
 | **argus-spring-boot-starter** | Spring Boot 3.2+ auto-configuration for Argus agent |
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,7 +6,7 @@ Welcome to the Project Argus documentation.
 
 1. [Getting Started](getting-started.md) - Installation and quick start guide
 2. [Usage Guide](usage.md) - CLI and Agent dashboard usage
-3. [CLI Command Reference](cli-commands.md) - All 42 commands with usage and output examples
+3. [CLI Command Reference](cli-commands.md) - All 47 commands with usage and output examples
 4. [Configuration](configuration.md) - Configuration options and tuning
 5. [Architecture](architecture.md) - System architecture and design
 6. [Troubleshooting](troubleshooting.md) - Common issues and solutions

--- a/docs/cli-commands.md
+++ b/docs/cli-commands.md
@@ -1,6 +1,6 @@
 # Argus CLI Command Reference
 
-Complete reference for all 42 Argus CLI commands with usage examples and actual output.
+Complete reference for all 47 Argus CLI commands with usage examples and actual output.
 
 ## Global Options
 

--- a/site/index.html
+++ b/site/index.html
@@ -629,14 +629,14 @@
                         <span class="badge green">Java 11+ CLI</span>
                         <span class="badge green">Java 17+ Dashboard</span>
                         <span class="badge green">Java 21+ Full Features</span>
-                        <span class="badge">42 Commands</span>
+                        <span class="badge">47 Commands</span>
                         <span class="badge">Zero Dependencies</span>
                     </div>
                 </div>
 
                 <p>Argus gives you two tools for JVM diagnostics:</p>
                 <ul>
-                    <li><strong>Argus CLI</strong> — 42 diagnostic commands that work on any running JVM. No agent, no restart, no configuration. Point at a PID and get answers in seconds.</li>
+                    <li><strong>Argus CLI</strong> — 47 diagnostic commands that work on any running JVM. No agent, no restart, no configuration. Point at a PID and get answers in seconds.</li>
                     <li><strong>Argus Agent</strong> — Attach as a Java agent and get a live web dashboard with GC timelines, CPU graphs, heap usage, flame graphs, and thread analysis, all streaming in real time.</li>
                 </ul>
 
@@ -659,7 +659,7 @@
                 <div class="feature-grid">
                     <div class="feature-card">
                         <h4>Instant CLI Diagnostics</h4>
-                        <p>42 commands that work on any running JVM. No agent, no restart, no configuration. Just point at a PID and get answers in seconds.</p>
+                        <p>47 commands that work on any running JVM. No agent, no restart, no configuration. Just point at a PID and get answers in seconds.</p>
                     </div>
                     <div class="feature-card">
                         <h4>Real-time Dashboard</h4>
@@ -725,7 +725,7 @@ argus histo 12345</code></pre>
                 <p class="video-caption">Argus CLI in action — diagnosing a running JVM process</p>
 
                 <span class="section-anchor" id="command-reference"></span>
-                <h3>All 42 Commands</h3>
+                <h3>All 47 Commands</h3>
 
                 <p>Every command follows the same pattern: <code>argus &lt;command&gt; &lt;pid&gt;</code>. All commands support <code>--format=json</code> for scripting and <code>--source=auto|agent|jdk</code> to control the data source.</p>
 
@@ -912,7 +912,7 @@ argus_allocation_rate_bytes_per_second   # Allocation pressure</code></pre>
                             <tr><th>Feature</th><th>Java 11+</th><th>Java 17+</th><th>Java 21+</th></tr>
                         </thead>
                         <tbody>
-                            <tr><td>CLI (42 commands)</td><td>Yes</td><td>Yes</td><td>Yes</td></tr>
+                            <tr><td>CLI (47 commands)</td><td>Yes</td><td>Yes</td><td>Yes</td></tr>
                             <tr><td>Dashboard &amp; Web UI</td><td>—</td><td>Yes (MXBean)</td><td>Yes (JFR)</td></tr>
                             <tr><td>GC / CPU / Memory</td><td>CLI only</td><td>Yes</td><td>Yes</td></tr>
                             <tr><td>Allocation Tracking</td><td>—</td><td>—</td><td>Yes</td></tr>
@@ -947,7 +947,7 @@ argus_allocation_rate_bytes_per_second   # Allocation pressure</code></pre>
                             <tr><td><code>argus-agent</code></td><td>Java agent entry point, JFR streaming engine, MXBean polling engine</td></tr>
                             <tr><td><code>argus-server</code></td><td>Netty HTTP/WebSocket server, 10 analyzers, metrics export</td></tr>
                             <tr><td><code>argus-frontend</code></td><td>Dashboard web UI (vanilla JS, Chart.js, D3 flame graph)</td></tr>
-                            <tr><td><code>argus-cli</code></td><td>42 diagnostic commands using jcmd/jstat</td></tr>
+                            <tr><td><code>argus-cli</code></td><td>47 diagnostic commands using jcmd/jstat</td></tr>
                             <tr><td><code>argus-micrometer</code></td><td>Framework-agnostic Micrometer MeterBinder</td></tr>
                             <tr><td><code>argus-spring-boot-starter</code></td><td>Spring Boot auto-configuration</td></tr>
                         </tbody>


### PR DESCRIPTION
Update all command counts 42→47, add doctor/gclog/flame/suggest/watch to README table