### PR TITLE
chore(release): bump to v1.2.1

### DIFF
--- a/Formula/argus.rb
+++ b/Formula/argus.rb
@@ -1,14 +1,14 @@
 class Argus < Formula
-  desc "JVM diagnostic toolkit — 65 commands, health diagnosis, GC analysis, profiling, interactive TUI"
+  desc "JVM diagnostic toolkit — 66 commands, health diagnosis, GC analysis, profiling, interactive TUI"
   homepage "https://github.com/rlaope/Argus"
-  url "https://github.com/rlaope/Argus/releases/download/v1.2.0/argus-cli-1.2.0-all.jar"
+  url "https://github.com/rlaope/Argus/releases/download/v1.2.1/argus-cli-1.2.1-all.jar"
   sha256 "5f83e90741a7c191636cd6a7089ae7f95a0d86f6b79d0ea8b3068d5ef63b1f6f"
   license "Apache-2.0"
 
   depends_on "openjdk@21"
 
   def install
-    libexec.install "argus-cli-1.2.0-all.jar" => "argus-cli.jar"
+    libexec.install "argus-cli-1.2.1-all.jar" => "argus-cli.jar"
 
     (bin/"argus").write <<~EOS
       #!/bin/bash

--- a/charts/argus/Chart.yaml
+++ b/charts/argus/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: argus
 description: Argus JVM Observability — Prometheus metrics, Grafana dashboards, and alerting for JVM applications
 type: application
-version: 1.2.0
-appVersion: "1.2.0"
+version: 1.2.1
+appVersion: "1.2.1"
 kubeVersion: ">=1.23.0-0"
 home: https://github.com/rlaope/Argus
 sources:

--- a/charts/argus/README.md
+++ b/charts/argus/README.md
@@ -63,13 +63,13 @@ env:
 <dependency>
   <groupId>io.github.rlaope</groupId>
   <artifactId>argus-spring-boot-starter</artifactId>
-  <version>1.2.0</version>
+  <version>1.2.1</version>
 </dependency>
 ```
 
 ```groovy
 // Gradle
-implementation 'io.github.rlaope:argus-spring-boot-starter:1.2.0'
+implementation 'io.github.rlaope:argus-spring-boot-starter:1.2.1'
 ```
 
 ### Step 3 — Expose the metrics port

--- a/deploy/sdkman/README.md
+++ b/deploy/sdkman/README.md
@@ -13,7 +13,7 @@ This directory contains the candidate definition for submitting Argus to the [SD
 Once the candidate is registered, publish each release via the SDKMAN Vendor API:
 
 ```bash
-VERSION="1.2.0"
+VERSION="1.2.1"
 CONSUMER_KEY="<your-key>"
 CONSUMER_SECRET="<your-secret>"
 
@@ -59,7 +59,7 @@ sdk install argus
 Or a specific version:
 
 ```bash
-sdk install argus 1.2.0
+sdk install argus 1.2.1
 ```
 
 ## Notes

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -43,15 +43,15 @@ argus report 12345
 
 ```bash
 # Install a specific version
-curl -fsSL https://raw.githubusercontent.com/rlaope/argus/master/install.sh | bash -s -- v1.2.0
+curl -fsSL https://raw.githubusercontent.com/rlaope/argus/master/install.sh | bash -s -- v1.2.1
 ```
 
 ### Option 2: Manual Download
 
 ```bash
 # Download JARs from GitHub Releases
-curl -LO https://github.com/rlaope/argus/releases/latest/download/argus-agent-1.2.0.jar
-curl -LO https://github.com/rlaope/argus/releases/latest/download/argus-cli-1.2.0-all.jar
+curl -LO https://github.com/rlaope/argus/releases/latest/download/argus-agent-1.2.1.jar
+curl -LO https://github.com/rlaope/argus/releases/latest/download/argus-cli-1.2.1-all.jar
 ```
 
 ### Option 3: Build from Source
@@ -63,8 +63,8 @@ cd argus
 ./gradlew :argus-cli:fatJar
 
 # JARs:
-# argus-agent/build/libs/argus-agent-1.2.0.jar
-# argus-cli/build/libs/argus-cli-1.2.0-all.jar
+# argus-agent/build/libs/argus-agent-1.2.1.jar
+# argus-cli/build/libs/argus-cli-1.2.1-all.jar
 ```
 
 ## Quick Start with Sample Project
@@ -119,7 +119,7 @@ argus info <pid>               # JVM information
 argus top
 
 # Or run directly
-java -jar argus-cli/build/libs/argus-cli-1.2.0-all.jar --help
+java -jar argus-cli/build/libs/argus-cli-1.2.1-all.jar --help
 ```
 
 The CLI auto-detects the best data source: Argus agent (HTTP) when available, JDK tools (`jcmd`) as fallback. Use `--source=agent|jdk` to override.

--- a/docs/kubernetes.md
+++ b/docs/kubernetes.md
@@ -68,7 +68,7 @@ Use an init container to inject the agent JAR via a shared volume. This avoids m
 ```yaml
 initContainers:
   - name: argus-init
-    image: ghcr.io/rlaope/argus:1.2.0
+    image: ghcr.io/rlaope/argus:1.2.1
     command: ["cp", "/opt/argus/argus-cli.jar", "/argus-volume/argus-cli.jar"]
     volumeMounts:
       - name: argus-volume
@@ -98,13 +98,13 @@ Add the Argus Spring Boot starter to `pom.xml` or `build.gradle`. No `-javaagent
 <dependency>
   <groupId>io.argus</groupId>
   <artifactId>argus-spring-boot-starter</artifactId>
-  <version>1.2.0</version>
+  <version>1.2.1</version>
 </dependency>
 ```
 
 **Gradle:**
 ```groovy
-implementation 'io.argus:argus-spring-boot-starter:1.2.0'
+implementation 'io.argus:argus-spring-boot-starter:1.2.1'
 ```
 
 The `/prometheus` and `/argus` endpoints are auto-registered alongside your application's existing endpoints.
@@ -279,7 +279,7 @@ spec:
               mountPath: /argus
       initContainers:
         - name: argus-init
-          image: ghcr.io/rlaope/argus:1.2.0
+          image: ghcr.io/rlaope/argus:1.2.1
           command: ["cp", "/opt/argus/argus-cli.jar", "/argus-volume/argus-cli.jar"]
           volumeMounts:
             - name: argus-volume

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -119,7 +119,7 @@ All settings are passed as `-D` system properties:
 Add `argus-spring-boot-starter` to your Spring Boot 3.2+ application for zero-config JVM monitoring:
 
 ```kotlin
-implementation("io.argus:argus-spring-boot-starter:1.2.0")
+implementation("io.argus:argus-spring-boot-starter:1.2.1")
 ```
 
 Configure via `application.yml`:

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
-argusVersion=1.2.0
+argusVersion=1.2.1
 nettyVersion=4.1.115.Final
 junitVersion=5.11.4

--- a/install.ps1
+++ b/install.ps1
@@ -11,7 +11,7 @@
     irm https://raw.githubusercontent.com/rlaope/argus/master/install.ps1 | iex
 
 .EXAMPLE
-    .\install.ps1 -Version v1.2.0
+    .\install.ps1 -Version v1.2.1
 #>
 
 param(
@@ -55,8 +55,8 @@ if ($Version -eq "latest") {
         $Release = Invoke-RestMethod "https://api.github.com/repos/$Repo/releases/latest" -UseBasicParsing
         $Version = $Release.tag_name
     } catch {
-        Write-Warn "Could not resolve latest release. Using 'v1.2.0' as fallback."
-        $Version = "v1.2.0"
+        Write-Warn "Could not resolve latest release. Using 'v1.2.1' as fallback."
+        $Version = "v1.2.1"
     }
 }
 

--- a/install.sh
+++ b/install.sh
@@ -85,8 +85,8 @@ if [ "$VERSION" = "latest" ]; then
         | grep '"tag_name"' | head -1 | sed 's/.*"tag_name"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/')
 
     if [ -z "$VERSION" ]; then
-        warn "Could not resolve latest release. Using 'v1.2.0' as fallback."
-        VERSION="v1.2.0"
+        warn "Could not resolve latest release. Using 'v1.2.1' as fallback."
+        VERSION="v1.2.1"
     fi
 fi
 

--- a/site/index.html
+++ b/site/index.html
@@ -633,7 +633,7 @@
                         <span class="badge green">Java 21+ Full Features</span>
                         <span class="badge">66 Commands</span>
                         <span class="badge">Zero Dependencies</span>
-                        <span class="badge green">v1.2.0</span>
+                        <span class="badge green">v1.2.1</span>
                     </div>
                 </div>
 
@@ -967,7 +967,7 @@ $ argus zgc 12345 --watch=10 --interval=60</code></pre>
                 <h3>Setup</h3>
 
                 <pre><code>// build.gradle.kts
-implementation("io.argus:argus-spring-boot-starter:1.2.0")</code></pre>
+implementation("io.argus:argus-spring-boot-starter:1.2.1")</code></pre>
 
                 <p>When your Spring Boot application starts, Argus will:</p>
                 <ul>


### PR DESCRIPTION
## Summary

Patch release that ships the docker-agent CI fix from #159 plus the dependency / docs / i18n hygiene from #158. The 1.2.0 release silently shipped without `ghcr.io/<owner>/argus-agent:1.2.0` because `docker.yml`'s `build-agent` job failed against the broken workflow at that tag; cutting 1.2.1 retriggers the fixed pipeline so the agent image actually lands on GHCR.

Source-of-truth bump: `gradle.properties` `argusVersion` 1.2.0 → 1.2.1.

Mirror references updated in the same commit (per the project's "version sync on release, never skip" rule):
- `install.sh`, `install.ps1` — fallback + example version
- `charts/argus/Chart.yaml` — `version` + `appVersion`
- `charts/argus/README.md`, `deploy/sdkman/README.md` — starter coordinates / candidate version
- `docs/getting-started.md` — install URL + JAR filenames
- `docs/kubernetes.md` — image tags + starter coordinates (3 locations)
- `docs/usage.md` — starter coordinate
- `site/index.html` — header badge + starter snippet
- `Formula/argus.rb` — `url` + `libexec.install` + desc text

## Known follow-up

`Formula/argus.rb` `sha256` still references the v1.2.0 JAR hash. It must be recomputed against the v1.2.1 JAR after the release workflow uploads assets. `brew install` will fail with a checksum mismatch until then, which is the desired safe behavior (prevents installing the wrong artifact silently).

## Test plan

- [x] `./gradlew compileJava :argus-cli:test` → exit 0
- [x] `grep -rn "1\.2\.0"` excluding `architecture.md` historical notes and `samples/*` returns 0 hits
- [ ] After merge: tag `v1.2.1` and push, watch `release.yml` + `docker.yml` complete
- [ ] After release: verify `ghcr.io/<owner>/argus:1.2.1` and `ghcr.io/<owner>/argus-agent:1.2.1` both exist (manifest fetch returns 200)
- [ ] After release: open follow-up PR to update `Formula/argus.rb` `sha256`