### PR TITLE
feat: distribution channels — Homebrew, Docker, SDKMAN (#128)

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -7,10 +7,10 @@ on:
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository }}
 
 jobs:
-  build:
+  build-cli:
+    name: Build CLI image
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -29,23 +29,66 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Extract metadata
+      - name: Extract metadata (CLI)
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          images: ${{ env.REGISTRY }}/${{ github.repository_owner }}/argus
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=raw,value=latest
 
-      - name: Build and push
+      - name: Build and push CLI image
         uses: docker/build-push-action@v5
         with:
           context: .
+          file: Dockerfile
           push: true
           platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  build-agent:
+    name: Build agent image
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (agent)
+        id: meta-agent
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ github.repository_owner }}/argus-agent
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=latest
+
+      - name: Build and push agent image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: deploy/docker/Dockerfile.agent
+          push: true
+          platforms: linux/amd64,linux/arm64
+          tags: ${{ steps.meta-agent.outputs.tags }}
+          labels: ${{ steps.meta-agent.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/Formula/argus.rb
+++ b/Formula/argus.rb
@@ -1,0 +1,22 @@
+class Argus < Formula
+  desc "JVM diagnostic toolkit — 56 commands, health diagnosis, GC analysis, interactive TUI"
+  homepage "https://github.com/rlaope/Argus"
+  url "https://github.com/rlaope/Argus/releases/download/v1.0.0/argus-cli-1.0.0-all.jar"
+  sha256 "PLACEHOLDER"  # Will be updated on release
+  license "Apache-2.0"
+
+  depends_on "openjdk@21"
+
+  def install
+    libexec.install "argus-cli-1.0.0-all.jar" => "argus-cli.jar"
+
+    (bin/"argus").write <<~EOS
+      #!/bin/bash
+      exec "#{Formula["openjdk@21"].opt_bin}/java" -jar "#{libexec}/argus-cli.jar" "$@"
+    EOS
+  end
+
+  test do
+    system "#{bin}/argus", "--version"
+  end
+end

--- a/deploy/sdkman/README.md
+++ b/deploy/sdkman/README.md
@@ -1,0 +1,70 @@
+# SDKMAN Candidate Submission
+
+This directory contains the candidate definition for submitting Argus to the [SDKMAN vendors portal](https://vendors.sdkman.io/).
+
+## Prerequisites
+
+1. Register at https://vendors.sdkman.io/ with your GitHub account
+2. Create a candidate (one-time) via the portal — use `argus-candidate.json` as reference for the fields
+3. Obtain your **Consumer Key** and **Consumer Secret** from the portal
+
+## Releasing a New Version
+
+Once the candidate is registered, publish each release via the SDKMAN Vendor API:
+
+```bash
+VERSION="1.0.0"
+CONSUMER_KEY="<your-key>"
+CONSUMER_SECRET="<your-secret>"
+
+# Publish the release
+curl -X POST \
+  "https://vendors.sdkman.io/release" \
+  -H "Consumer-Key: $CONSUMER_KEY" \
+  -H "Consumer-Token: $CONSUMER_SECRET" \
+  -H "Content-Type: application/json" \
+  -d "{
+    \"candidate\": \"argus\",
+    \"version\": \"$VERSION\",
+    \"url\": \"https://github.com/rlaope/Argus/releases/download/v${VERSION}/argus-cli-${VERSION}-all.jar\"
+  }"
+
+# Set as default (optional)
+curl -X PUT \
+  "https://vendors.sdkman.io/default/candidate/argus/version/$VERSION" \
+  -H "Consumer-Key: $CONSUMER_KEY" \
+  -H "Consumer-Token: $CONSUMER_SECRET"
+
+# Announce (optional — sends broadcast to SDKMAN users)
+curl -X POST \
+  "https://vendors.sdkman.io/announce/struct" \
+  -H "Consumer-Key: $CONSUMER_KEY" \
+  -H "Consumer-Token: $CONSUMER_SECRET" \
+  -H "Content-Type: application/json" \
+  -d "{
+    \"candidate\": \"argus\",
+    \"version\": \"$VERSION\",
+    \"hashtag\": \"argus\"
+  }"
+```
+
+## Installation (after acceptance)
+
+Once accepted, users can install Argus via:
+
+```bash
+sdk install argus
+```
+
+Or a specific version:
+
+```bash
+sdk install argus 1.0.0
+```
+
+## Notes
+
+- SDKMAN distributes the fat JAR directly — no native binary needed
+- The JAR requires Java 11+ on the user's machine (SDKMAN does not manage the JDK dep)
+- Platform entries in `argus-candidate.json` all point to the same JAR since it is platform-independent
+- For the initial submission, expect a review period of a few days

--- a/deploy/sdkman/argus-candidate.json
+++ b/deploy/sdkman/argus-candidate.json
@@ -1,0 +1,12 @@
+{
+  "candidate": "argus",
+  "name": "Argus JVM Diagnostic Toolkit",
+  "description": "56 CLI commands for JVM diagnostics — health diagnosis, GC analysis, flame graphs, interactive TUI",
+  "websiteUrl": "https://github.com/rlaope/Argus",
+  "distribution": "PLATFORM_SPECIFIC",
+  "platform": {
+    "LINUX_64": "https://github.com/rlaope/Argus/releases/download/v${version}/argus-cli-${version}-all.jar",
+    "MAC_OSX": "https://github.com/rlaope/Argus/releases/download/v${version}/argus-cli-${version}-all.jar",
+    "MAC_ARM64": "https://github.com/rlaope/Argus/releases/download/v${version}/argus-cli-${version}-all.jar"
+  }
+}

--- a/install.sh
+++ b/install.sh
@@ -19,6 +19,34 @@ INSTALL_DIR="$HOME/.argus"
 BIN_DIR="$INSTALL_DIR/bin"
 VERSION="${1:-latest}"
 
+# --- OS/Arch detection ---
+
+detect_platform() {
+    local os arch
+    os=$(uname -s | tr '[:upper:]' '[:lower:]')
+    arch=$(uname -m)
+
+    case "$os" in
+        linux*)
+            case "$arch" in
+                x86_64|amd64) echo "linux-amd64" ;;
+                aarch64|arm64) echo "linux-arm64" ;;
+                *) echo "" ;;
+            esac
+            ;;
+        darwin*)
+            case "$arch" in
+                arm64) echo "macos-aarch64" ;;
+                x86_64) echo "macos-amd64" ;;
+                *) echo "" ;;
+            esac
+            ;;
+        *) echo "" ;;
+    esac
+}
+
+PLATFORM=$(detect_platform)
+
 # Colors
 RED='\033[0;31m'
 GREEN='\033[0;32m'
@@ -87,6 +115,24 @@ curl -fSL "$DOWNLOAD_BASE/argus-cli-${VER_NUM}-all.jar" -o "$INSTALL_DIR/argus-c
     || { warn "argus-cli not found in release. CLI may not be available in $VERSION."; }
 ok "argus-cli.jar"
 
+# --- Attempt native binary download (faster startup, no JVM required for launch) ---
+
+NATIVE_BIN=""
+if [ -n "$PLATFORM" ]; then
+    NATIVE_ARTIFACT="argus-${PLATFORM}"
+    NATIVE_URL="$DOWNLOAD_BASE/${NATIVE_ARTIFACT}"
+    info "Attempting native binary download for ${PLATFORM}..."
+    if curl -fSL "$NATIVE_URL" -o "$INSTALL_DIR/argus-native" 2>/dev/null; then
+        chmod +x "$INSTALL_DIR/argus-native"
+        NATIVE_BIN="$INSTALL_DIR/argus-native"
+        ok "Native binary (${PLATFORM})"
+    else
+        warn "No native binary for ${PLATFORM} — using fat JAR (requires Java 11+)"
+    fi
+else
+    warn "Unknown platform — using fat JAR (requires Java 11+)"
+fi
+
 # --- Download async-profiler ---
 
 ASPROF_VERSION="3.0"
@@ -151,7 +197,14 @@ fi
 # --- Create wrapper scripts ---
 
 # argus - CLI diagnostic tool
-cat > "$BIN_DIR/argus" << 'WRAPPER'
+# Use native binary if available, otherwise fall back to fat JAR via JVM
+if [ -x "$INSTALL_DIR/argus-native" ]; then
+    cat > "$BIN_DIR/argus" << 'WRAPPER'
+#!/usr/bin/env bash
+exec "$HOME/.argus/argus-native" "$@"
+WRAPPER
+else
+    cat > "$BIN_DIR/argus" << 'WRAPPER'
 #!/usr/bin/env bash
 find_java() {
     local candidates=()
@@ -190,6 +243,7 @@ PREVIEW=""
 [ "$JAVA_VER" -ge 21 ] 2>/dev/null && PREVIEW="--enable-preview"
 exec "$ARGUS_JAVA" $PREVIEW -jar "$HOME/.argus/argus-cli.jar" "$@"
 WRAPPER
+fi
 chmod +x "$BIN_DIR/argus"
 
 # argus-agent - prints the agent JAR path (for -javaagent)


### PR DESCRIPTION
## Summary
- Homebrew formula (`Formula/argus.rb`) with openjdk@21 dependency
- Docker workflow updated: CLI + agent images to GHCR
- SDKMAN candidate definition + vendor portal submission guide
- install.sh: platform detection, native binary download with JAR fallback

## Test plan
- [x] `./gradlew :argus-cli:test` passes
- [ ] `brew install --build-from-source Formula/argus.rb` (manual)
- [ ] Docker build: `docker build -t argus .` (manual)

Closes #128