### PR TITLE
fix: resolve merge conflict markers left on master

### DIFF
--- a/argus-cli/src/main/resources/messages_en.properties
+++ b/argus-cli/src/main/resources/messages_en.properties
@@ -354,7 +354,6 @@ error.profile.invalid.type=Invalid profiling type: %s. Use: cpu, alloc, lock, wa
 gcnew.age.title=Object Age Distribution
 gcnew.age.unavailable=Age data unavailable. Enable -Xlog:gc+age=debug for live data.
 cmd.gclog.tenuring.desc=Analyze tenuring threshold changes from GC age log
-<<<<<<< HEAD
 cmd.trace.desc=Method execution tracing via rapid thread sampling
 header.trace=Method Trace
 desc.trace=Traces method execution by sampling thread dumps at 10/sec. Builds a call tree with timing estimates.
@@ -362,7 +361,6 @@ status.trace.sampling=Tracing PID %s for %ss (%s samples)...
 status.trace.no.match=No stack traces matched '%s' in %s samples
 error.trace.invalid.target=Invalid target format: '%s'. Use class.method (e.g. com.example.OrderService.createOrder)
 trace.summary=%s samples, %s matched target method '%s'
-=======
 
 # Spring Boot
 cmd.spring.desc=Inspect Spring Boot application via JMX
@@ -420,4 +418,3 @@ status.benchmark.warmup=Warming up for %ss...
 status.benchmark.sampling=Sampling for %ss...
 error.benchmark.jfr.failed=Failed to start JFR recording: %s
 error.benchmark.target.invalid=Invalid target method: %s. Use fully-qualified format: com.example.Class.method
->>>>>>> e23934b (feat: argus spring + benchmark commands (#132, #133))

--- a/argus-cli/src/main/resources/messages_ja.properties
+++ b/argus-cli/src/main/resources/messages_ja.properties
@@ -338,7 +338,6 @@ error.profile.invalid.type=\u7121\u52B9\u306A\u30D7\u30ED\u30D5\u30A1\u30A4\u30E
 gcnew.age.title=\u30AA\u30D6\u30B8\u30A7\u30AF\u30C8\u5E74\u9F62\u5206\u5E03
 gcnew.age.unavailable=\u5E74\u9F62\u30C7\u30FC\u30BF\u306F\u5229\u7528\u4E0D\u53EF\u3002-Xlog:gc+age=debug\u3067\u6709\u52B9\u5316\u3057\u3066\u304F\u3060\u3055\u3044\u3002
 cmd.gclog.tenuring.desc=GC\u30A8\u30FC\u30B8\u30ED\u30B0\u304B\u3089\u30C6\u30CB\u30E5\u30A2\u30EA\u30F3\u30B0\u5909\u5316\u3092\u5206\u6790
-<<<<<<< HEAD
 cmd.trace.desc=高速スレッドサンプリングによるメソッド実行トレース
 header.trace=メソッドトレース
 desc.trace=秒間10回のスレッドダンプサンプリングでメソッド実行を追跡します。タイミング推定付きのコールツリーを生成します。
@@ -346,7 +345,6 @@ status.trace.sampling=PID %sを%s秒間トレース中 (%sサンプル)...
 status.trace.no.match=%sサンプルで'%s'に一致するスタックトレースが見つかりません
 error.trace.invalid.target=無効なターゲット形式: '%s'。class.method形式を使用してください (例: com.example.OrderService.createOrder)
 trace.summary=%sサンプル、%s件がターゲットメソッド'%s'に一致
-=======
 
 # Spring Boot
 cmd.spring.desc=JMX\u7d4c\u7531\u3067Spring Boot\u30a2\u30d7\u30ea\u3092\u691c\u67fb
@@ -404,4 +402,3 @@ status.benchmark.warmup=%ss\u9593\u30a6\u30a9\u30fc\u30e0\u30a2\u30c3\u30d7\u4e2
 status.benchmark.sampling=%ss\u9593\u30b5\u30f3\u30d7\u30ea\u30f3\u30b0\u4e2d...
 error.benchmark.jfr.failed=JFR\u30ec\u30b3\u30fc\u30c7\u30a3\u30f3\u30b0\u306e\u958b\u59cb\u306b\u5931\u6557\u3057\u307e\u3057\u305f: %s
 error.benchmark.target.invalid=\u7121\u52b9\u306a\u30bf\u30fc\u30b2\u30c3\u30c8\u30e1\u30bd\u30c3\u30c9: %s\u3002\u5f62\u5f0f: com.example.Class.method
->>>>>>> e23934b (feat: argus spring + benchmark commands (#132, #133))

--- a/argus-cli/src/main/resources/messages_ko.properties
+++ b/argus-cli/src/main/resources/messages_ko.properties
@@ -338,7 +338,6 @@ error.profile.invalid.type=\uC798\uBABB\uB41C \uD504\uB85C\uD30C\uC77C\uB9C1 \uD
 gcnew.age.title=\uAC1D\uCCB4 \uC5F0\uB839 \uBD84\uD3EC
 gcnew.age.unavailable=\uC5F0\uB839 \uB370\uC774\uD130\uB97C \uC0AC\uC6A9\uD560 \uC218 \uC5C6\uC2B5\uB2C8\uB2E4. -Xlog:gc+age=debug\uB97C \uC0AC\uC6A9\uD558\uC138\uC694.
 cmd.gclog.tenuring.desc=GC \uC5D0\uC774\uC9C0 \uB85C\uADF8\uC5D0\uC11C \uD14C\uB274\uC5B4\uB9C1 \uBCC0\uD654 \uBD84\uC11D
-<<<<<<< HEAD
 cmd.trace.desc=고속 스레드 샘플링을 통한 메서드 실행 추적
 header.trace=메서드 추적
 desc.trace=초당 10회 스레드 덤프 샘플링으로 메서드 실행을 추적합니다. 타이밍 추정치와 함께 호출 트리를 생성합니다.
@@ -346,7 +345,6 @@ status.trace.sampling=PID %s를 %s초 동안 추적 중 (%s개 샘플)...
 status.trace.no.match=%s개 샘플에서 '%s'와 일치하는 스택 트레이스가 없습니다
 error.trace.invalid.target=잘못된 대상 형식: '%s'. class.method 형식을 사용하세요 (예: com.example.OrderService.createOrder)
 trace.summary=%s개 샘플, %s개가 대상 메서드 '%s'와 일치
-=======
 
 # Spring Boot
 cmd.spring.desc=JMX\ub97c \ud1b5\ud55c Spring Boot \uc560\ud50c\ub9ac\ucf00\uc774\uc158 \uac80\uc0ac
@@ -404,4 +402,3 @@ status.benchmark.warmup=%ss \ub3d9\uc548 \uc6cc\uba3c\uc5c5 \uc911...
 status.benchmark.sampling=%ss \ub3d9\uc548 \uc0d8\ud50c\ub9c1 \uc911...
 error.benchmark.jfr.failed=JFR \ub808\ucf54\ub529 \uc2dc\uc791 \uc2e4\ud328: %s
 error.benchmark.target.invalid=\uc798\ubabb\ub41c \ub300\uc0c1 \uba54\uc11c\ub4dc: %s. \ud615\uc2dd: com.example.Class.method
->>>>>>> e23934b (feat: argus spring + benchmark commands (#132, #133))

--- a/argus-cli/src/main/resources/messages_zh.properties
+++ b/argus-cli/src/main/resources/messages_zh.properties
@@ -335,7 +335,6 @@ error.profile.unsupported.platform=\u6B64\u5E73\u53F0\u4E0D\u652F\u6301async-pro
 error.profile.download.failed=async-profiler\u4E0B\u8F7D\u5931\u8D25: %s
 error.profile.asprof.failed=async-profiler\u5931\u8D25: %s
 error.profile.invalid.type=\u65E0\u6548\u7684\u5206\u6790\u7C7B\u578B: %s\u3002\u8BF7\u4F7F\u7528: cpu, alloc, lock, wall
-<<<<<<< HEAD
 cmd.trace.desc=通过高速线程采样进行方法执行追踪
 header.trace=方法追踪
 desc.trace=以每秒10次的频率采样线程转储来追踪方法执行，生成带时间估算的调用树。
@@ -343,7 +342,6 @@ status.trace.sampling=正在追踪PID %s，持续%s秒（%s个样本）...
 status.trace.no.match=在%s个样本中未找到匹配'%s'的堆栈跟踪
 error.trace.invalid.target=无效的目标格式：'%s'。请使用class.method格式（例如：com.example.OrderService.createOrder）
 trace.summary=%s个样本，%s个匹配目标方法'%s'
-=======
 
 # Spring Boot
 cmd.spring.desc=\u901a\u8fc7JMX\u68c0\u67e5Spring Boot\u5e94\u7528\u7a0b\u5e8f
@@ -401,4 +399,3 @@ status.benchmark.warmup=\u9884\u70ed%ss...
 status.benchmark.sampling=\u91c7\u6837%ss...
 error.benchmark.jfr.failed=\u542f\u52a8JFR\u5f55\u5236\u5931\u8d25: %s
 error.benchmark.target.invalid=\u65e0\u6548\u7684\u76ee\u6807\u65b9\u6cd5: %s\u3002\u683c\u5f0f: com.example.Class.method
->>>>>>> e23934b (feat: argus spring + benchmark commands (#132, #133))

--- a/completions/argus.bash
+++ b/completions/argus.bash
@@ -3,11 +3,7 @@ _argus_completions() {
     cur="${COMP_WORDS[COMP_CWORD]}"
     prev="${COMP_WORDS[COMP_CWORD-1]}"
 
-<<<<<<< HEAD
-    commands="alert init ps histo threads gc gcutil heap sysprops vmflag nmt classloader profile jfr jfranalyze diff report doctor gclog gclogdiff gcprofile flame suggest watch tui info heapdump heapanalyze deadlock threaddump buffers gcrun logger events compilerqueue sc env compiler finalizer stringtable pool gccause metaspace dynlibs vmset vmlog jmx classstat gcnew symboltable top perfcounter mbean ci compare slowlog explain trace"
-=======
-    commands="init ps histo threads gc gcutil heap sysprops vmflag nmt classloader profile jfr jfranalyze diff report doctor gclog gclogdiff gcprofile flame suggest watch tui info heapdump heapanalyze deadlock threaddump buffers gcrun logger events compilerqueue sc env compiler finalizer stringtable pool gccause metaspace dynlibs vmset vmlog jmx classstat gcnew symboltable top perfcounter mbean ci compare slowlog explain spring benchmark"
->>>>>>> e23934b (feat: argus spring + benchmark commands (#132, #133))
+    commands="alert cluster init ps histo threads gc gcutil heap sysprops vmflag nmt classloader profile jfr jfranalyze diff report doctor gclog gclogdiff gcprofile flame suggest watch tui info heapdump heapanalyze deadlock threaddump buffers gcrun logger events compilerqueue sc env compiler finalizer stringtable pool gccause metaspace dynlibs vmset vmlog jmx classstat gcnew symboltable top perfcounter mbean ci compare slowlog explain trace spring benchmark"
 
     if [ "$COMP_CWORD" -eq 1 ]; then
         COMPREPLY=($(compgen -W "$commands --help --version" -- "$cur"))


### PR DESCRIPTION
## Summary
Five files on master carried unresolved git conflict markers (`<<<<<<<` / `=======` / `>>>>>>>`) from the concurrent merges of `feat/argus-trace` and `feat/spring-benchmark`.

Affected:
- `completions/argus.bash`
- `argus-cli/src/main/resources/messages_en.properties`
- `argus-cli/src/main/resources/messages_ko.properties`
- `argus-cli/src/main/resources/messages_ja.properties`
- `argus-cli/src/main/resources/messages_zh.properties`

## Resolution
Both sides of every conflict held valid keys that should coexist (`trace` + `spring` + `benchmark` are all real commands registered in `ArgusCli`). Marker lines were removed, both sides' content preserved.

The bash completion command list was also extended to include `cluster` (registered in `ArgusCli` but previously missing from the completion list — a separate pre-existing gap that this PR cleans up while touching the same lines).

## Impact
Before: `.properties` files fail to load cleanly past line 340, breaking i18n for all locales. Bash completion list silently stopped mid-line.
After: `./gradlew :argus-cli:compileJava` succeeds, `./gradlew :argus-cli:test` passes.

## Test plan
- [x] `./gradlew :argus-cli:compileJava --rerun-tasks` — BUILD SUCCESSFUL
- [x] `./gradlew :argus-cli:test` — passes
- [x] `grep -n '^<<<<<<<\|^=======\|^>>>>>>>' .` on repo — no matches

Unblocks follow-up work on #150 (argus gcscore), #151 (argus gcwhy), #152 (argus alloc).