### PR TITLE
chore(formula): update Homebrew sha256 for v1.2.1

### DIFF
--- a/Formula/argus.rb
+++ b/Formula/argus.rb
@@ -2,7 +2,7 @@ class Argus < Formula
   desc "JVM diagnostic toolkit — 66 commands, health diagnosis, GC analysis, profiling, interactive TUI"
   homepage "https://github.com/rlaope/Argus"
   url "https://github.com/rlaope/Argus/releases/download/v1.2.1/argus-cli-1.2.1-all.jar"
-  sha256 "5f83e90741a7c191636cd6a7089ae7f95a0d86f6b79d0ea8b3068d5ef63b1f6f"
+  sha256 "f0bb79ef3a599c206fa26a86012b9e0f4236d7750a2b789652472ea8aaf3d0ee"
   license "Apache-2.0"
 
   depends_on "openjdk@21"


### PR DESCRIPTION
## Summary

Recompute the Homebrew Formula `sha256` against the v1.2.1 release artifact published by `release.yml`.

```bash
curl -fsSL https://github.com/rlaope/Argus/releases/download/v1.2.1/argus-cli-1.2.1-all.jar \
  | shasum -a 256
# => f0bb79ef3a599c206fa26a86012b9e0f4236d7750a2b789652472ea8aaf3d0ee
```

The v1.2.1 release PR (#160) updated `url` and `libexec.install` but intentionally left `sha256` pointing at the stale v1.2.0 hash because the new JAR didn't exist yet. With this fix, `brew install argus` will succeed against the v1.2.1 artifact.

## Test plan

- [x] `curl ... | shasum -a 256` matches the value in this PR
- [ ] `brew install --build-from-source ./Formula/argus.rb` from a clone (manual)