### PR TITLE
feat: dashboard file-input modal system for WRITE commands (#113)

### DIFF
--- a/argus-frontend/src/main/resources/public/css/style.css
+++ b/argus-frontend/src/main/resources/public/css/style.css
@@ -1402,3 +1402,156 @@ footer {
 canvas {
     max-width: 100%;
 }
+
+/* ----------------------------------------------------------------
+   FILE ANALYSIS PANEL
+---------------------------------------------------------------- */
+.analysis-panel { margin-top: var(--section-gap); }
+.analysis-commands {
+    display: flex;
+    gap: 0.75rem;
+    flex-wrap: wrap;
+    padding: 0.75rem 0;
+}
+.analysis-cmd-btn {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.5rem 1.25rem;
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    background: var(--bg);
+    cursor: pointer;
+    font-family: var(--font-sans);
+    font-size: 0.875rem;
+    color: var(--ink);
+    transition: border-color 0.15s, background 0.15s;
+}
+.analysis-cmd-btn:hover {
+    border-color: var(--blue);
+    background: var(--off-white);
+}
+.cmd-icon {
+    font-size: 0.75rem;
+    font-weight: 700;
+    color: var(--blue);
+    font-family: var(--font-mono);
+}
+
+/* ----------------------------------------------------------------
+   ANALYSIS MODAL EXTENSIONS
+---------------------------------------------------------------- */
+.modal-wide { max-width: 820px; }
+.modal-actions {
+    display: flex;
+    gap: 0.5rem;
+    justify-content: flex-end;
+    margin-top: 1rem;
+    padding-top: 1rem;
+    border-top: 1px solid var(--border-light);
+}
+.form-group { margin-bottom: 1rem; }
+.form-group label {
+    display: block;
+    margin-bottom: 0.25rem;
+    font-size: 0.875rem;
+    font-weight: 600;
+    color: var(--ink);
+}
+.form-group input[type=file] {
+    width: 100%;
+    padding: 0.5rem;
+    border: 1px dashed var(--border);
+    border-radius: 4px;
+    font-size: 0.875rem;
+    background: var(--off-white);
+}
+.file-status {
+    font-size: 0.8125rem;
+    margin-top: 0.25rem;
+    display: block;
+    min-height: 1.2em;
+}
+.file-status.ok  { color: var(--green); }
+.file-status.error { color: var(--red); }
+.validation-msg {
+    color: var(--red);
+    font-size: 0.875rem;
+    min-height: 1.2em;
+    margin-top: 0.25rem;
+}
+.progress-bar {
+    height: 4px;
+    background: var(--border);
+    border-radius: 2px;
+    overflow: hidden;
+    margin: 0.75rem 0 0.25rem;
+}
+.progress-fill {
+    width: 30%;
+    height: 100%;
+    background: var(--blue);
+    animation: analysis-progress 1.5s ease-in-out infinite;
+}
+@keyframes analysis-progress {
+    0%   { width: 15%; margin-left: 0; }
+    50%  { width: 60%; margin-left: 20%; }
+    100% { width: 15%; margin-left: 85%; }
+}
+.progress-text {
+    font-size: 0.8125rem;
+    color: var(--ink-3);
+}
+
+/* ----------------------------------------------------------------
+   ANALYSIS RESULT RENDERING
+---------------------------------------------------------------- */
+.result-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 1rem;
+}
+.result-section { margin-bottom: 0.5rem; }
+.result-section.full-width { grid-column: 1 / -1; }
+.result-section h4 {
+    font-size: 0.8125rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    color: var(--ink-3);
+    margin-bottom: 0.5rem;
+}
+.result-table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 0.875rem;
+}
+.result-table td,
+.result-table th {
+    padding: 0.3rem 0.5rem;
+    border-bottom: 1px solid var(--border-light);
+    text-align: left;
+}
+.result-table th {
+    font-weight: 700;
+    color: var(--ink-2);
+}
+.good { color: var(--green); font-weight: 600; }
+.warn { color: var(--amber); font-weight: 600; }
+.bad  { color: var(--red);   font-weight: 600; }
+.rec-list { list-style: none; padding: 0; }
+.rec-list li {
+    padding: 0.5rem 0.75rem;
+    margin: 0.25rem 0;
+    border-radius: 4px;
+    font-size: 0.875rem;
+    line-height: 1.5;
+}
+.rec-list code {
+    font-family: var(--font-mono);
+    font-size: 0.8125rem;
+    color: var(--ink-2);
+}
+.rec-critical { background: rgba(198,40,40,0.07); border-left: 3px solid var(--red); }
+.rec-warning  { background: rgba(249,168,37,0.09); border-left: 3px solid var(--amber); }
+.rec-info     { background: rgba(21,101,192,0.07); border-left: 3px solid var(--blue); }

--- a/argus-frontend/src/main/resources/public/index.html
+++ b/argus-frontend/src/main/resources/public/index.html
@@ -486,6 +486,26 @@
 
         </div><!-- end #vt-tab -->
 
+        <!-- ================================================================
+             FILE ANALYSIS COMMANDS
+        ================================================================ -->
+        <section class="content-section analysis-panel">
+            <div class="section-header">
+                <h3>File Analysis</h3>
+                <p class="section-desc">Upload GC log files for offline analysis and comparison.</p>
+            </div>
+            <div class="analysis-commands">
+                <button class="analysis-cmd-btn" data-cmd="gclog" title="Analyze GC log file">
+                    <span class="cmd-icon">GC</span>
+                    <span class="cmd-name">GC Log Analysis</span>
+                </button>
+                <button class="analysis-cmd-btn" data-cmd="gclogdiff" title="Compare two GC log files">
+                    <span class="cmd-icon">Diff</span>
+                    <span class="cmd-name">GC Log Diff</span>
+                </button>
+            </div>
+        </section>
+
     </main>
 
     <footer>
@@ -707,6 +727,47 @@
         });
     });
     </script>
+    <!-- ================================================================
+         FILE ANALYSIS MODAL
+    ================================================================ -->
+    <div id="analysis-modal" class="modal hidden">
+        <div class="modal-backdrop"></div>
+        <div class="modal-content">
+            <div class="modal-header">
+                <h2 id="analysis-modal-title">GC Log Analysis</h2>
+                <button class="modal-close">&times;</button>
+            </div>
+            <div class="modal-body">
+                <div id="analysis-modal-form"></div>
+                <div id="analysis-modal-validation" class="validation-msg"></div>
+                <div id="analysis-progress" class="hidden">
+                    <div class="progress-bar"><div class="progress-fill"></div></div>
+                    <span class="progress-text">Uploading...</span>
+                </div>
+                <div class="modal-actions">
+                    <button id="analysis-cancel-btn" class="btn">Cancel</button>
+                    <button id="analysis-submit-btn" class="btn btn-primary" disabled>Analyze</button>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <!-- ================================================================
+         ANALYSIS RESULT PANEL
+    ================================================================ -->
+    <div id="analysis-result" class="modal hidden">
+        <div class="modal-backdrop"></div>
+        <div class="modal-content modal-wide">
+            <div class="modal-header">
+                <h2 id="result-title">Analysis Result</h2>
+                <button class="modal-close">&times;</button>
+            </div>
+            <div class="modal-body">
+                <div id="result-body"></div>
+            </div>
+        </div>
+    </div>
+
     <script type="module" src="/js/app.js"></script>
 </body>
 </html>

--- a/argus-frontend/src/main/resources/public/js/analysis.js
+++ b/argus-frontend/src/main/resources/public/js/analysis.js
@@ -1,0 +1,241 @@
+/**
+ * File Analysis Modal System
+ * Handles file input, validation, upload, and result rendering.
+ */
+
+const COMMANDS = {
+    gclog: {
+        title: 'GC Log Analysis',
+        fields: [{ name: 'file1', label: 'GC Log File', type: 'file', accept: '.log,.gz,.txt', required: true }],
+        endpoint: '/api/analyze/gclog'
+    },
+    gclogdiff: {
+        title: 'GC Log Comparison',
+        fields: [
+            { name: 'file1', label: 'Before (file 1)', type: 'file', accept: '.log,.gz,.txt', required: true },
+            { name: 'file2', label: 'After (file 2)', type: 'file', accept: '.log,.gz,.txt', required: true }
+        ],
+        endpoint: '/api/analyze/gclogdiff'
+    }
+};
+
+export function initAnalysis() {
+    document.querySelectorAll('.analysis-cmd-btn').forEach(btn => {
+        btn.addEventListener('click', () => openModal(btn.dataset.cmd));
+    });
+
+    document.querySelector('#analysis-modal .modal-backdrop').addEventListener('click', closeModal);
+    document.querySelector('#analysis-modal .modal-close').addEventListener('click', closeModal);
+    document.getElementById('analysis-cancel-btn').addEventListener('click', closeModal);
+    document.getElementById('analysis-submit-btn').addEventListener('click', submitAnalysis);
+
+    document.querySelector('#analysis-result .modal-backdrop').addEventListener('click', closeResult);
+    document.querySelector('#analysis-result .modal-close').addEventListener('click', closeResult);
+}
+
+function openModal(cmdName) {
+    const cmd = COMMANDS[cmdName];
+    if (!cmd) return;
+
+    document.getElementById('analysis-modal-title').textContent = cmd.title;
+    const form = document.getElementById('analysis-modal-form');
+    form.innerHTML = '';
+    form.dataset.cmd = cmdName;
+
+    cmd.fields.forEach(field => {
+        const div = document.createElement('div');
+        div.className = 'form-group';
+        div.innerHTML = `
+            <label for="analysis-${field.name}">${field.label}</label>
+            <input type="file" id="analysis-${field.name}" name="${field.name}"
+                   accept="${field.accept}" ${field.required ? 'required' : ''}>
+            <span class="file-status" id="status-${field.name}"></span>
+        `;
+        form.appendChild(div);
+    });
+
+    form.querySelectorAll('input[type=file]').forEach(input => {
+        input.addEventListener('change', validateForm);
+    });
+
+    document.getElementById('analysis-submit-btn').disabled = true;
+    document.getElementById('analysis-modal-validation').textContent = '';
+    document.getElementById('analysis-progress').classList.add('hidden');
+    document.getElementById('analysis-modal').classList.remove('hidden');
+}
+
+function closeModal() {
+    document.getElementById('analysis-modal').classList.add('hidden');
+}
+
+function closeResult() {
+    document.getElementById('analysis-result').classList.add('hidden');
+}
+
+function validateForm() {
+    const form = document.getElementById('analysis-modal-form');
+    const cmdName = form.dataset.cmd;
+    const cmd = COMMANDS[cmdName];
+
+    let valid = true;
+    cmd.fields.forEach(field => {
+        const input = document.getElementById(`analysis-${field.name}`);
+        const status = document.getElementById(`status-${field.name}`);
+        if (field.required && (!input.files || input.files.length === 0)) {
+            valid = false;
+            status.textContent = '';
+            status.className = 'file-status';
+        } else if (input.files && input.files.length > 0) {
+            const file = input.files[0];
+            const sizeMB = (file.size / (1024 * 1024)).toFixed(1);
+            if (file.size > 200 * 1024 * 1024) {
+                status.textContent = `File too large: ${sizeMB}MB (max 200MB)`;
+                status.className = 'file-status error';
+                valid = false;
+            } else {
+                status.textContent = `${file.name} (${sizeMB}MB)`;
+                status.className = 'file-status ok';
+            }
+        }
+    });
+
+    document.getElementById('analysis-submit-btn').disabled = !valid;
+    if (valid) document.getElementById('analysis-modal-validation').textContent = '';
+}
+
+async function submitAnalysis() {
+    const form = document.getElementById('analysis-modal-form');
+    const cmdName = form.dataset.cmd;
+    const cmd = COMMANDS[cmdName];
+
+    const formData = new FormData();
+    cmd.fields.forEach(field => {
+        const input = document.getElementById(`analysis-${field.name}`);
+        if (input.files && input.files.length > 0) {
+            formData.append(field.name, input.files[0]);
+        }
+    });
+
+    const progress = document.getElementById('analysis-progress');
+    progress.classList.remove('hidden');
+    document.getElementById('analysis-submit-btn').disabled = true;
+
+    try {
+        const resp = await fetch(cmd.endpoint, { method: 'POST', body: formData });
+        if (!resp.ok) {
+            const text = await resp.text().catch(() => resp.statusText);
+            throw new Error(`Server error ${resp.status}: ${text}`);
+        }
+        const result = await resp.json();
+        closeModal();
+        showResult(cmdName, result);
+    } catch (e) {
+        document.getElementById('analysis-modal-validation').textContent = 'Error: ' + e.message;
+    } finally {
+        progress.classList.add('hidden');
+        document.getElementById('analysis-submit-btn').disabled = false;
+    }
+}
+
+function showResult(cmdName, data) {
+    document.getElementById('result-title').textContent = COMMANDS[cmdName].title + ' — Results';
+    const body = document.getElementById('result-body');
+
+    if (cmdName === 'gclog') {
+        body.innerHTML = renderGcLogResult(data);
+    } else if (cmdName === 'gclogdiff') {
+        body.innerHTML = renderGcDiffResult(data);
+    } else {
+        body.innerHTML = `<pre>${JSON.stringify(data, null, 2)}</pre>`;
+    }
+
+    document.getElementById('analysis-result').classList.remove('hidden');
+}
+
+function renderGcLogResult(d) {
+    const tp = parseFloat(d.throughputPercent);
+    const tpClass = tp >= 95 ? 'good' : tp >= 90 ? 'warn' : 'bad';
+    const pauses = d.pauses || {};
+
+    let causesHtml = '';
+    if (d.causes && Object.keys(d.causes).length > 0) {
+        const rows = Object.entries(d.causes).map(([cause, stats]) =>
+            `<tr><td>${escapeHtml(cause)}</td><td>${stats.count}</td><td>${stats.avgMs}ms</td><td>${stats.maxMs}ms</td></tr>`
+        ).join('');
+        causesHtml = `
+        <div class="result-section">
+            <h4>GC Causes</h4>
+            <table class="result-table">
+                <tr><th>Cause</th><th>Count</th><th>Avg</th><th>Max</th></tr>
+                ${rows}
+            </table>
+        </div>`;
+    }
+
+    let recsHtml = '';
+    if (d.recommendations && d.recommendations.length > 0) {
+        const items = d.recommendations.map(r =>
+            `<li class="rec-${r.severity.toLowerCase()}">
+                <strong>[${escapeHtml(r.severity)}]</strong> ${escapeHtml(r.problem)}
+                ${r.flag ? `<br><code>${escapeHtml(r.flag)}</code>` : ''}
+            </li>`
+        ).join('');
+        recsHtml = `
+        <div class="result-section full-width">
+            <h4>Recommendations</h4>
+            <ul class="rec-list">${items}</ul>
+        </div>`;
+    }
+
+    return `<div class="result-grid">
+        <div class="result-section">
+            <h4>Summary</h4>
+            <table class="result-table">
+                <tr><td>Total Events</td><td>${d.totalEvents} (${d.pauseEvents} pauses, ${d.fullGcEvents} full)</td></tr>
+                <tr><td>Duration</td><td>${d.durationSec}s</td></tr>
+                <tr><td>Throughput</td><td class="${tpClass}">${d.throughputPercent}%</td></tr>
+            </table>
+        </div>
+        <div class="result-section">
+            <h4>Pause Distribution</h4>
+            <table class="result-table">
+                <tr><td>p50</td><td>${pauses.p50Ms}ms</td></tr>
+                <tr><td>p95</td><td>${pauses.p95Ms}ms</td></tr>
+                <tr><td>p99</td><td>${pauses.p99Ms}ms</td></tr>
+                <tr><td>Max</td><td>${pauses.maxMs}ms</td></tr>
+                <tr><td>Avg</td><td>${pauses.avgMs}ms</td></tr>
+            </table>
+        </div>
+        ${causesHtml}
+        ${recsHtml}
+    </div>`;
+}
+
+function renderGcDiffResult(d) {
+    const metrics = d.metrics || {};
+    const rows = Object.entries(metrics).map(([k, v]) => {
+        const before = Array.isArray(v) ? v[0] : '-';
+        const after = Array.isArray(v) ? v[1] : '-';
+        return `<tr><td>${escapeHtml(k)}</td><td>${before}</td><td>${after}</td></tr>`;
+    }).join('');
+
+    const statusClass = d.regression ? 'bad' : 'good';
+    const statusText = d.regression ? 'Regression detected' : 'No regression detected';
+
+    return `<div class="result-section full-width">
+        <p class="${statusClass}" style="margin-bottom:1rem;font-weight:600;">${statusText}</p>
+        <table class="result-table">
+            <tr><th>Metric</th><th>Before</th><th>After</th></tr>
+            ${rows}
+        </table>
+    </div>`;
+}
+
+function escapeHtml(str) {
+    if (str == null) return '';
+    return String(str)
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;');
+}

--- a/argus-frontend/src/main/resources/public/js/app.js
+++ b/argus-frontend/src/main/resources/public/js/app.js
@@ -25,6 +25,7 @@ import {
 } from './state.js';
 import { formatNumber, formatTimestamp, escapeHtml, formatDuration } from './utils.js';
 import { initFilters, addEvent as addEventToFilter, clearEvents as clearFilterEvents } from './filter.js';
+import { initAnalysis } from './analysis.js';
 
 // DOM elements
 const elements = {
@@ -175,6 +176,9 @@ const maxEvents = 500;
 
 // Initialize modules
 function init() {
+    // Initialize file analysis modal
+    initAnalysis();
+
     // Initialize thread view
     initThreadView(elements);
 

--- a/argus-server/build.gradle.kts
+++ b/argus-server/build.gradle.kts
@@ -5,6 +5,7 @@ plugins {
 
 dependencies {
     implementation(project(":argus-core"))
+    implementation(project(":argus-cli"))
     implementation(project(":argus-frontend"))
     implementation("io.netty:netty-all:${project.findProperty("nettyVersion")}")
     testImplementation("org.junit.jupiter:junit-jupiter:${project.findProperty("junitVersion")}")

--- a/argus-server/src/main/java/io/argus/server/handler/ArgusChannelHandler.java
+++ b/argus-server/src/main/java/io/argus/server/handler/ArgusChannelHandler.java
@@ -1,7 +1,15 @@
 package io.argus.server.handler;
 
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
 import java.util.Map;
 
+import io.argus.cli.gclog.GcEvent;
+import io.argus.cli.gclog.GcLogAnalysis;
+import io.argus.cli.gclog.GcLogAnalyzer;
+import io.argus.cli.gclog.GcLogParser;
 import io.argus.core.config.AgentConfig;
 import io.argus.server.command.ServerCommandExecutor;
 import io.argus.server.analysis.AllocationAnalyzer;
@@ -26,6 +34,12 @@ import io.netty.channel.SimpleChannelInboundHandler;
 import io.netty.channel.group.ChannelGroup;
 import io.netty.handler.codec.http.FullHttpRequest;
 import io.netty.handler.codec.http.HttpHeaderNames;
+import io.netty.handler.codec.http.HttpMethod;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import io.netty.handler.codec.http.multipart.DefaultHttpDataFactory;
+import io.netty.handler.codec.http.multipart.FileUpload;
+import io.netty.handler.codec.http.multipart.HttpPostRequestDecoder;
+import io.netty.handler.codec.http.multipart.InterfaceHttpData;
 import io.netty.handler.codec.http.websocketx.*;
 
 /**
@@ -168,6 +182,8 @@ public final class ArgusChannelHandler extends SimpleChannelInboundHandler<Objec
                     HttpResponseHelper.sendJson(ctx, req, "{\"processInfo\":\"" + escapeJson(info) + "\"}");
                 })
                 .exact("/api/commands", (ctx, req, uri) -> handleCommandsList(ctx, req))
+                .exact("/api/analyze/gclog", (ctx, req, uri) -> handleGcLogUpload(ctx, req))
+                .exact("/api/analyze/gclogdiff", (ctx, req, uri) -> handleGcLogDiffUpload(ctx, req))
                 // Prefix routes
                 .prefix("/threads/", this::handleThreadRoute)
                 .prefix("/flame-graph", (ctx, req, uri) -> handleFlameGraph(ctx, req, uri))
@@ -1204,6 +1220,173 @@ public final class ArgusChannelHandler extends SimpleChannelInboundHandler<Objec
         }
         sb.append("]}");
         HttpResponseHelper.sendJson(ctx, request, sb.toString());
+    }
+
+    private void handleGcLogUpload(ChannelHandlerContext ctx, FullHttpRequest request) {
+        if (!HttpMethod.POST.equals(request.method())) {
+            HttpResponseHelper.send(ctx, request, HttpResponseStatus.METHOD_NOT_ALLOWED,
+                    "{\"error\":\"POST required\"}", "application/json");
+            return;
+        }
+        Path tempFile = null;
+        try {
+            HttpPostRequestDecoder decoder = new HttpPostRequestDecoder(
+                    new DefaultHttpDataFactory(false), request);
+            FileUpload upload = null;
+            for (InterfaceHttpData data : decoder.getBodyHttpDatas()) {
+                if (data instanceof FileUpload fu && "file1".equals(fu.getName())) {
+                    upload = fu;
+                    break;
+                }
+            }
+            if (upload == null || !upload.isCompleted()) {
+                HttpResponseHelper.send(ctx, request, HttpResponseStatus.BAD_REQUEST,
+                        "{\"error\":\"Missing file1 field\"}", "application/json");
+                decoder.destroy();
+                return;
+            }
+            tempFile = Files.createTempFile("argus-gclog-", ".log");
+            upload.renameTo(tempFile.toFile());
+            decoder.destroy();
+
+            List<GcEvent> events = GcLogParser.parse(tempFile);
+            GcLogAnalysis a = GcLogAnalyzer.analyze(events);
+            String json = gcLogAnalysisToJson(a, tempFile.getFileName().toString());
+            HttpResponseHelper.sendJson(ctx, request, json);
+        } catch (IOException e) {
+            LOG.log(System.Logger.Level.WARNING, "GC log upload error: {0}", e.getMessage());
+            HttpResponseHelper.send(ctx, request, HttpResponseStatus.INTERNAL_SERVER_ERROR,
+                    "{\"error\":\"" + escapeJson(e.getMessage()) + "\"}", "application/json");
+        } finally {
+            if (tempFile != null) {
+                try { Files.deleteIfExists(tempFile); } catch (IOException ignored) {}
+            }
+        }
+    }
+
+    private void handleGcLogDiffUpload(ChannelHandlerContext ctx, FullHttpRequest request) {
+        if (!HttpMethod.POST.equals(request.method())) {
+            HttpResponseHelper.send(ctx, request, HttpResponseStatus.METHOD_NOT_ALLOWED,
+                    "{\"error\":\"POST required\"}", "application/json");
+            return;
+        }
+        Path tempFile1 = null;
+        Path tempFile2 = null;
+        try {
+            HttpPostRequestDecoder decoder = new HttpPostRequestDecoder(
+                    new DefaultHttpDataFactory(false), request);
+            FileUpload upload1 = null;
+            FileUpload upload2 = null;
+            for (InterfaceHttpData data : decoder.getBodyHttpDatas()) {
+                if (data instanceof FileUpload fu) {
+                    if ("file1".equals(fu.getName())) upload1 = fu;
+                    else if ("file2".equals(fu.getName())) upload2 = fu;
+                }
+            }
+            if (upload1 == null || !upload1.isCompleted()
+                    || upload2 == null || !upload2.isCompleted()) {
+                HttpResponseHelper.send(ctx, request, HttpResponseStatus.BAD_REQUEST,
+                        "{\"error\":\"Both file1 and file2 are required\"}", "application/json");
+                decoder.destroy();
+                return;
+            }
+            tempFile1 = Files.createTempFile("argus-gclog1-", ".log");
+            tempFile2 = Files.createTempFile("argus-gclog2-", ".log");
+            upload1.renameTo(tempFile1.toFile());
+            upload2.renameTo(tempFile2.toFile());
+            String name1 = upload1.getFilename() != null ? upload1.getFilename() : "file1";
+            String name2 = upload2.getFilename() != null ? upload2.getFilename() : "file2";
+            decoder.destroy();
+
+            GcLogAnalysis a = GcLogAnalyzer.analyze(GcLogParser.parse(tempFile1));
+            GcLogAnalysis b = GcLogAnalyzer.analyze(GcLogParser.parse(tempFile2));
+            String json = gcLogDiffToJson(a, b, name1, name2);
+            HttpResponseHelper.sendJson(ctx, request, json);
+        } catch (IOException e) {
+            LOG.log(System.Logger.Level.WARNING, "GC log diff upload error: {0}", e.getMessage());
+            HttpResponseHelper.send(ctx, request, HttpResponseStatus.INTERNAL_SERVER_ERROR,
+                    "{\"error\":\"" + escapeJson(e.getMessage()) + "\"}", "application/json");
+        } finally {
+            if (tempFile1 != null) { try { Files.deleteIfExists(tempFile1); } catch (IOException ignored) {} }
+            if (tempFile2 != null) { try { Files.deleteIfExists(tempFile2); } catch (IOException ignored) {} }
+        }
+    }
+
+    private String gcLogAnalysisToJson(GcLogAnalysis a, String filename) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("{\"file\":\"").append(escapeJson(filename)).append('"');
+        sb.append(",\"totalEvents\":").append(a.totalEvents());
+        sb.append(",\"pauseEvents\":").append(a.pauseEvents());
+        sb.append(",\"fullGcEvents\":").append(a.fullGcEvents());
+        sb.append(",\"durationSec\":").append(String.format("%.1f", a.durationSec()));
+        sb.append(",\"throughputPercent\":").append(String.format("%.1f", a.throughputPercent()));
+        sb.append(",\"pauses\":{");
+        sb.append("\"totalMs\":").append(a.totalPauseMs());
+        sb.append(",\"maxMs\":").append(a.maxPauseMs());
+        sb.append(",\"p50Ms\":").append(a.p50PauseMs());
+        sb.append(",\"p95Ms\":").append(a.p95PauseMs());
+        sb.append(",\"p99Ms\":").append(a.p99PauseMs());
+        sb.append(",\"avgMs\":").append(a.avgPauseMs()).append('}');
+        sb.append(",\"causes\":{");
+        boolean first = true;
+        for (var entry : a.causeBreakdown().entrySet()) {
+            var cs = entry.getValue();
+            if (!first) sb.append(',');
+            sb.append('"').append(escapeJson(cs.cause())).append("\":{");
+            sb.append("\"count\":").append(cs.count());
+            sb.append(",\"avgMs\":").append(cs.avgMs());
+            sb.append(",\"maxMs\":").append(cs.maxMs()).append('}');
+            first = false;
+        }
+        sb.append('}');
+        sb.append(",\"recommendations\":[");
+        for (int i = 0; i < a.recommendations().size(); i++) {
+            var rec = a.recommendations().get(i);
+            if (i > 0) sb.append(',');
+            sb.append("{\"severity\":\"").append(escapeJson(rec.severity())).append('"');
+            sb.append(",\"problem\":\"").append(escapeJson(rec.problem())).append('"');
+            sb.append(",\"flag\":\"").append(escapeJson(rec.flag())).append("\"}");
+        }
+        sb.append("]}");
+        return sb.toString();
+    }
+
+    private String gcLogDiffToJson(GcLogAnalysis a, GcLogAnalysis b, String name1, String name2) {
+        boolean regression =
+                regressionExceeds(a.p99PauseMs(), b.p99PauseMs(), false, 10)
+                || regressionExceeds(a.maxPauseMs(), b.maxPauseMs(), false, 10)
+                || regressionExceeds(a.throughputPercent(), b.throughputPercent(), true, 10);
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("{\"file1\":\"").append(escapeJson(name1)).append('"');
+        sb.append(",\"file2\":\"").append(escapeJson(name2)).append('"');
+        sb.append(",\"regression\":").append(regression);
+        sb.append(",\"metrics\":{");
+        sb.append("\"throughputPct\":[").append(String.format("%.1f", a.throughputPercent()))
+                .append(',').append(String.format("%.1f", b.throughputPercent())).append(']');
+        sb.append(",\"p50PauseMs\":[").append(a.p50PauseMs()).append(',').append(b.p50PauseMs()).append(']');
+        sb.append(",\"p95PauseMs\":[").append(a.p95PauseMs()).append(',').append(b.p95PauseMs()).append(']');
+        sb.append(",\"p99PauseMs\":[").append(a.p99PauseMs()).append(',').append(b.p99PauseMs()).append(']');
+        sb.append(",\"maxPauseMs\":[").append(a.maxPauseMs()).append(',').append(b.maxPauseMs()).append(']');
+        sb.append(",\"avgPauseMs\":[").append(a.avgPauseMs()).append(',').append(b.avgPauseMs()).append(']');
+        sb.append(",\"fullGcEvents\":[").append(a.fullGcEvents()).append(',').append(b.fullGcEvents()).append(']');
+        sb.append(",\"totalPauseMs\":[").append(a.totalPauseMs()).append(',').append(b.totalPauseMs()).append(']');
+        sb.append("}}");
+        return sb.toString();
+    }
+
+    private static boolean regressionExceeds(long a, long b, boolean higherIsBetter, double thresholdPct) {
+        if (a == 0) return false;
+        double diff = b - a;
+        double pct = diff / a * 100;
+        return higherIsBetter ? pct < -thresholdPct : pct > thresholdPct;
+    }
+
+    private static boolean regressionExceeds(double a, double b, boolean higherIsBetter, double thresholdPct) {
+        if (a == 0) return false;
+        double diff = b - a;
+        double pct = diff / a * 100;
+        return higherIsBetter ? pct < -thresholdPct : pct > thresholdPct;
     }
 
     @Override


### PR DESCRIPTION
## Summary
- Add file analysis modal system to the web dashboard (argus-frontend)
- Users can upload GC log files directly in the browser and see analysis results
- Server-side file upload endpoints for GC log parsing and comparison

## Frontend Changes
- `analysis.js` — modal component with file upload, validation, progress bar, result rendering
- `index.html` — File Analysis panel + modal HTML + result panel
- `style.css` — modal styles, form groups, result grid, severity colors
- `app.js` — wired up `initAnalysis()` module

## Server Changes
- `POST /api/analyze/gclog` — upload GC log → JSON analysis
- `POST /api/analyze/gclogdiff` — upload 2 files → comparison JSON
- `build.gradle.kts` — added argus-cli dependency for parser/analyzer access

## UX Flow
1. Click "GC Log Analysis" or "GC Log Diff" button in dashboard
2. Modal opens with file input fields + validation
3. Upload → progress bar → results rendered in modal

## Test plan
- [x] `./gradlew :argus-server:compileJava` passes
- [ ] Manual test: upload GC log in browser dashboard
- [ ] Manual test: upload 2 GC logs for diff comparison

Closes #113