### PR TITLE
feat: extend gcprofile with --by=class and --fold (allocation hotspot views)

### DIFF
--- a/argus-cli/src/main/java/io/argus/cli/command/GcProfileCommand.java
+++ b/argus-cli/src/main/java/io/argus/cli/command/GcProfileCommand.java
@@ -3,6 +3,8 @@ package io.argus.cli.command;
 import io.argus.cli.config.CliConfig;
 import io.argus.cli.config.Messages;
 import io.argus.cli.profiler.AllocationProfiler;
+import io.argus.cli.profiler.AllocationProfiler.AllocatedType;
+import io.argus.cli.profiler.AllocationProfiler.AllocationByClass;
 import io.argus.cli.profiler.AllocationProfiler.AllocationProfile;
 import io.argus.cli.profiler.AllocationProfiler.AllocationSite;
 import io.argus.cli.provider.ProviderRegistry;
@@ -13,7 +15,9 @@ import io.argus.core.command.CommandGroup;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
 import java.util.List;
+import java.util.Map;
 
 /**
  * GC-aware allocation profiling via JFR.
@@ -69,6 +73,8 @@ public final class GcProfileCommand implements Command {
         int durationSec = DEFAULT_DURATION;
         int top = DEFAULT_TOP;
         boolean json = "json".equals(config.format());
+        String by = "site";
+        String foldPath = null;
 
         for (int i = 1; i < args.length; i++) {
             String arg = args[i];
@@ -80,6 +86,11 @@ public final class GcProfileCommand implements Command {
                 try { top = Integer.parseInt(arg.substring(6)); } catch (NumberFormatException ignored) {}
             } else if (arg.equals("--format=json") || arg.equals("--json")) {
                 json = true;
+            } else if (arg.startsWith("--by=")) {
+                String v = arg.substring(5).toLowerCase();
+                if (v.equals("class") || v.equals("site")) by = v;
+            } else if (arg.startsWith("--fold=")) {
+                foldPath = arg.substring(7);
             }
         }
 
@@ -133,12 +144,30 @@ public final class GcProfileCommand implements Command {
                 return;
             }
 
-            AllocationProfile profile = AllocationProfiler.analyze(tmpFile);
+            // Optional: write folded stacks for flamegraph.pl consumption.
+            if (foldPath != null) {
+                Map<String, Long> folded = AllocationProfiler.analyzeFoldedStacks(tmpFile);
+                writeFolded(Path.of(foldPath), folded);
+                System.out.println("  Folded stacks written: " + foldPath
+                        + " (" + folded.size() + " stacks)");
+                System.out.println("  Render with: flamegraph.pl --title=\"alloc\" --colors=mem "
+                        + foldPath + " > alloc.svg");
+            }
 
-            if (json) {
-                printJson(profile, pid, durationSec, top);
+            if ("class".equals(by)) {
+                AllocationByClass byClass = AllocationProfiler.analyzeByClass(tmpFile);
+                if (json) {
+                    printJsonByClass(byClass, pid, durationSec, top);
+                } else {
+                    printRichByClass(byClass, pid, durationSec, top, useColor);
+                }
             } else {
-                printRich(profile, pid, durationSec, top, useColor);
+                AllocationProfile profile = AllocationProfiler.analyze(tmpFile);
+                if (json) {
+                    printJson(profile, pid, durationSec, top);
+                } else {
+                    printRich(profile, pid, durationSec, top, useColor);
+                }
             }
 
         } catch (IOException e) {
@@ -282,7 +311,13 @@ public final class GcProfileCommand implements Command {
                 + "Recording duration in seconds (default: 30)", WIDTH));
         System.out.println(RichRenderer.boxLine(
                 RichRenderer.padRight("  --top=N", 36)
-                + "Show top N allocation sites (default: 10)", WIDTH));
+                + "Show top N rows (default: 10)", WIDTH));
+        System.out.println(RichRenderer.boxLine(
+                RichRenderer.padRight("  --by=site|class", 36)
+                + "Aggregate by stack frame (default) or allocated class", WIDTH));
+        System.out.println(RichRenderer.boxLine(
+                RichRenderer.padRight("  --fold=FILE", 36)
+                + "Write folded stacks for flamegraph.pl consumption", WIDTH));
         System.out.println(RichRenderer.boxLine(
                 RichRenderer.padRight("  --format=json", 36)
                 + "Output as JSON", WIDTH));
@@ -345,5 +380,96 @@ public final class GcProfileCommand implements Command {
         int dot = className.lastIndexOf('.');
         String simple = dot >= 0 ? className.substring(dot + 1) : className;
         return simple + "." + methodName;
+    }
+
+    // -------------------------------------------------------------------------
+    // --by=class rendering
+    // -------------------------------------------------------------------------
+
+    private static void printRichByClass(AllocationByClass byClass, long pid, int durationSec,
+                                         int top, boolean useColor) {
+        System.out.println();
+        System.out.println(RichRenderer.boxHeader(useColor, "GC Allocation Profile (by class)",
+                WIDTH, "pid:" + pid, durationSec + "s"));
+        System.out.println(RichRenderer.emptyLine(WIDTH));
+
+        double totalMb = byClass.totalBytes() / (1024.0 * 1024.0);
+        double mbPerSec = byClass.durationSec() > 0 ? totalMb / byClass.durationSec() : 0;
+        System.out.println(RichRenderer.boxLine(
+                "  Total Allocated: " + formatBytes(byClass.totalBytes())
+                        + " in " + durationSec + "s"
+                        + " (" + formatBytesPerSec(mbPerSec) + ")", WIDTH));
+        System.out.println(RichRenderer.emptyLine(WIDTH));
+        System.out.println(RichRenderer.boxSeparator(WIDTH));
+
+        if (byClass.sites().isEmpty()) {
+            System.out.println(RichRenderer.emptyLine(WIDTH));
+            System.out.println(RichRenderer.boxLine("  No allocation events found in recording.", WIDTH));
+            System.out.println(RichRenderer.emptyLine(WIDTH));
+            System.out.println(RichRenderer.boxFooter(useColor, null, WIDTH));
+            return;
+        }
+
+        String colHeader = AnsiStyle.style(useColor, AnsiStyle.BOLD)
+                + "  " + RichRenderer.padRight("#", 4)
+                + RichRenderer.padRight("Total", 12)
+                + RichRenderer.padRight("% ", 8)
+                + RichRenderer.padRight("Count", 10)
+                + "Class"
+                + AnsiStyle.style(useColor, AnsiStyle.RESET);
+        System.out.println(RichRenderer.boxLine(colHeader, WIDTH));
+
+        int limit = Math.min(top, byClass.sites().size());
+        for (int i = 0; i < limit; i++) {
+            AllocatedType t = byClass.sites().get(i);
+            double pct = byClass.totalBytes() > 0
+                    ? (t.totalBytes() * 100.0 / byClass.totalBytes()) : 0;
+            int classWidth = WIDTH - 4 - 4 - 12 - 8 - 10 - 2;
+            String line = "  " + RichRenderer.padRight(String.valueOf(i + 1), 4)
+                    + RichRenderer.padRight(formatBytes(t.totalBytes()), 12)
+                    + RichRenderer.padRight(String.format("%.1f%%", pct), 8)
+                    + RichRenderer.padRight(formatWithCommas(t.allocationCount()), 10)
+                    + RichRenderer.truncate(t.className(), Math.max(10, classWidth));
+            System.out.println(RichRenderer.boxLine(line, WIDTH));
+        }
+
+        System.out.println(RichRenderer.emptyLine(WIDTH));
+        System.out.println(RichRenderer.boxFooter(useColor,
+                byClass.sites().size() + " unique classes", WIDTH));
+        System.out.println();
+    }
+
+    private static void printJsonByClass(AllocationByClass byClass, long pid, int durationSec, int top) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("{\"pid\":").append(pid);
+        sb.append(",\"durationSec\":").append(durationSec);
+        sb.append(",\"by\":\"class\"");
+        sb.append(",\"totalBytes\":").append(byClass.totalBytes());
+        sb.append(",\"sites\":[");
+        int limit = Math.min(top, byClass.sites().size());
+        for (int i = 0; i < limit; i++) {
+            AllocatedType t = byClass.sites().get(i);
+            if (i > 0) sb.append(',');
+            sb.append("{\"className\":\"").append(RichRenderer.escapeJson(t.className())).append('"');
+            sb.append(",\"totalBytes\":").append(t.totalBytes());
+            sb.append(",\"allocationCount\":").append(t.allocationCount());
+            sb.append(",\"bytesPerSec\":").append(String.format("%.2f", t.bytesPerSec()));
+            sb.append('}');
+        }
+        sb.append("]}");
+        System.out.println(sb);
+    }
+
+    // -------------------------------------------------------------------------
+    // Folded stacks writer (flamegraph.pl input)
+    // -------------------------------------------------------------------------
+
+    private static void writeFolded(Path out, Map<String, Long> folded) throws IOException {
+        StringBuilder sb = new StringBuilder();
+        for (Map.Entry<String, Long> e : folded.entrySet()) {
+            sb.append(e.getKey()).append(' ').append(e.getValue()).append('\n');
+        }
+        Files.writeString(out, sb.toString(),
+                StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING);
     }
 }

--- a/argus-cli/src/main/java/io/argus/cli/profiler/AllocationProfiler.java
+++ b/argus-cli/src/main/java/io/argus/cli/profiler/AllocationProfiler.java
@@ -10,7 +10,9 @@ import java.nio.file.Path;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -142,4 +144,142 @@ public final class AllocationProfiler {
             long allocationCount,
             double bytesPerSec
     ) {}
+
+    /**
+     * Aggregated allocation view grouped by the <em>allocated type</em> rather than stack frame.
+     * Answers "which classes are burning allocation bytes".
+     *
+     * @param sites       allocated types sorted by total bytes descending
+     * @param totalBytes  total bytes allocated across all events
+     * @param durationSec recording duration in seconds
+     */
+    public record AllocationByClass(
+            List<AllocatedType> sites,
+            long totalBytes,
+            double durationSec
+    ) {}
+
+    /** A single allocated-type row: the class that was allocated, not the code that allocated it. */
+    public record AllocatedType(
+            String className,
+            long totalBytes,
+            long allocationCount,
+            double bytesPerSec
+    ) {}
+
+    // -------------------------------------------------------------------------
+    // New: group by allocated class
+    // -------------------------------------------------------------------------
+
+    /**
+     * Analyzes a JFR file and aggregates allocation events by the <em>allocated object's class</em>
+     * (the {@code objectClass} event field), producing a top-allocated-types view that complements
+     * the stack-frame view produced by {@link #analyze(Path)}.
+     */
+    public static AllocationByClass analyzeByClass(Path jfrFile) throws IOException {
+        Map<String, long[]> agg = new HashMap<>();
+        long totalBytes = 0;
+        Instant earliest = null;
+        Instant latest = null;
+
+        try (RecordingFile rf = new RecordingFile(jfrFile)) {
+            while (rf.hasMoreEvents()) {
+                RecordedEvent event = rf.readEvent();
+                String eventType = event.getEventType().getName();
+                if (!eventType.equals("jdk.ObjectAllocationInNewTLAB")
+                        && !eventType.equals("jdk.ObjectAllocationOutsideTLAB")) {
+                    continue;
+                }
+
+                Instant startTime = event.getStartTime();
+                if (earliest == null || startTime.isBefore(earliest)) earliest = startTime;
+                Instant endTime = event.getEndTime();
+                if (latest == null || endTime.isAfter(latest)) latest = endTime;
+
+                long size = readAllocationSize(event);
+                String className;
+                try {
+                    className = event.getClass("objectClass").getName();
+                } catch (Exception ignored) {
+                    className = "<unknown>";
+                }
+
+                agg.computeIfAbsent(className, k -> new long[2]);
+                agg.get(className)[0] += size;
+                agg.get(className)[1] += 1;
+                totalBytes += size;
+            }
+        }
+
+        double durationSec = (earliest != null && latest != null)
+                ? Duration.between(earliest, latest).toNanos() / 1_000_000_000.0 : 0.0;
+        if (durationSec <= 0.0) durationSec = 1.0;
+
+        final double dur = durationSec;
+        List<AllocatedType> rows = new ArrayList<>();
+        for (Map.Entry<String, long[]> e : agg.entrySet()) {
+            long bytes = e.getValue()[0];
+            long count = e.getValue()[1];
+            rows.add(new AllocatedType(e.getKey(), bytes, count, bytes / dur));
+        }
+        rows.sort((a, b) -> Long.compare(b.totalBytes(), a.totalBytes()));
+
+        return new AllocationByClass(rows, totalBytes, durationSec);
+    }
+
+    // -------------------------------------------------------------------------
+    // New: folded stacks (flamegraph.pl input format)
+    // -------------------------------------------------------------------------
+
+    /**
+     * Produces a folded-stacks map keyed by semicolon-joined stack (leaf last),
+     * with values equal to total allocated bytes. Suitable as input to
+     * {@code flamegraph.pl} (Brendan Gregg).
+     */
+    public static Map<String, Long> analyzeFoldedStacks(Path jfrFile) throws IOException {
+        Map<String, Long> folded = new LinkedHashMap<>();
+
+        try (RecordingFile rf = new RecordingFile(jfrFile)) {
+            while (rf.hasMoreEvents()) {
+                RecordedEvent event = rf.readEvent();
+                String eventType = event.getEventType().getName();
+                if (!eventType.equals("jdk.ObjectAllocationInNewTLAB")
+                        && !eventType.equals("jdk.ObjectAllocationOutsideTLAB")) {
+                    continue;
+                }
+
+                RecordedStackTrace stack = event.getStackTrace();
+                if (stack == null || stack.getFrames().isEmpty()) continue;
+
+                long size = readAllocationSize(event);
+                if (size <= 0) continue;
+
+                // flamegraph.pl expects root-first, leaf-last; JFR frames are leaf-first.
+                List<RecordedFrame> frames = stack.getFrames();
+                StringBuilder sb = new StringBuilder();
+                for (int i = frames.size() - 1; i >= 0; i--) {
+                    RecordedFrame f = frames.get(i);
+                    if (f.getMethod() == null) continue;
+                    String cls = f.getMethod().getType().getName();
+                    String mth = f.getMethod().getName();
+                    if (sb.length() > 0) sb.append(';');
+                    sb.append(cls).append('.').append(mth);
+                }
+                if (sb.length() == 0) continue;
+
+                folded.merge(sb.toString(), size, Long::sum);
+            }
+        }
+
+        // Sort entries deterministically so output is stable.
+        return folded.entrySet().stream()
+                .sorted(Map.Entry.<String, Long>comparingByValue(Comparator.reverseOrder()))
+                .collect(LinkedHashMap::new, (m, e) -> m.put(e.getKey(), e.getValue()), LinkedHashMap::putAll);
+    }
+
+    private static long readAllocationSize(RecordedEvent event) {
+        try { return event.getLong("allocationSize"); } catch (Exception ignored) {}
+        try { return event.getLong("tlabSize"); } catch (Exception ignored) {}
+        return 0;
+    }
 }

--- a/argus-cli/src/test/java/io/argus/cli/profiler/AllocationProfilerTest.java
+++ b/argus-cli/src/test/java/io/argus/cli/profiler/AllocationProfilerTest.java
@@ -1,5 +1,7 @@
 package io.argus.cli.profiler;
 
+import io.argus.cli.profiler.AllocationProfiler.AllocatedType;
+import io.argus.cli.profiler.AllocationProfiler.AllocationByClass;
 import io.argus.cli.profiler.AllocationProfiler.AllocationProfile;
 import io.argus.cli.profiler.AllocationProfiler.AllocationSite;
 import org.junit.jupiter.api.Test;
@@ -7,6 +9,7 @@ import org.junit.jupiter.api.Test;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -176,6 +179,150 @@ class AllocationProfilerTest {
         AllocationProfile profile = agg.build(100);
 
         assertEquals(2, profile.sites().size());
+    }
+
+    // -------------------------------------------------------------------------
+    // --by=class aggregation — mirrors AllocationProfiler.analyzeByClass() logic
+    // -------------------------------------------------------------------------
+
+    static final class ClassAggregator {
+        private final Map<String, long[]> agg = new HashMap<>();
+        private long totalBytes = 0;
+        private final double durationSec;
+
+        ClassAggregator(double durationSec) { this.durationSec = durationSec; }
+
+        void add(String className, long bytes) {
+            agg.computeIfAbsent(className, k -> new long[2]);
+            agg.get(className)[0] += bytes;
+            agg.get(className)[1]++;
+            totalBytes += bytes;
+        }
+
+        AllocationByClass build() {
+            double dur = durationSec > 0 ? durationSec : 1.0;
+            List<AllocatedType> rows = new ArrayList<>();
+            for (Map.Entry<String, long[]> e : agg.entrySet()) {
+                long bytes = e.getValue()[0];
+                long count = e.getValue()[1];
+                rows.add(new AllocatedType(e.getKey(), bytes, count, bytes / dur));
+            }
+            rows.sort((a, b) -> Long.compare(b.totalBytes(), a.totalBytes()));
+            return new AllocationByClass(rows, totalBytes, dur);
+        }
+    }
+
+    @Test
+    void byClassSortsByTotalBytesDescending() {
+        ClassAggregator agg = new ClassAggregator(5.0);
+        agg.add("byte[]", 1_000_000);
+        agg.add("java.util.HashMap$Node", 500_000);
+        agg.add("java.lang.String", 250_000);
+        agg.add("byte[]", 200_000); // accumulates with first byte[]
+
+        AllocationByClass result = agg.build();
+
+        assertEquals(3, result.sites().size(), "byte[] entries coalesce");
+        assertEquals("byte[]", result.sites().get(0).className());
+        assertEquals(1_200_000, result.sites().get(0).totalBytes());
+        assertEquals(2, result.sites().get(0).allocationCount());
+        assertEquals(1_950_000, result.totalBytes());
+    }
+
+    @Test
+    void byClassRateCalculation() {
+        ClassAggregator agg = new ClassAggregator(2.0);
+        agg.add("java.lang.String", 400_000); // 200 KB/s
+
+        AllocationByClass result = agg.build();
+        assertEquals(200_000, result.sites().getFirst().bytesPerSec(), 1);
+    }
+
+    @Test
+    void byClassEmpty() {
+        AllocationByClass r = new ClassAggregator(10.0).build();
+        assertTrue(r.sites().isEmpty());
+        assertEquals(0, r.totalBytes());
+    }
+
+    // -------------------------------------------------------------------------
+    // Folded stack aggregation — mirrors AllocationProfiler.analyzeFoldedStacks()
+    // -------------------------------------------------------------------------
+
+    /**
+     * Mirror of the folded-stack building in {@link AllocationProfiler#analyzeFoldedStacks}.
+     * Each "event" is a list of frames ordered leaf-first (matching JFR), with an
+     * allocated byte count.
+     */
+    static Map<String, Long> foldStacks(List<Object[]> events) {
+        Map<String, Long> folded = new LinkedHashMap<>();
+        for (Object[] ev : events) {
+            @SuppressWarnings("unchecked")
+            List<String> leafFirstFrames = (List<String>) ev[0];
+            long size = (long) ev[1];
+            if (size <= 0 || leafFirstFrames.isEmpty()) continue;
+            StringBuilder sb = new StringBuilder();
+            for (int i = leafFirstFrames.size() - 1; i >= 0; i--) {
+                if (sb.length() > 0) sb.append(';');
+                sb.append(leafFirstFrames.get(i));
+            }
+            folded.merge(sb.toString(), size, Long::sum);
+        }
+        return folded.entrySet().stream()
+                .sorted(Map.Entry.<String, Long>comparingByValue(Comparator.reverseOrder()))
+                .collect(LinkedHashMap::new, (m, e) -> m.put(e.getKey(), e.getValue()), LinkedHashMap::putAll);
+    }
+
+    @Test
+    void foldedStacksReorderLeafLast() {
+        List<Object[]> events = new ArrayList<>();
+        events.add(new Object[]{List.of("Leaf.alloc", "Mid.call", "Root.main"), 1000L});
+
+        Map<String, Long> folded = foldStacks(events);
+
+        assertEquals(1, folded.size());
+        assertTrue(folded.containsKey("Root.main;Mid.call;Leaf.alloc"),
+                "expected root-first leaf-last stack, got " + folded.keySet());
+    }
+
+    @Test
+    void foldedStacksMergeIdenticalStacks() {
+        List<Object[]> events = new ArrayList<>();
+        events.add(new Object[]{List.of("byte[].<init>", "Loader.load", "App.main"), 500L});
+        events.add(new Object[]{List.of("byte[].<init>", "Loader.load", "App.main"), 300L});
+
+        Map<String, Long> folded = foldStacks(events);
+
+        assertEquals(1, folded.size());
+        assertEquals(800L, folded.values().iterator().next());
+    }
+
+    @Test
+    void foldedStacksSortedByBytesDesc() {
+        List<Object[]> events = new ArrayList<>();
+        events.add(new Object[]{List.of("A.a"), 100L});
+        events.add(new Object[]{List.of("B.b"), 500L});
+        events.add(new Object[]{List.of("C.c"), 250L});
+
+        Map<String, Long> folded = foldStacks(events);
+
+        List<Long> values = new ArrayList<>(folded.values());
+        assertEquals(500L, values.get(0));
+        assertEquals(250L, values.get(1));
+        assertEquals(100L, values.get(2));
+    }
+
+    @Test
+    void foldedStacksSkipEmptyOrZero() {
+        List<Object[]> events = new ArrayList<>();
+        events.add(new Object[]{List.<String>of(), 1000L});        // no frames → skip
+        events.add(new Object[]{List.of("A.a"), 0L});              // zero bytes → skip
+        events.add(new Object[]{List.of("B.b"), 500L});            // keep
+
+        Map<String, Long> folded = foldStacks(events);
+
+        assertEquals(1, folded.size());
+        assertEquals(500L, folded.get("B.b"));
     }
 
     @Test

--- a/completions/argus.bash
+++ b/completions/argus.bash
@@ -32,6 +32,7 @@ _argus_completions() {
                 case "${COMP_WORDS[1]}" in
                     histo) opts="$opts --top=" ;;
                     profile) opts="$opts --type= --duration= --flame --file= --top=" ;;
+                    gcprofile) opts="$opts --duration= --top= --by= --fold=" ;;
                     gcutil) opts="$opts --watch=" ;;
                     sysprops|vmflag) opts="$opts --filter=" ;;
                     vmflag) opts="$opts --set=" ;;


### PR DESCRIPTION
Closes #152.

## Summary
Extends `argus gcprofile` with two new views instead of introducing a redundant `argus alloc` command. During implementation it became clear that `gcprofile` already does 80% of what the original `alloc` proposal described — same JFR event types (`jdk.ObjectAllocationInNewTLAB` / `OutsideTLAB`), same `--duration` / `--top`, same top-N table, same JSON. A second command would just split the mental model.

What `gcprofile` was actually missing (vs async-profiler `-e alloc` / JDK Mission Control):
1. A **class-grouped view** — today it only shows stack-frame sites.
2. **Flamegraph-compatible output** — today there is no way to visualize call chains.

This PR closes both gaps with two surgical flags.

## Changes
- `--by=site|class` (default `site` — unchanged)
  - `site` — current stack-frame aggregation.
  - `class` — aggregates by the allocated object's type (`event.getClass(\"objectClass\")`). Answers *\"which classes are burning bytes\"*.
- `--fold=FILE` — writes folded stacks in Brendan Gregg's `flamegraph.pl` format (root-first, leaf-last, merged by total bytes). Render with `flamegraph.pl --colors=mem FILE > alloc.svg`.
- New public API in `AllocationProfiler`:
  - `analyzeByClass(Path) → AllocationByClass`
  - `analyzeFoldedStacks(Path) → Map<String, Long>`
- Help text and bash completion updated.

## Non-goals in this PR
- Not a new command. `argus gcprofile` remains the single entry point for allocation profiling.
- No inline SVG rendering — `--fold=FILE` produces folded text; SVG is one `flamegraph.pl` call away. A bundled renderer can be added in a follow-up if needed.
- No live streaming — bounded `--duration`, same as today.

## Backwards compatibility
`argus gcprofile <pid>` (no extra flags) emits the exact same output as before. No existing caller is affected.

## Developer experience
```
# Unchanged — default stack-frame view
argus gcprofile 12345 --duration=30s

# New — allocated types
argus gcprofile 12345 --duration=30s --by=class
#   1. byte[]                       1.8 GB  42.1%
#   2. java.util.HashMap\$Node       620 MB  14.4%

# New — folded stacks for flamegraph.pl
argus gcprofile 12345 --duration=30s --fold=alloc.folded
flamegraph.pl --colors=mem alloc.folded > alloc.svg
```

## References
- async-profiler `-e alloc` mode
- JFR: `jdk.ObjectAllocationInNewTLAB`, `jdk.ObjectAllocationOutsideTLAB`
- Brendan Gregg, \"Folded stacks\" format (flamegraph.pl)

## Test plan
- [x] `./gradlew :argus-cli:compileJava` — BUILD SUCCESSFUL
- [x] `./gradlew :argus-cli:test` — full suite passes
- [x] New unit tests cover: byClass sort/rate/coalesce/empty; folded stacks reordering/merging/sorting/skip-empty
- [x] Existing `argus gcprofile` behavior unchanged (default `--by=site` path still the first branch)