### PR TITLE
feat: support Java 11/17/21 runtimes for the CLI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,3 +68,38 @@ jobs:
       - name: Check Gradle wrapper
         uses: gradle/actions/wrapper-validation@v3
         continue-on-error: true
+
+  runtime-compat:
+    name: Runtime smoke (Java ${{ matrix.java }})
+    runs-on: ubuntu-latest
+    needs: build
+    strategy:
+      matrix:
+        java: [ '11', '17', '21' ]
+      fail-fast: false
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 21 (build)
+        uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+          cache: 'gradle'
+
+      - name: Build fat JAR
+        run: ./gradlew :argus-cli:fatJar --no-daemon
+
+      - name: Set up runtime JDK ${{ matrix.java }}
+        uses: actions/setup-java@v4
+        with:
+          java-version: ${{ matrix.java }}
+          distribution: 'temurin'
+
+      - name: Smoke test on Java ${{ matrix.java }}
+        run: |
+          JAR=$(ls argus-cli/build/libs/argus-cli-*-all.jar | head -1)
+          java -jar "$JAR" --version
+          java -jar "$JAR" ps

--- a/argus-agent/build.gradle.kts
+++ b/argus-agent/build.gradle.kts
@@ -8,6 +8,10 @@ dependencies {
     testImplementation("org.junit.jupiter:junit-jupiter:${project.findProperty("junitVersion")}")
 }
 
+tasks.withType<JavaCompile> {
+    options.release.set(17)
+}
+
 tasks.jar {
     dependsOn(":argus-core:jar", ":argus-server:jar")
 

--- a/argus-agent/src/main/java/io/argus/agent/ArgusAgent.java
+++ b/argus-agent/src/main/java/io/argus/agent/ArgusAgent.java
@@ -38,17 +38,16 @@ import java.lang.instrument.Instrumentation;
  */
 public final class ArgusAgent {
 
-    private static final String BANNER = """
-
-           _____
-          /  _  \\_______  ____  __ __  ______
-         /  /_\\  \\_  __ \\/ ___\\|  |  \\/  ___/
-        /    |    \\  | \\/ /_/  >  |  /\\___ \\
-        \\____|__  /__|  \\___  /|____//____  >
-                \\/     /_____/            \\/
-
-        Virtual Thread Profiler v%s
-        """;
+    private static final String BANNER = "\n" +
+            "           _____\n" +
+            "          /  _  \\_______  ____  __ __  ______\n" +
+            "         /  /_\\  \\_  __ \\/ ___\\|  |  \\/  ___/\n" +
+            "        /    |    \\  | \\/ /_/  >  |  /\\___ \\\n" +
+            "        \\____|__  /__|  \\___  /|____//____  >\n" +
+            "                \\/     /_____/            \\/\n" +
+            "\n" +
+            "        Virtual Thread Profiler v%s\n" +
+            "        ";
 
     private static volatile JfrStreamingEngine engine;
     private static volatile MxBeanPollingEngine pollingEngine;

--- a/argus-cli/build.gradle.kts
+++ b/argus-cli/build.gradle.kts
@@ -20,12 +20,8 @@ tasks.jar {
     }
 }
 
-java {
-    sourceCompatibility = JavaVersion.VERSION_21
-    targetCompatibility = JavaVersion.VERSION_21
-}
-
 tasks.withType<JavaCompile> {
+    options.release.set(11)
     options.compilerArgs.remove("--enable-preview")
 }
 

--- a/argus-cli/src/main/java/io/argus/cli/alert/AlertRule.java
+++ b/argus-cli/src/main/java/io/argus/cli/alert/AlertRule.java
@@ -2,29 +2,62 @@ package io.argus.cli.alert;
 
 /**
  * A single alerting rule that compares a Prometheus metric value against a threshold.
- *
- * @param name        human-readable rule name (e.g. "gc-overhead")
- * @param metric      Prometheus metric name (e.g. "argus_gc_overhead_ratio")
- * @param threshold   numeric threshold value
- * @param comparator  "&gt;" or "&lt;" — defaults to "&gt;" when unrecognised
- * @param severity    "warning" or "critical"
- * @param webhookUrl  destination webhook URL (may be null)
  */
-public record AlertRule(
-        String name,
-        String metric,
-        double threshold,
-        String comparator,
-        String severity,
-        String webhookUrl) {
+public final class AlertRule {
+    private final String name;
+    private final String metric;
+    private final double threshold;
+    private final String comparator;
+    private final String severity;
+    private final String webhookUrl;
+
+    public AlertRule(String name, String metric, double threshold,
+                     String comparator, String severity, String webhookUrl) {
+        this.name = name;
+        this.metric = metric;
+        this.threshold = threshold;
+        this.comparator = comparator;
+        this.severity = severity;
+        this.webhookUrl = webhookUrl;
+    }
+
+    public String name() { return name; }
+    public String metric() { return metric; }
+    public double threshold() { return threshold; }
+    public String comparator() { return comparator; }
+    public String severity() { return severity; }
+    public String webhookUrl() { return webhookUrl; }
 
     /** Returns true when the given metric value breaches this rule's threshold. */
     public boolean isBreached(double value) {
-        return switch (comparator) {
-            case "<"  -> value < threshold;
-            case "<=" -> value <= threshold;
-            case ">=" -> value >= threshold;
-            default   -> value > threshold; // ">" and fallback
-        };
+        if ("<".equals(comparator)) return value < threshold;
+        if ("<=".equals(comparator)) return value <= threshold;
+        if (">=".equals(comparator)) return value >= threshold;
+        return value > threshold; // ">" and fallback
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof AlertRule)) return false;
+        AlertRule that = (AlertRule) o;
+        return Double.compare(that.threshold, threshold) == 0
+                && java.util.Objects.equals(name, that.name)
+                && java.util.Objects.equals(metric, that.metric)
+                && java.util.Objects.equals(comparator, that.comparator)
+                && java.util.Objects.equals(severity, that.severity)
+                && java.util.Objects.equals(webhookUrl, that.webhookUrl);
+    }
+
+    @Override
+    public int hashCode() {
+        return java.util.Objects.hash(name, metric, threshold, comparator, severity, webhookUrl);
+    }
+
+    @Override
+    public String toString() {
+        return "AlertRule[name=" + name + ", metric=" + metric + ", threshold=" + threshold
+                + ", comparator=" + comparator + ", severity=" + severity
+                + ", webhookUrl=" + webhookUrl + "]";
     }
 }

--- a/argus-cli/src/main/java/io/argus/cli/classleak/ClassLeakDiff.java
+++ b/argus-cli/src/main/java/io/argus/cli/classleak/ClassLeakDiff.java
@@ -14,30 +14,70 @@ import java.util.Map;
  *   <li>CRITICAL — class count grew ≥ 50 % OR added &gt; 1 000 new classes</li>
  * </ul>
  */
-public record ClassLeakDiff(
-        long baseEpochSec,
-        long currentEpochSec,
-        List<Row> rows
-) {
+public final class ClassLeakDiff {
+
+    private final long baseEpochSec;
+    private final long currentEpochSec;
+    private final List<Row> rows;
+
+    public ClassLeakDiff(long baseEpochSec, long currentEpochSec, List<Row> rows) {
+        this.baseEpochSec = baseEpochSec;
+        this.currentEpochSec = currentEpochSec;
+        this.rows = rows;
+    }
+
+    public long baseEpochSec() { return baseEpochSec; }
+    public long currentEpochSec() { return currentEpochSec; }
+    public List<Row> rows() { return rows; }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof ClassLeakDiff)) return false;
+        ClassLeakDiff that = (ClassLeakDiff) o;
+        return baseEpochSec == that.baseEpochSec
+                && currentEpochSec == that.currentEpochSec
+                && java.util.Objects.equals(rows, that.rows);
+    }
+
+    @Override
+    public int hashCode() {
+        return java.util.Objects.hash(baseEpochSec, currentEpochSec, rows);
+    }
+
+    @Override
+    public String toString() {
+        return "ClassLeakDiff[baseEpochSec=" + baseEpochSec
+                + ", currentEpochSec=" + currentEpochSec + ", rows=" + rows + "]";
+    }
 
     public enum Severity { OK, WARNING, CRITICAL }
 
     /**
      * A single diff row — one classloader, base vs. current counts.
-     *
-     * @param address      classloader address (stable identity key)
-     * @param type         classloader type name
-     * @param baseCount    class count in the baseline snapshot (0 if loader is new)
-     * @param currentCount class count in the current snapshot (0 if loader vanished)
-     * @param isNew        true when this loader did not exist in the baseline
      */
-    public record Row(
-            String address,
-            String type,
-            long baseCount,
-            long currentCount,
-            boolean isNew
-    ) {
+    public static final class Row {
+        private final String address;
+        private final String type;
+        private final long baseCount;
+        private final long currentCount;
+        private final boolean isNew;
+
+        public Row(String address, String type, long baseCount,
+                   long currentCount, boolean isNew) {
+            this.address = address;
+            this.type = type;
+            this.baseCount = baseCount;
+            this.currentCount = currentCount;
+            this.isNew = isNew;
+        }
+
+        public String address() { return address; }
+        public String type() { return type; }
+        public long baseCount() { return baseCount; }
+        public long currentCount() { return currentCount; }
+        public boolean isNew() { return isNew; }
+
         public long delta() { return currentCount - baseCount; }
 
         public double deltaPct() {
@@ -53,6 +93,29 @@ public record ClassLeakDiff(
             if (pct >= 50.0 || d > 1_000) return Severity.CRITICAL;
             if (pct >= 10.0) return Severity.WARNING;
             return Severity.OK;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (!(o instanceof Row)) return false;
+            Row that = (Row) o;
+            return baseCount == that.baseCount
+                    && currentCount == that.currentCount
+                    && isNew == that.isNew
+                    && java.util.Objects.equals(address, that.address)
+                    && java.util.Objects.equals(type, that.type);
+        }
+
+        @Override
+        public int hashCode() {
+            return java.util.Objects.hash(address, type, baseCount, currentCount, isNew);
+        }
+
+        @Override
+        public String toString() {
+            return "Row[address=" + address + ", type=" + type + ", baseCount=" + baseCount
+                    + ", currentCount=" + currentCount + ", isNew=" + isNew + "]";
         }
     }
 

--- a/argus-cli/src/main/java/io/argus/cli/classleak/ClassLeakSnapshot.java
+++ b/argus-cli/src/main/java/io/argus/cli/classleak/ClassLeakSnapshot.java
@@ -25,7 +25,38 @@ import java.util.regex.Pattern;
  * @param capturedAtEpochSec  Unix epoch second when the snapshot was taken
  * @param entries             parsed classloader rows, ordered as returned by the JVM
  */
-public record ClassLeakSnapshot(long capturedAtEpochSec, List<ClassLoaderEntry> entries) {
+public final class ClassLeakSnapshot {
+
+    private final long capturedAtEpochSec;
+    private final List<ClassLoaderEntry> entries;
+
+    public ClassLeakSnapshot(long capturedAtEpochSec, List<ClassLoaderEntry> entries) {
+        this.capturedAtEpochSec = capturedAtEpochSec;
+        this.entries = entries;
+    }
+
+    public long capturedAtEpochSec() { return capturedAtEpochSec; }
+    public List<ClassLoaderEntry> entries() { return entries; }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof ClassLeakSnapshot)) return false;
+        ClassLeakSnapshot that = (ClassLeakSnapshot) o;
+        return capturedAtEpochSec == that.capturedAtEpochSec
+                && java.util.Objects.equals(entries, that.entries);
+    }
+
+    @Override
+    public int hashCode() {
+        return java.util.Objects.hash(capturedAtEpochSec, entries);
+    }
+
+    @Override
+    public String toString() {
+        return "ClassLeakSnapshot[capturedAtEpochSec=" + capturedAtEpochSec
+                + ", entries=" + entries + "]";
+    }
 
     // ── Serialization ────────────────────────────────────────────────────────
 
@@ -111,12 +142,12 @@ public record ClassLeakSnapshot(long capturedAtEpochSec, List<ClassLoaderEntry> 
         for (int i = 0; i < s.length(); i++) {
             char c = s.charAt(i);
             switch (c) {
-                case '"'  -> sb.append("\\\"");
-                case '\\' -> sb.append("\\\\");
-                case '\n' -> sb.append("\\n");
-                case '\r' -> sb.append("\\r");
-                case '\t' -> sb.append("\\t");
-                default   -> { if (c < 0x20) sb.append(String.format("\\u%04x", (int) c)); else sb.append(c); }
+                case '"': sb.append("\\\""); break;
+                case '\\': sb.append("\\\\"); break;
+                case '\n': sb.append("\\n"); break;
+                case '\r': sb.append("\\r"); break;
+                case '\t': sb.append("\\t"); break;
+                default: if (c < 0x20) sb.append(String.format("\\u%04x", (int) c)); else sb.append(c); break;
             }
         }
         return sb.toString();

--- a/argus-cli/src/main/java/io/argus/cli/classleak/ClassLoaderEntry.java
+++ b/argus-cli/src/main/java/io/argus/cli/classleak/ClassLoaderEntry.java
@@ -7,19 +7,54 @@ package io.argus.cli.classleak;
  * <pre>
  * 0x0000000500068770  0x0000000500069008  0x0000000cb30b9400     735   5586944   5581408  jdk.internal.loader.ClassLoaders$AppClassLoader
  * </pre>
- *
- * @param address    hex address of the ClassLoaderData (used as stable identity key for diff)
- * @param parent     hex address of the parent classloader (or "0x0" for bootstrap)
- * @param type       classloader type name (e.g. {@code jdk.internal.loader.ClassLoaders$AppClassLoader})
- * @param classCount number of loaded classes
- * @param chunkBytes total allocated metaspace chunk bytes
- * @param blockBytes total allocated metaspace block bytes
  */
-public record ClassLoaderEntry(
-        String address,
-        String parent,
-        String type,
-        long classCount,
-        long chunkBytes,
-        long blockBytes
-) {}
+public final class ClassLoaderEntry {
+    private final String address;
+    private final String parent;
+    private final String type;
+    private final long classCount;
+    private final long chunkBytes;
+    private final long blockBytes;
+
+    public ClassLoaderEntry(String address, String parent, String type,
+                            long classCount, long chunkBytes, long blockBytes) {
+        this.address = address;
+        this.parent = parent;
+        this.type = type;
+        this.classCount = classCount;
+        this.chunkBytes = chunkBytes;
+        this.blockBytes = blockBytes;
+    }
+
+    public String address() { return address; }
+    public String parent() { return parent; }
+    public String type() { return type; }
+    public long classCount() { return classCount; }
+    public long chunkBytes() { return chunkBytes; }
+    public long blockBytes() { return blockBytes; }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof ClassLoaderEntry)) return false;
+        ClassLoaderEntry that = (ClassLoaderEntry) o;
+        return classCount == that.classCount
+                && chunkBytes == that.chunkBytes
+                && blockBytes == that.blockBytes
+                && java.util.Objects.equals(address, that.address)
+                && java.util.Objects.equals(parent, that.parent)
+                && java.util.Objects.equals(type, that.type);
+    }
+
+    @Override
+    public int hashCode() {
+        return java.util.Objects.hash(address, parent, type, classCount, chunkBytes, blockBytes);
+    }
+
+    @Override
+    public String toString() {
+        return "ClassLoaderEntry[address=" + address + ", parent=" + parent
+                + ", type=" + type + ", classCount=" + classCount
+                + ", chunkBytes=" + chunkBytes + ", blockBytes=" + blockBytes + "]";
+    }
+}

--- a/argus-cli/src/main/java/io/argus/cli/cluster/ClusterHealthAggregator.java
+++ b/argus-cli/src/main/java/io/argus/cli/cluster/ClusterHealthAggregator.java
@@ -35,25 +35,6 @@ public final class ClusterHealthAggregator {
 
     private ClusterHealthAggregator() {}
 
-    public record InstanceMetrics(
-        String target,
-        double heapPercent,
-        double gcOverhead,
-        double cpuPercent,
-        boolean leakSuspected,
-        long activeVThreads,
-        boolean reachable
-    ) {}
-
-    public record AggregateStats(
-        double heapMin, double heapMax, double heapAvg,
-        double gcMin,   double gcMax,   double gcAvg,
-        double cpuMin,  double cpuMax,  double cpuAvg,
-        long   vtTotal,
-        int    leakCount,
-        String worstTarget,
-        String worstReason
-    ) {}
 
     /**
      * Extracts per-instance metrics from the raw Prometheus map.
@@ -71,7 +52,8 @@ public final class ClusterHealthAggregator {
      * Computes aggregate statistics from a list of reachable instance metrics.
      */
     public static AggregateStats aggregate(List<InstanceMetrics> instances) {
-        List<InstanceMetrics> up = instances.stream().filter(InstanceMetrics::reachable).toList();
+        List<InstanceMetrics> up = instances.stream().filter(InstanceMetrics::reachable)
+                .collect(java.util.stream.Collectors.toList());
         if (up.isEmpty()) {
             return new AggregateStats(-1,-1,-1,-1,-1,-1,-1,-1,-1,0,0,null,"no reachable instances");
         }
@@ -120,7 +102,7 @@ public final class ClusterHealthAggregator {
             reason.append(String.format("GC overhead %.1f%%", worst.gcOverhead()));
         }
         if (worst.leakSuspected()) {
-            if (!reason.isEmpty()) reason.append(", ");
+            if (reason.length() > 0) reason.append(", ");
             reason.append("memory leak suspected");
         }
 
@@ -138,5 +120,142 @@ public final class ClusterHealthAggregator {
             if (v != null) return v;
         }
         return def;
+    }
+
+    public static final class InstanceMetrics {
+        private final String target;
+        private final double heapPercent;
+        private final double gcOverhead;
+        private final double cpuPercent;
+        private final boolean leakSuspected;
+        private final long activeVThreads;
+        private final boolean reachable;
+
+        public InstanceMetrics(String target, double heapPercent, double gcOverhead,
+                               double cpuPercent, boolean leakSuspected,
+                               long activeVThreads, boolean reachable) {
+            this.target = target;
+            this.heapPercent = heapPercent;
+            this.gcOverhead = gcOverhead;
+            this.cpuPercent = cpuPercent;
+            this.leakSuspected = leakSuspected;
+            this.activeVThreads = activeVThreads;
+            this.reachable = reachable;
+        }
+
+        public String target() { return target; }
+        public double heapPercent() { return heapPercent; }
+        public double gcOverhead() { return gcOverhead; }
+        public double cpuPercent() { return cpuPercent; }
+        public boolean leakSuspected() { return leakSuspected; }
+        public long activeVThreads() { return activeVThreads; }
+        public boolean reachable() { return reachable; }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (!(o instanceof InstanceMetrics)) return false;
+            InstanceMetrics that = (InstanceMetrics) o;
+            return Double.compare(that.heapPercent, heapPercent) == 0
+                    && Double.compare(that.gcOverhead, gcOverhead) == 0
+                    && Double.compare(that.cpuPercent, cpuPercent) == 0
+                    && leakSuspected == that.leakSuspected
+                    && activeVThreads == that.activeVThreads
+                    && reachable == that.reachable
+                    && java.util.Objects.equals(target, that.target);
+        }
+
+        @Override
+        public int hashCode() {
+            return java.util.Objects.hash(target, heapPercent, gcOverhead, cpuPercent,
+                    leakSuspected, activeVThreads, reachable);
+        }
+
+        @Override
+        public String toString() {
+            return "InstanceMetrics[target=" + target + ", heapPercent=" + heapPercent
+                    + ", gcOverhead=" + gcOverhead + ", cpuPercent=" + cpuPercent
+                    + ", leakSuspected=" + leakSuspected + ", activeVThreads=" + activeVThreads
+                    + ", reachable=" + reachable + "]";
+        }
+    }
+
+    public static final class AggregateStats {
+        private final double heapMin, heapMax, heapAvg;
+        private final double gcMin, gcMax, gcAvg;
+        private final double cpuMin, cpuMax, cpuAvg;
+        private final long vtTotal;
+        private final int leakCount;
+        private final String worstTarget;
+        private final String worstReason;
+
+        public AggregateStats(double heapMin, double heapMax, double heapAvg,
+                              double gcMin, double gcMax, double gcAvg,
+                              double cpuMin, double cpuMax, double cpuAvg,
+                              long vtTotal, int leakCount,
+                              String worstTarget, String worstReason) {
+            this.heapMin = heapMin;
+            this.heapMax = heapMax;
+            this.heapAvg = heapAvg;
+            this.gcMin = gcMin;
+            this.gcMax = gcMax;
+            this.gcAvg = gcAvg;
+            this.cpuMin = cpuMin;
+            this.cpuMax = cpuMax;
+            this.cpuAvg = cpuAvg;
+            this.vtTotal = vtTotal;
+            this.leakCount = leakCount;
+            this.worstTarget = worstTarget;
+            this.worstReason = worstReason;
+        }
+
+        public double heapMin() { return heapMin; }
+        public double heapMax() { return heapMax; }
+        public double heapAvg() { return heapAvg; }
+        public double gcMin() { return gcMin; }
+        public double gcMax() { return gcMax; }
+        public double gcAvg() { return gcAvg; }
+        public double cpuMin() { return cpuMin; }
+        public double cpuMax() { return cpuMax; }
+        public double cpuAvg() { return cpuAvg; }
+        public long vtTotal() { return vtTotal; }
+        public int leakCount() { return leakCount; }
+        public String worstTarget() { return worstTarget; }
+        public String worstReason() { return worstReason; }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (!(o instanceof AggregateStats)) return false;
+            AggregateStats that = (AggregateStats) o;
+            return Double.compare(that.heapMin, heapMin) == 0
+                    && Double.compare(that.heapMax, heapMax) == 0
+                    && Double.compare(that.heapAvg, heapAvg) == 0
+                    && Double.compare(that.gcMin, gcMin) == 0
+                    && Double.compare(that.gcMax, gcMax) == 0
+                    && Double.compare(that.gcAvg, gcAvg) == 0
+                    && Double.compare(that.cpuMin, cpuMin) == 0
+                    && Double.compare(that.cpuMax, cpuMax) == 0
+                    && Double.compare(that.cpuAvg, cpuAvg) == 0
+                    && vtTotal == that.vtTotal
+                    && leakCount == that.leakCount
+                    && java.util.Objects.equals(worstTarget, that.worstTarget)
+                    && java.util.Objects.equals(worstReason, that.worstReason);
+        }
+
+        @Override
+        public int hashCode() {
+            return java.util.Objects.hash(heapMin, heapMax, heapAvg, gcMin, gcMax, gcAvg,
+                    cpuMin, cpuMax, cpuAvg, vtTotal, leakCount, worstTarget, worstReason);
+        }
+
+        @Override
+        public String toString() {
+            return "AggregateStats[heapMin=" + heapMin + ", heapMax=" + heapMax + ", heapAvg=" + heapAvg
+                    + ", gcMin=" + gcMin + ", gcMax=" + gcMax + ", gcAvg=" + gcAvg
+                    + ", cpuMin=" + cpuMin + ", cpuMax=" + cpuMax + ", cpuAvg=" + cpuAvg
+                    + ", vtTotal=" + vtTotal + ", leakCount=" + leakCount
+                    + ", worstTarget=" + worstTarget + ", worstReason=" + worstReason + "]";
+        }
     }
 }

--- a/argus-cli/src/main/java/io/argus/cli/command/AlertCommand.java
+++ b/argus-cli/src/main/java/io/argus/cli/command/AlertCommand.java
@@ -208,7 +208,18 @@ public final class AlertCommand implements Command {
         return new ConfigResult(target, interval, webhook, rules);
     }
 
-    private record ConfigResult(String target, int interval, String webhook, List<AlertRule> rules) {}
+    private static final class ConfigResult {
+        final String target;
+        final int interval;
+        final String webhook;
+        final List<AlertRule> rules;
+        ConfigResult(String target, int interval, String webhook, List<AlertRule> rules) {
+            this.target = target;
+            this.interval = interval;
+            this.webhook = webhook;
+            this.rules = rules;
+        }
+    }
 
     // ── Help ────────────────────────────────────────────────────────────────
 

--- a/argus-cli/src/main/java/io/argus/cli/command/CiCommand.java
+++ b/argus-cli/src/main/java/io/argus/cli/command/CiCommand.java
@@ -66,10 +66,10 @@ public final class CiCommand implements Command {
         if ("critical".equals(failOn) && exitCode == 1) exitCode = 0; // warnings OK
 
         switch (format) {
-            case "github-annotations" -> printGitHubAnnotations(findings);
-            case "json" -> printJson(findings, exitCode);
-            case "junit" -> printJunit(findings);
-            default -> printSummary(findings, exitCode);
+            case "github-annotations": printGitHubAnnotations(findings); break;
+            case "json": printJson(findings, exitCode); break;
+            case "junit": printJunit(findings); break;
+            default: printSummary(findings, exitCode); break;
         }
 
         if (exitCode > 0) throw new CommandExitException(exitCode);
@@ -92,11 +92,12 @@ public final class CiCommand implements Command {
 
     private void printGitHubAnnotations(List<Finding> findings) {
         for (Finding f : findings) {
-            String level = switch (f.severity()) {
-                case CRITICAL -> "error";
-                case WARNING -> "warning";
-                case INFO -> "notice";
-            };
+            String level;
+            switch (f.severity()) {
+                case CRITICAL: level = "error";   break;
+                case WARNING:  level = "warning"; break;
+                default:       level = "notice";  break;
+            }
             // GitHub Actions annotation format
             System.out.println("::" + level + " title=Argus " + f.category() + "::" + f.title());
             if (!f.detail().isEmpty()) {

--- a/argus-cli/src/main/java/io/argus/cli/command/ClassLeakCommand.java
+++ b/argus-cli/src/main/java/io/argus/cli/command/ClassLeakCommand.java
@@ -16,6 +16,7 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.util.Comparator;
 import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * Classloader-level metaspace leak attribution.
@@ -150,7 +151,7 @@ public final class ClassLeakCommand implements Command {
         List<ClassLoaderEntry> sorted = entries.stream()
                 .sorted(Comparator.comparingLong(ClassLoaderEntry::classCount).reversed())
                 .limit(top)
-                .toList();
+                .collect(Collectors.toList());
 
         long totalClasses = entries.stream().mapToLong(ClassLoaderEntry::classCount).sum();
         long totalChunk   = entries.stream().mapToLong(ClassLoaderEntry::chunkBytes).sum();
@@ -227,7 +228,7 @@ public final class ClassLeakCommand implements Command {
         List<ClassLeakDiff.Row> changed = diff.rows().stream()
                 .filter(r -> r.delta() != 0 || r.isNew())
                 .sorted(Comparator.comparingLong(ClassLeakDiff.Row::delta).reversed())
-                .toList();
+                .collect(Collectors.toList());
 
         if (changed.isEmpty()) {
             System.out.println(RichRenderer.boxLine(
@@ -235,11 +236,12 @@ public final class ClassLeakCommand implements Command {
         } else {
             for (ClassLeakDiff.Row row : changed) {
                 long delta = row.delta();
-                String sev = switch (row.severity()) {
-                    case CRITICAL -> red + "[CRITICAL]" + reset;
-                    case WARNING  -> yellow + "[WARNING]" + reset;
-                    case OK       -> green + "[OK]" + reset;
-                };
+                String sev;
+                switch (row.severity()) {
+                    case CRITICAL: sev = red + "[CRITICAL]" + reset;    break;
+                    case WARNING:  sev = yellow + "[WARNING]" + reset;  break;
+                    default:       sev = green + "[OK]" + reset;        break;
+                }
                 String deltaColor = delta > 0
                         ? (row.severity() == ClassLeakDiff.Severity.CRITICAL ? red : yellow)
                         : green;
@@ -347,7 +349,7 @@ public final class ClassLeakCommand implements Command {
         List<ClassLoaderEntry> sorted = current.stream()
                 .sorted(Comparator.comparingLong(ClassLoaderEntry::classCount).reversed())
                 .limit(top)
-                .toList();
+                .collect(Collectors.toList());
 
         sb.append(bold)
           .append(RichRenderer.padRight("Type", 44))

--- a/argus-cli/src/main/java/io/argus/cli/command/ClusterCommand.java
+++ b/argus-cli/src/main/java/io/argus/cli/command/ClusterCommand.java
@@ -114,7 +114,7 @@ public final class ClusterCommand implements Command {
 
         List<CompletableFuture<InstanceMetrics>> futures = targets.stream()
                 .map(target -> fetchOne(client, target))
-                .toList();
+                .collect(java.util.stream.Collectors.toList());
 
         CompletableFuture.allOf(futures.toArray(new CompletableFuture[0])).join();
 

--- a/argus-cli/src/main/java/io/argus/cli/command/CompareCommand.java
+++ b/argus-cli/src/main/java/io/argus/cli/command/CompareCommand.java
@@ -358,12 +358,12 @@ public final class CompareCommand implements Command {
         for (int i = 0; i < s.length(); i++) {
             char c = s.charAt(i);
             switch (c) {
-                case '"' -> sb.append("\\\"");
-                case '\\' -> sb.append("\\\\");
-                case '\n' -> sb.append("\\n");
-                case '\r' -> sb.append("\\r");
-                case '\t' -> sb.append("\\t");
-                default -> { if (c < 0x20) sb.append(String.format("\\u%04x", (int) c)); else sb.append(c); }
+                case '"': sb.append("\\\""); break;
+                case '\\': sb.append("\\\\"); break;
+                case '\n': sb.append("\\n"); break;
+                case '\r': sb.append("\\r"); break;
+                case '\t': sb.append("\\t"); break;
+                default: if (c < 0x20) sb.append(String.format("\\u%04x", (int) c)); else sb.append(c); break;
             }
         }
         return sb.toString();

--- a/argus-cli/src/main/java/io/argus/cli/command/DiffCommand.java
+++ b/argus-cli/src/main/java/io/argus/cli/command/DiffCommand.java
@@ -212,14 +212,33 @@ public final class DiffCommand implements Command {
     /**
      * Immutable record representing a single class's heap growth between two snapshots.
      */
-    private record DiffEntry(
-            String className,
-            long instancesBefore,
-            long instancesAfter,
-            long instancesDelta,
-            long bytesBefore,
-            long bytesAfter,
-            long bytesDelta,
-            double growthPercent
-    ) {}
+    private static final class DiffEntry {
+        final String className;
+        final long instancesBefore;
+        final long instancesAfter;
+        final long instancesDelta;
+        final long bytesBefore;
+        final long bytesAfter;
+        final long bytesDelta;
+        final double growthPercent;
+        DiffEntry(String className, long instancesBefore, long instancesAfter, long instancesDelta,
+                  long bytesBefore, long bytesAfter, long bytesDelta, double growthPercent) {
+            this.className = className;
+            this.instancesBefore = instancesBefore;
+            this.instancesAfter = instancesAfter;
+            this.instancesDelta = instancesDelta;
+            this.bytesBefore = bytesBefore;
+            this.bytesAfter = bytesAfter;
+            this.bytesDelta = bytesDelta;
+            this.growthPercent = growthPercent;
+        }
+        String className() { return className; }
+        long instancesBefore() { return instancesBefore; }
+        long instancesAfter() { return instancesAfter; }
+        long instancesDelta() { return instancesDelta; }
+        long bytesBefore() { return bytesBefore; }
+        long bytesAfter() { return bytesAfter; }
+        long bytesDelta() { return bytesDelta; }
+        double growthPercent() { return growthPercent; }
+    }
 }

--- a/argus-cli/src/main/java/io/argus/cli/command/DoctorCommand.java
+++ b/argus-cli/src/main/java/io/argus/cli/command/DoctorCommand.java
@@ -207,11 +207,12 @@ public final class DoctorCommand implements Command {
 
             // Each finding
             for (Finding f : findings) {
-                String sevColor = switch (f.severity()) {
-                    case CRITICAL -> AnsiStyle.style(c, AnsiStyle.RED, AnsiStyle.BOLD);
-                    case WARNING -> AnsiStyle.style(c, AnsiStyle.YELLOW, AnsiStyle.BOLD);
-                    case INFO -> AnsiStyle.style(c, AnsiStyle.CYAN);
-                };
+                String sevColor;
+                switch (f.severity()) {
+                    case CRITICAL: sevColor = AnsiStyle.style(c, AnsiStyle.RED, AnsiStyle.BOLD);    break;
+                    case WARNING:  sevColor = AnsiStyle.style(c, AnsiStyle.YELLOW, AnsiStyle.BOLD); break;
+                    default:       sevColor = AnsiStyle.style(c, AnsiStyle.CYAN);                   break;
+                }
 
                 // Title line with icon
                 System.out.println(RichRenderer.boxLine(
@@ -278,11 +279,12 @@ public final class DoctorCommand implements Command {
                                 + AnsiStyle.style(c, AnsiStyle.RESET), WIDTH));
             } else {
                 for (Finding f : profileFindings) {
-                    String sevColor = switch (f.severity()) {
-                        case CRITICAL -> AnsiStyle.style(c, AnsiStyle.RED, AnsiStyle.BOLD);
-                        case WARNING  -> AnsiStyle.style(c, AnsiStyle.YELLOW, AnsiStyle.BOLD);
-                        case INFO     -> AnsiStyle.style(c, AnsiStyle.CYAN);
-                    };
+                    String sevColor;
+                    switch (f.severity()) {
+                        case CRITICAL: sevColor = AnsiStyle.style(c, AnsiStyle.RED, AnsiStyle.BOLD);    break;
+                        case WARNING:  sevColor = AnsiStyle.style(c, AnsiStyle.YELLOW, AnsiStyle.BOLD); break;
+                        default:       sevColor = AnsiStyle.style(c, AnsiStyle.CYAN);                   break;
+                    }
                     System.out.println(RichRenderer.boxLine(
                             "  " + sevColor + f.severity().icon() + " " + f.severity().label()
                                     + ": " + f.title()
@@ -349,11 +351,11 @@ public final class DoctorCommand implements Command {
                 lines.add(current.toString());
                 current = new StringBuilder(word);
             } else {
-                if (!current.isEmpty()) current.append(' ');
+                if (current.length() > 0) current.append(' ');
                 current.append(word);
             }
         }
-        if (!current.isEmpty()) lines.add(current.toString());
+        if (current.length() > 0) lines.add(current.toString());
         return lines;
     }
 

--- a/argus-cli/src/main/java/io/argus/cli/command/DynLibsCommand.java
+++ b/argus-cli/src/main/java/io/argus/cli/command/DynLibsCommand.java
@@ -60,9 +60,9 @@ public final class DynLibsCommand implements Command {
         int jdkCount = 0, appCount = 0, sysCount = 0;
         for (DynLibsResult.LibInfo lib : result.libraries()) {
             switch (lib.category()) {
-                case "jdk" -> jdkCount++;
-                case "app" -> appCount++;
-                default -> sysCount++;
+                case "jdk": jdkCount++; break;
+                case "app": appCount++; break;
+                default: sysCount++; break;
             }
         }
 

--- a/argus-cli/src/main/java/io/argus/cli/command/GcLogCommand.java
+++ b/argus-cli/src/main/java/io/argus/cli/command/GcLogCommand.java
@@ -324,11 +324,12 @@ public final class GcLogCommand implements Command {
 
             for (int i = 0; i < a.recommendations().size(); i++) {
                 var rec = a.recommendations().get(i);
-                String sevColor = switch (rec.severity()) {
-                    case "CRITICAL" -> AnsiStyle.style(c, AnsiStyle.RED, AnsiStyle.BOLD);
-                    case "WARNING" -> AnsiStyle.style(c, AnsiStyle.YELLOW, AnsiStyle.BOLD);
-                    default -> AnsiStyle.style(c, AnsiStyle.CYAN);
-                };
+                String sevColor;
+                switch (rec.severity()) {
+                    case "CRITICAL": sevColor = AnsiStyle.style(c, AnsiStyle.RED, AnsiStyle.BOLD);    break;
+                    case "WARNING":  sevColor = AnsiStyle.style(c, AnsiStyle.YELLOW, AnsiStyle.BOLD); break;
+                    default:         sevColor = AnsiStyle.style(c, AnsiStyle.CYAN);                   break;
+                }
 
                 System.out.println(RichRenderer.boxLine(
                         "  " + sevColor + (i + 1) + ". " + rec.problem()
@@ -427,7 +428,7 @@ public final class GcLogCommand implements Command {
 
         // Latest age snapshot
         if (!analysis.snapshots().isEmpty()) {
-            TenuringAnalyzer.GcAgeSnapshot latest = analysis.snapshots().getLast();
+            TenuringAnalyzer.GcAgeSnapshot latest = analysis.snapshots().get(analysis.snapshots().size() - 1);
             section(c, "Latest Age Distribution (GC " + latest.gcId() + ")");
 
             var entries = latest.distribution().entries();

--- a/argus-cli/src/main/java/io/argus/cli/command/GcLogDiffCommand.java
+++ b/argus-cli/src/main/java/io/argus/cli/command/GcLogDiffCommand.java
@@ -333,5 +333,20 @@ public final class GcLogDiffCommand implements Command {
         return higherIsBetter ? pct < -thresholdPct : pct > thresholdPct;
     }
 
-    private record DeltaResult(String text, boolean regression, boolean improvement, boolean unchanged) {}
+    private static final class DeltaResult {
+        final String text;
+        final boolean regression;
+        final boolean improvement;
+        final boolean unchanged;
+        DeltaResult(String text, boolean regression, boolean improvement, boolean unchanged) {
+            this.text = text;
+            this.regression = regression;
+            this.improvement = improvement;
+            this.unchanged = unchanged;
+        }
+        String text() { return text; }
+        boolean regression() { return regression; }
+        boolean improvement() { return improvement; }
+        boolean unchanged() { return unchanged; }
+    }
 }

--- a/argus-cli/src/main/java/io/argus/cli/command/GcNewCommand.java
+++ b/argus-cli/src/main/java/io/argus/cli/command/GcNewCommand.java
@@ -154,7 +154,7 @@ public final class GcNewCommand implements Command {
         System.out.println(RichRenderer.emptyLine(WIDTH));
 
         long total = dist.survivorCapacity();
-        if (total == 0 && !entries.isEmpty()) total = entries.getLast().cumulativeBytes();
+        if (total == 0 && !entries.isEmpty()) total = entries.get(entries.size() - 1).cumulativeBytes();
 
         // Group ages >= 6 together
         long ageGe6Bytes = 0;
@@ -199,7 +199,7 @@ public final class GcNewCommand implements Command {
         // Insights
         System.out.println(RichRenderer.emptyLine(WIDTH));
         if (!entries.isEmpty() && total > 0) {
-            long age1Bytes = entries.getFirst().age() == 1 ? entries.getFirst().bytes() : 0;
+            long age1Bytes = entries.get(0).age() == 1 ? entries.get(0).bytes() : 0;
             int age1Pct = (int) (age1Bytes * 100 / total);
             if (age1Pct >= 50) {
                 System.out.println(RichRenderer.boxLine(

--- a/argus-cli/src/main/java/io/argus/cli/command/GcProfileCommand.java
+++ b/argus-cli/src/main/java/io/argus/cli/command/GcProfileCommand.java
@@ -243,7 +243,7 @@ public final class GcProfileCommand implements Command {
 
         // Insight line for the top allocator
         if (!sites.isEmpty() && profile.totalBytes() > 0) {
-            AllocationSite top1 = sites.getFirst();
+            AllocationSite top1 = sites.get(0);
             double pct = (double) top1.totalBytes() / profile.totalBytes() * 100;
             if (pct > 10) {
                 System.out.println(RichRenderer.emptyLine(WIDTH));

--- a/argus-cli/src/main/java/io/argus/cli/command/GcScoreCommand.java
+++ b/argus-cli/src/main/java/io/argus/cli/command/GcScoreCommand.java
@@ -237,10 +237,10 @@ public final class GcScoreCommand implements Command {
         String mark;
         String color;
         switch (ax.verdict()) {
-            case PASS -> { mark = "\u2713 Pass "; color = AnsiStyle.GREEN; }
-            case WARN -> { mark = "\u26A0 Warn "; color = AnsiStyle.YELLOW; }
-            case FAIL -> { mark = "\u2717 Fail "; color = AnsiStyle.RED; }
-            default   -> { mark = "\u2013 N/A  "; color = AnsiStyle.DIM;    }
+            case PASS: mark = "\u2713 Pass "; color = AnsiStyle.GREEN;  break;
+            case WARN: mark = "\u26A0 Warn "; color = AnsiStyle.YELLOW; break;
+            case FAIL: mark = "\u2717 Fail "; color = AnsiStyle.RED;    break;
+            default:   mark = "\u2013 N/A  "; color = AnsiStyle.DIM;    break;
         }
         String coloredMark = AnsiStyle.style(useColor, color) + mark + AnsiStyle.style(useColor, AnsiStyle.RESET);
         String valueStr = ax.available() ? formatValue(ax) : "-";
@@ -251,23 +251,27 @@ public final class GcScoreCommand implements Command {
     }
 
     private static String formatValue(AxisScore ax) {
-        return switch (ax.name()) {
-            case "Pause p99", "Pause tail (max)" -> String.format("%.0f %s", ax.value(), ax.unit());
-            case "Throughput", "Promotion ratio" -> String.format("%.1f%s", ax.value(), ax.unit());
-            case "Allocation rate" -> String.format("%.0f %s", ax.value(), ax.unit());
-            case "Full GC frequency", "Allocation pressure (ZGC)" -> String.format("%.2f %s", ax.value(), ax.unit());
-            default -> String.format("%.2f %s", ax.value(), ax.unit());
-        };
+        switch (ax.name()) {
+            case "Pause p99":
+            case "Pause tail (max)": return String.format("%.0f %s", ax.value(), ax.unit());
+            case "Throughput":
+            case "Promotion ratio": return String.format("%.1f%s", ax.value(), ax.unit());
+            case "Allocation rate": return String.format("%.0f %s", ax.value(), ax.unit());
+            case "Full GC frequency":
+            case "Allocation pressure (ZGC)": return String.format("%.2f %s", ax.value(), ax.unit());
+            default: return String.format("%.2f %s", ax.value(), ax.unit());
+        }
     }
 
     private static String gradeColor(boolean useColor, String grade) {
-        String code = switch (grade) {
-            case "A" -> AnsiStyle.GREEN;
-            case "B" -> AnsiStyle.CYAN;
-            case "C" -> AnsiStyle.YELLOW;
-            case "D" -> AnsiStyle.YELLOW;
-            default  -> AnsiStyle.RED;
-        };
+        String code;
+        switch (grade) {
+            case "A": code = AnsiStyle.GREEN;  break;
+            case "B": code = AnsiStyle.CYAN;   break;
+            case "C": code = AnsiStyle.YELLOW; break;
+            case "D": code = AnsiStyle.YELLOW; break;
+            default:  code = AnsiStyle.RED;    break;
+        }
         return AnsiStyle.style(useColor, AnsiStyle.BOLD) + AnsiStyle.style(useColor, code);
     }
 

--- a/argus-cli/src/main/java/io/argus/cli/command/GcWhyCommand.java
+++ b/argus-cli/src/main/java/io/argus/cli/command/GcWhyCommand.java
@@ -279,12 +279,12 @@ public final class GcWhyCommand implements Command {
             char last = s.charAt(s.length() - 1);
             if (Character.isDigit(last)) return Double.parseDouble(s);
             double n = Double.parseDouble(s.substring(0, s.length() - 1));
-            return switch (last) {
-                case 's' -> n;
-                case 'm' -> n * 60;
-                case 'h' -> n * 3600;
-                default -> null;
-            };
+            switch (last) {
+                case 's': return n;
+                case 'm': return n * 60;
+                case 'h': return n * 3600;
+                default: return null;
+            }
         } catch (NumberFormatException e) {
             return null;
         }

--- a/argus-cli/src/main/java/io/argus/cli/command/JmxCommand.java
+++ b/argus-cli/src/main/java/io/argus/cli/command/JmxCommand.java
@@ -43,12 +43,15 @@ public final class JmxCommand implements Command {
         System.out.println(RichRenderer.emptyLine(WIDTH));
 
         try {
-            String jcmdCommand = switch (subcommand) {
-                case "start" -> buildStartCommand(args);
-                case "start-local", "startlocal", "local" -> "ManagementAgent.start_local";
-                case "stop" -> "ManagementAgent.stop";
-                default -> "ManagementAgent.status";
-            };
+            String jcmdCommand;
+            switch (subcommand) {
+                case "start": jcmdCommand = buildStartCommand(args); break;
+                case "start-local":
+                case "startlocal":
+                case "local": jcmdCommand = "ManagementAgent.start_local"; break;
+                case "stop": jcmdCommand = "ManagementAgent.stop"; break;
+                default: jcmdCommand = "ManagementAgent.status"; break;
+            }
 
             String output = JcmdExecutor.execute(pid, jcmdCommand);
 

--- a/argus-cli/src/main/java/io/argus/cli/command/LoggerCommand.java
+++ b/argus-cli/src/main/java/io/argus/cli/command/LoggerCommand.java
@@ -167,12 +167,19 @@ public final class LoggerCommand implements Command {
     }
 
     private static String levelColor(boolean useColor, String level) {
-        return switch (level.toUpperCase()) {
-            case "ERROR", "SEVERE", "OFF" -> AnsiStyle.style(useColor, AnsiStyle.RED);
-            case "WARNING", "WARN" -> AnsiStyle.style(useColor, AnsiStyle.YELLOW);
-            case "DEBUG", "FINE", "FINER", "FINEST", "TRACE" -> AnsiStyle.style(useColor, AnsiStyle.CYAN);
-            default -> AnsiStyle.style(useColor, AnsiStyle.GREEN);
-        };
+        switch (level.toUpperCase()) {
+            case "ERROR":
+            case "SEVERE":
+            case "OFF": return AnsiStyle.style(useColor, AnsiStyle.RED);
+            case "WARNING":
+            case "WARN": return AnsiStyle.style(useColor, AnsiStyle.YELLOW);
+            case "DEBUG":
+            case "FINE":
+            case "FINER":
+            case "FINEST":
+            case "TRACE": return AnsiStyle.style(useColor, AnsiStyle.CYAN);
+            default: return AnsiStyle.style(useColor, AnsiStyle.GREEN);
+        }
     }
 
     private static void printJson(LoggerResult result, String filter) {

--- a/argus-cli/src/main/java/io/argus/cli/command/MBeanCommand.java
+++ b/argus-cli/src/main/java/io/argus/cli/command/MBeanCommand.java
@@ -240,21 +240,28 @@ public final class MBeanCommand implements Command {
 
     private String formatAttrValue(Object value) {
         if (value == null) return "null";
-        if (value instanceof CompositeData cd) {
+        if (value instanceof CompositeData) {
+            CompositeData cd = (CompositeData) value;
             StringBuilder sb = new StringBuilder();
             for (String key : cd.getCompositeType().keySet()) {
                 Object v = cd.get(key);
-                String formatted = v instanceof Long l && l > 1024 * 1024
-                        ? String.format("%,d (%s)", l, RichRenderer.formatBytes(l))
-                        : String.valueOf(v);
+                String formatted;
+                if (v instanceof Long && ((Long) v) > 1024 * 1024) {
+                    long l = (Long) v;
+                    formatted = String.format("%,d (%s)", l, RichRenderer.formatBytes(l));
+                } else {
+                    formatted = String.valueOf(v);
+                }
                 sb.append(key).append(" = ").append(formatted).append('\n');
             }
             return sb.toString().stripTrailing();
         }
-        if (value instanceof TabularData td) {
+        if (value instanceof TabularData) {
+            TabularData td = (TabularData) value;
             StringBuilder sb = new StringBuilder();
             for (Object row : td.values()) {
-                if (row instanceof CompositeData cd) {
+                if (row instanceof CompositeData) {
+                    CompositeData cd = (CompositeData) row;
                     for (String key : cd.getCompositeType().keySet()) {
                         sb.append(key).append("=").append(cd.get(key)).append("  ");
                     }
@@ -263,10 +270,12 @@ public final class MBeanCommand implements Command {
             }
             return sb.toString().stripTrailing();
         }
-        if (value instanceof long[] la) {
+        if (value instanceof long[]) {
+            long[] la = (long[]) value;
             return "length=" + la.length;
         }
-        if (value instanceof Long l && l > 1024 * 1024) {
+        if (value instanceof Long && ((Long) value) > 1024 * 1024) {
+            long l = (Long) value;
             return String.format("%,d (%s)", l, RichRenderer.formatBytes(l));
         }
         return String.valueOf(value);
@@ -314,5 +323,17 @@ public final class MBeanCommand implements Command {
         }
     }
 
-    private record AttrEntry(String name, String type, String value) {}
+    private static final class AttrEntry {
+        final String name;
+        final String type;
+        final String value;
+        AttrEntry(String name, String type, String value) {
+            this.name = name;
+            this.type = type;
+            this.value = value;
+        }
+        String name() { return name; }
+        String type() { return type; }
+        String value() { return value; }
+    }
 }

--- a/argus-cli/src/main/java/io/argus/cli/command/PerfCounterCommand.java
+++ b/argus-cli/src/main/java/io/argus/cli/command/PerfCounterCommand.java
@@ -188,5 +188,14 @@ public final class PerfCounterCommand implements Command {
         System.out.println(sb);
     }
 
-    private record Counter(String name, String value) {}
+    private static final class Counter {
+        final String name;
+        final String value;
+        Counter(String name, String value) {
+            this.name = name;
+            this.value = value;
+        }
+        String name() { return name; }
+        String value() { return value; }
+    }
 }

--- a/argus-cli/src/main/java/io/argus/cli/command/PoolCommand.java
+++ b/argus-cli/src/main/java/io/argus/cli/command/PoolCommand.java
@@ -110,22 +110,23 @@ public final class PoolCommand implements Command {
     }
 
     private static String getStateColor(boolean useColor, String state) {
-        return switch (state) {
-            case "RUNNABLE" -> AnsiStyle.style(useColor, AnsiStyle.GREEN);
-            case "BLOCKED" -> AnsiStyle.style(useColor, AnsiStyle.RED);
-            case "WAITING", "TIMED_WAITING" -> AnsiStyle.style(useColor, AnsiStyle.YELLOW);
-            default -> "";
-        };
+        switch (state) {
+            case "RUNNABLE": return AnsiStyle.style(useColor, AnsiStyle.GREEN);
+            case "BLOCKED": return AnsiStyle.style(useColor, AnsiStyle.RED);
+            case "WAITING":
+            case "TIMED_WAITING": return AnsiStyle.style(useColor, AnsiStyle.YELLOW);
+            default: return "";
+        }
     }
 
     private static String abbreviateState(String state) {
-        return switch (state) {
-            case "RUNNABLE" -> "RUN";
-            case "BLOCKED" -> "BLK";
-            case "WAITING" -> "WAIT";
-            case "TIMED_WAITING" -> "TWAIT";
-            default -> state;
-        };
+        switch (state) {
+            case "RUNNABLE": return "RUN";
+            case "BLOCKED": return "BLK";
+            case "WAITING": return "WAIT";
+            case "TIMED_WAITING": return "TWAIT";
+            default: return state;
+        }
     }
 
     private static void printJson(PoolResult result) {

--- a/argus-cli/src/main/java/io/argus/cli/command/ProfileCommand.java
+++ b/argus-cli/src/main/java/io/argus/cli/command/ProfileCommand.java
@@ -1010,11 +1010,12 @@ public final class ProfileCommand implements Command {
         int limit = Math.min(top, deltas.size());
         for (int i = 0; i < limit; i++) {
             ProfileSnapshot.DiffEntry de = deltas.get(i);
-            String suffix = switch (de.state()) {
-                case "new"  -> " (NEW)";
-                case "gone" -> " (GONE)";
-                default     -> "";
-            };
+            String suffix;
+            switch (de.state()) {
+                case "new":  suffix = " (NEW)";  break;
+                case "gone": suffix = " (GONE)"; break;
+                default:     suffix = "";         break;
+            }
             String methodDisplay = RichRenderer.truncate(de.method() + suffix, 42);
             String deltaColor = de.deltaSamples() > 0 ? red : (de.deltaSamples() < 0 ? green : "");
             String sign = de.deltaSamples() >= 0 ? "+" : "";

--- a/argus-cli/src/main/java/io/argus/cli/command/ProfileGateCommand.java
+++ b/argus-cli/src/main/java/io/argus/cli/command/ProfileGateCommand.java
@@ -12,6 +12,7 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * CI/CD gate command that compares two profile snapshots and exits non-zero on regression.
@@ -155,7 +156,7 @@ public final class ProfileGateCommand implements Command {
         List<RegressionEntry> failing = regressions.stream()
                 .filter(r -> r.deltaPp >= thresh
                         && Math.abs(r.de.deltaSamples()) >= threshSamples)
-                .toList();
+                .collect(Collectors.toList());
 
         // Pass iff no threshold violations; also fail when total (any) regressions > maxRegressions
         boolean gatePass = baselineOnly || failing.isEmpty();
@@ -414,10 +415,18 @@ public final class ProfileGateCommand implements Command {
     // Internal record
     // -------------------------------------------------------------------------
 
-    private record RegressionEntry(ProfileSnapshot.DiffEntry de,
-                                   double beforePct,
-                                   double afterPct,
-                                   double deltaPp) {}
+    private static final class RegressionEntry {
+        final ProfileSnapshot.DiffEntry de;
+        final double beforePct;
+        final double afterPct;
+        final double deltaPp;
+        RegressionEntry(ProfileSnapshot.DiffEntry de, double beforePct, double afterPct, double deltaPp) {
+            this.de = de;
+            this.beforePct = beforePct;
+            this.afterPct = afterPct;
+            this.deltaPp = deltaPp;
+        }
+    }
 
     // -------------------------------------------------------------------------
     // Utilities

--- a/argus-cli/src/main/java/io/argus/cli/command/SlowlogCommand.java
+++ b/argus-cli/src/main/java/io/argus/cli/command/SlowlogCommand.java
@@ -10,10 +10,10 @@ import jdk.jfr.consumer.RecordedEvent;
 import jdk.jfr.consumer.RecordedFrame;
 import jdk.jfr.consumer.RecordedMethod;
 import jdk.jfr.consumer.RecordedStackTrace;
-import jdk.jfr.consumer.RecordingStream;
 
 import java.time.Duration;
 import java.io.IOException;
+import java.lang.reflect.Method;
 
 /**
  * Real-time slow method detection via JFR streaming.
@@ -92,38 +92,60 @@ public final class SlowlogCommand implements Command {
 
     private void streamLocal(long thresholdMs, String filter, int durationSec,
                              boolean useColor, boolean json) {
-        try (RecordingStream rs = new RecordingStream()) {
-            rs.enable("jdk.ExecutionSample").withPeriod(Duration.ofMillis(20));
-            rs.enable("jdk.JavaMonitorEnter").withThreshold(Duration.ofMillis(thresholdMs));
-            rs.enable("jdk.ThreadSleep").withThreshold(Duration.ofMillis(thresholdMs));
-            rs.enable("jdk.FileRead").withThreshold(Duration.ofMillis(thresholdMs));
-            rs.enable("jdk.FileWrite").withThreshold(Duration.ofMillis(thresholdMs));
-            rs.enable("jdk.SocketRead").withThreshold(Duration.ofMillis(thresholdMs));
-            rs.enable("jdk.SocketWrite").withThreshold(Duration.ofMillis(thresholdMs));
+        int feature = Runtime.version().feature();
+        if (feature < 14) {
+            System.err.println("argus slowlog: requires Java 14+ runtime (current: Java " + feature + ").");
+            System.err.println("This command uses jdk.jfr.consumer.RecordingStream which was added in Java 14.");
+            System.err.println("Most other argus commands work on Java 11+; only argus slowlog requires 14+.");
+            return;
+        }
+        // RecordingStream is loaded reflectively to keep this source file compatible with --release 11.
+        try {
+            Class<?> rsClass = Class.forName("jdk.jfr.consumer.RecordingStream");
+            // RecordingStream implements AutoCloseable
+            try (AutoCloseable rs = (AutoCloseable) rsClass.getConstructor().newInstance()) {
+                Method enable = rsClass.getMethod("enable", String.class);
+                Class<?> esClass = enable.getReturnType(); // EventSettings
+                Method withPeriod = esClass.getMethod("withPeriod", Duration.class);
+                Method withThreshold = esClass.getMethod("withThreshold", Duration.class);
 
-            final String f = filter;
-            rs.onEvent(event -> {
-                String method = extractMethod(event);
-                if (method.isEmpty()) return;
-                if (!f.isEmpty() && !matchesFilter(method, f)) return;
+                withPeriod.invoke(enable.invoke(rs, "jdk.ExecutionSample"), Duration.ofMillis(20));
+                withThreshold.invoke(enable.invoke(rs, "jdk.JavaMonitorEnter"), Duration.ofMillis(thresholdMs));
+                withThreshold.invoke(enable.invoke(rs, "jdk.ThreadSleep"), Duration.ofMillis(thresholdMs));
+                withThreshold.invoke(enable.invoke(rs, "jdk.FileRead"), Duration.ofMillis(thresholdMs));
+                withThreshold.invoke(enable.invoke(rs, "jdk.FileWrite"), Duration.ofMillis(thresholdMs));
+                withThreshold.invoke(enable.invoke(rs, "jdk.SocketRead"), Duration.ofMillis(thresholdMs));
+                withThreshold.invoke(enable.invoke(rs, "jdk.SocketWrite"), Duration.ofMillis(thresholdMs));
 
-                long durationMs = event.getDuration().toMillis();
-                if (durationMs < thresholdMs && !event.getEventType().getName().equals("jdk.ExecutionSample")) return;
+                final String f = filter;
+                final AutoCloseable rsRef = rs;
+                // onEvent(RecordedEvent consumer)
+                Method onEvent = rsClass.getMethod("onEvent", java.util.function.Consumer.class);
+                onEvent.invoke(rs, (java.util.function.Consumer<RecordedEvent>) event -> {
+                    String method = extractMethod(event);
+                    if (method.isEmpty()) return;
+                    if (!f.isEmpty() && !matchesFilter(method, f)) return;
 
-                String tag = categorize(event.getEventType().getName(), method);
-                printEvent(method, durationMs, tag, event.getEventType().getName(), useColor, json);
-            });
+                    long durationMs = event.getDuration().toMillis();
+                    if (durationMs < thresholdMs && !event.getEventType().getName().equals("jdk.ExecutionSample")) return;
 
-            if (durationSec > 0) {
-                Thread.ofPlatform().daemon(true).start(() -> {
-                    try {
-                        Thread.sleep(durationSec * 1000L);
-                        rs.close();
-                    } catch (InterruptedException ignored) {}
+                    String tag = categorize(event.getEventType().getName(), method);
+                    printEvent(method, durationMs, tag, event.getEventType().getName(), useColor, json);
                 });
-            }
 
-            rs.start();
+                if (durationSec > 0) {
+                    Thread t = new Thread(() -> {
+                        try {
+                            Thread.sleep(durationSec * 1000L);
+                            rsRef.close();
+                        } catch (Exception ignored) {}
+                    });
+                    t.setDaemon(true);
+                    t.start();
+                }
+
+                rsClass.getMethod("start").invoke(rs);
+            }
         } catch (Exception e) {
             System.err.println("JFR streaming error: " + e.getMessage());
         }
@@ -187,7 +209,7 @@ public final class SlowlogCommand implements Command {
     private static String extractMethod(RecordedEvent event) {
         RecordedStackTrace stack = event.getStackTrace();
         if (stack == null || stack.getFrames().isEmpty()) return "";
-        RecordedFrame frame = stack.getFrames().getFirst();
+        RecordedFrame frame = stack.getFrames().get(0);
         RecordedMethod method = frame.getMethod();
         if (method == null) return "";
         return method.getType().getName() + "." + method.getName();
@@ -199,20 +221,22 @@ public final class SlowlogCommand implements Command {
     }
 
     private static String categorize(String eventType, String method) {
-        return switch (eventType) {
-            case "jdk.JavaMonitorEnter" -> "\u26a0 Lock";
-            case "jdk.FileRead", "jdk.FileWrite" -> "\u26a0 I/O";
-            case "jdk.SocketRead", "jdk.SocketWrite" -> "\u26a0 Network";
-            case "jdk.ThreadSleep" -> "Sleep";
-            default -> {
+        switch (eventType) {
+            case "jdk.JavaMonitorEnter": return "\u26a0 Lock";
+            case "jdk.FileRead":
+            case "jdk.FileWrite": return "\u26a0 I/O";
+            case "jdk.SocketRead":
+            case "jdk.SocketWrite": return "\u26a0 Network";
+            case "jdk.ThreadSleep": return "Sleep";
+            default: {
                 String lower = method.toLowerCase();
                 if (lower.contains("jdbc") || lower.contains("sql") || lower.contains("datasource"))
-                    yield "\u26a0 SQL?";
+                    return "\u26a0 SQL?";
                 if (lower.contains("http") || lower.contains("socket") || lower.contains("rest"))
-                    yield "\u26a0 Network?";
-                yield "";
+                    return "\u26a0 Network?";
+                return "";
             }
-        };
+        }
     }
 
     private static void printEvent(String method, long durationMs, String tag,

--- a/argus-cli/src/main/java/io/argus/cli/command/SpringCommand.java
+++ b/argus-cli/src/main/java/io/argus/cli/command/SpringCommand.java
@@ -401,10 +401,11 @@ public final class SpringCommand implements Command {
     private long getLongAttr(MBeanServerConnection mbs, ObjectName on, String attr) {
         try {
             Object val = mbs.getAttribute(on, attr);
-            if (val instanceof Number n) return n.longValue();
-            if (val instanceof CompositeData cd) {
+            if (val instanceof Number) return ((Number) val).longValue();
+            if (val instanceof CompositeData) {
+                CompositeData cd = (CompositeData) val;
                 Object v = cd.get(attr);
-                if (v instanceof Number n) return n.longValue();
+                if (v instanceof Number) return ((Number) v).longValue();
             }
             return 0;
         } catch (Exception ignored) {

--- a/argus-cli/src/main/java/io/argus/cli/command/SuggestCommand.java
+++ b/argus-cli/src/main/java/io/argus/cli/command/SuggestCommand.java
@@ -214,7 +214,7 @@ public final class SuggestCommand implements Command {
 
         // GC algorithm recommendation
         switch (profile) {
-            case "web" -> {
+            case "web": {
                 if (!gc.contains("g1") && !gc.contains("zgc")) {
                     suggestions.add(new Suggestion("GC Algorithm",
                             "Switch to G1GC for balanced latency/throughput",
@@ -231,8 +231,9 @@ public final class SuggestCommand implements Command {
                             "For heaps > 8GB, ZGC provides sub-ms pauses",
                             "-XX:+UseZGC", "Requires Java 17+"));
                 }
+                break;
             }
-            case "batch" -> {
+            case "batch": {
                 if (!gc.contains("parallel")) {
                     suggestions.add(new Suggestion("GC Algorithm",
                             "Parallel GC maximizes throughput for batch processing",
@@ -242,8 +243,9 @@ public final class SuggestCommand implements Command {
                         "Match GC threads to available processors",
                         "-XX:ParallelGCThreads=" + s.availableProcessors(),
                         s.availableProcessors() + " processors available"));
+                break;
             }
-            case "microservice" -> {
+            case "microservice": {
                 if (heapMB < 256) {
                     suggestions.add(new Suggestion("GC Algorithm",
                             "Serial GC is efficient for small heaps (<256MB)",
@@ -252,8 +254,9 @@ public final class SuggestCommand implements Command {
                 suggestions.add(new Suggestion("Class Data Sharing",
                         "Enable CDS for faster startup",
                         "-XX:SharedArchiveFile=app-cds.jsa", "Use: java -Xshare:dump first"));
+                break;
             }
-            case "streaming" -> {
+            case "streaming": {
                 if (!gc.contains("g1")) {
                     suggestions.add(new Suggestion("GC Algorithm",
                             "G1GC handles mixed workloads well for streaming",
@@ -262,15 +265,19 @@ public final class SuggestCommand implements Command {
                 suggestions.add(new Suggestion("Heap Region Size",
                         "Larger regions reduce fragmentation for steady allocation",
                         "-XX:G1HeapRegionSize=8m", "Default is auto-sized"));
+                break;
             }
-            case "general" -> {
+            case "general": {
                 // Conservative suggestions when workload is unknown
                 if (!gc.contains("g1") && heapMB > 512) {
                     suggestions.add(new Suggestion("GC Algorithm",
                             "G1GC is the safest default for general workloads",
                             "-XX:+UseG1GC", "Default since Java 9"));
                 }
+                break;
             }
+            default:
+                break;
         }
 
         // Universal recommendations based on current state
@@ -431,11 +438,12 @@ public final class SuggestCommand implements Command {
         } else {
             for (int i = 0; i < recs.size(); i++) {
                 ProfileRecommendation r = recs.get(i);
-                String confColor = switch (r.confidence()) {
-                    case HIGH -> AnsiStyle.GREEN;
-                    case MED  -> AnsiStyle.YELLOW;
-                    case LOW  -> AnsiStyle.DIM;
-                };
+                String confColor;
+                switch (r.confidence()) {
+                    case HIGH: confColor = AnsiStyle.GREEN; break;
+                    case MED:  confColor = AnsiStyle.YELLOW; break;
+                    default:   confColor = AnsiStyle.DIM; break;
+                }
                 System.out.println(RichRenderer.boxLine(
                         "  " + AnsiStyle.style(c, AnsiStyle.BOLD) + (i + 1) + ". "
                                 + r.ruleName() + AnsiStyle.style(c, AnsiStyle.RESET)
@@ -502,5 +510,20 @@ public final class SuggestCommand implements Command {
         System.out.println(sb);
     }
 
-    private record Suggestion(String area, String reason, String flag, String note) {}
+    private static final class Suggestion {
+        final String area;
+        final String reason;
+        final String flag;
+        final String note;
+        Suggestion(String area, String reason, String flag, String note) {
+            this.area = area;
+            this.reason = reason;
+            this.flag = flag;
+            this.note = note;
+        }
+        String area() { return area; }
+        String reason() { return reason; }
+        String flag() { return flag; }
+        String note() { return note; }
+    }
 }

--- a/argus-cli/src/main/java/io/argus/cli/command/ThreadDumpCommand.java
+++ b/argus-cli/src/main/java/io/argus/cli/command/ThreadDumpCommand.java
@@ -186,12 +186,13 @@ public final class ThreadDumpCommand implements Command {
     }
 
     private static String stateColor(boolean useColor, String state) {
-        return switch (state) {
-            case "RUNNABLE" -> AnsiStyle.style(useColor, AnsiStyle.GREEN);
-            case "BLOCKED" -> AnsiStyle.style(useColor, AnsiStyle.RED);
-            case "WAITING", "TIMED_WAITING" -> AnsiStyle.style(useColor, AnsiStyle.YELLOW);
-            default -> AnsiStyle.style(useColor, AnsiStyle.DIM);
-        };
+        switch (state) {
+            case "RUNNABLE": return AnsiStyle.style(useColor, AnsiStyle.GREEN);
+            case "BLOCKED": return AnsiStyle.style(useColor, AnsiStyle.RED);
+            case "WAITING":
+            case "TIMED_WAITING": return AnsiStyle.style(useColor, AnsiStyle.YELLOW);
+            default: return AnsiStyle.style(useColor, AnsiStyle.DIM);
+        }
     }
 
     private static void printJson(ThreadDumpResult result) {

--- a/argus-cli/src/main/java/io/argus/cli/command/ThreadsCommand.java
+++ b/argus-cli/src/main/java/io/argus/cli/command/ThreadsCommand.java
@@ -285,12 +285,14 @@ public final class ThreadsCommand implements Command {
                 else if (cpuPct > 20) cpuColor = AnsiStyle.style(c, AnsiStyle.YELLOW);
                 else cpuColor = AnsiStyle.style(c, AnsiStyle.GREEN);
 
-                String stateColor = switch (e.state) {
-                    case "RUNNABLE" -> AnsiStyle.style(c, AnsiStyle.GREEN);
-                    case "BLOCKED" -> AnsiStyle.style(c, AnsiStyle.RED);
-                    case "WAITING", "TIMED_WAITING" -> AnsiStyle.style(c, AnsiStyle.YELLOW);
-                    default -> AnsiStyle.style(c, AnsiStyle.DIM);
-                };
+                String stateColor;
+                switch (e.state) {
+                    case "RUNNABLE": stateColor = AnsiStyle.style(c, AnsiStyle.GREEN);  break;
+                    case "BLOCKED":  stateColor = AnsiStyle.style(c, AnsiStyle.RED);    break;
+                    case "WAITING":
+                    case "TIMED_WAITING": stateColor = AnsiStyle.style(c, AnsiStyle.YELLOW); break;
+                    default:         stateColor = AnsiStyle.style(c, AnsiStyle.DIM);    break;
+                }
 
                 String line = RichRenderer.padRight(String.valueOf(e.id), 8)
                         + cpuColor + RichRenderer.padRight(String.format("%.1f%%", cpuPct), 8)
@@ -353,7 +355,25 @@ public final class ThreadsCommand implements Command {
         System.out.println(sb);
     }
 
-    private record ThreadCpuEntry(long id, String name, String state, long cpuDelta, long totalCpu) {}
+    private static final class ThreadCpuEntry {
+        final long id;
+        final String name;
+        final String state;
+        final long cpuDelta;
+        final long totalCpu;
+        ThreadCpuEntry(long id, String name, String state, long cpuDelta, long totalCpu) {
+            this.id = id;
+            this.name = name;
+            this.state = state;
+            this.cpuDelta = cpuDelta;
+            this.totalCpu = totalCpu;
+        }
+        long id() { return id; }
+        String name() { return name; }
+        String state() { return state; }
+        long cpuDelta() { return cpuDelta; }
+        long totalCpu() { return totalCpu; }
+    }
 
     private static void printJson(ThreadResult result) {
         StringBuilder sb = new StringBuilder();

--- a/argus-cli/src/main/java/io/argus/cli/command/TraceCommand.java
+++ b/argus-cli/src/main/java/io/argus/cli/command/TraceCommand.java
@@ -147,7 +147,7 @@ public final class TraceCommand implements Command {
                         new java.io.InputStreamReader(process.getInputStream()))) {
                     String line;
                     while ((line = br.readLine()) != null) {
-                        if (!sb.isEmpty()) sb.append('\n');
+                        if (sb.length() > 0) sb.append('\n');
                         sb.append(line);
                     }
                 } catch (Exception ignored) {}

--- a/argus-cli/src/main/java/io/argus/cli/command/ZgcCommand.java
+++ b/argus-cli/src/main/java/io/argus/cli/command/ZgcCommand.java
@@ -429,9 +429,9 @@ public final class ZgcCommand implements Command {
             String severityMarker;
             String rowColor;
             switch (row.severity()) {
-                case REGRESSION -> { severityMarker = " ✘"; rowColor = red;    }
-                case WARN       -> { severityMarker = " ⚠"; rowColor = yellow; }
-                default         -> { severityMarker = "";   rowColor = reset;   }
+                case REGRESSION: severityMarker = " ✘"; rowColor = red;    break;
+                case WARN:       severityMarker = " ⚠"; rowColor = yellow; break;
+                default:         severityMarker = "";   rowColor = reset;   break;
             }
 
             String deltaDisplay = row.delta();
@@ -451,26 +451,42 @@ public final class ZgcCommand implements Command {
     }
 
     private static String rowLabel(String key, Messages messages) {
-        return switch (key) {
-            case "heapCommitted"  -> messages.get("cli.zgc.diff.row.committed");
-            case "minorCycles"    -> messages.get("cli.zgc.diff.row.cycles.minor");
-            case "majorCycles"    -> messages.get("cli.zgc.diff.row.cycles.major");
-            case "stallCount"     -> messages.get("cli.zgc.diff.row.stalls");
-            case "pauseMarkEnd"   -> messages.get("cli.zgc.diff.row.markend");
-            case "softMaxBreached"-> messages.get("cli.zgc.diff.row.softmax");
-            default               -> key;
-        };
+        switch (key) {
+            case "heapCommitted":   return messages.get("cli.zgc.diff.row.committed");
+            case "minorCycles":     return messages.get("cli.zgc.diff.row.cycles.minor");
+            case "majorCycles":     return messages.get("cli.zgc.diff.row.cycles.major");
+            case "stallCount":      return messages.get("cli.zgc.diff.row.stalls");
+            case "pauseMarkEnd":    return messages.get("cli.zgc.diff.row.markend");
+            case "softMaxBreached": return messages.get("cli.zgc.diff.row.softmax");
+            default:                return key;
+        }
     }
 
     // ── Target inspection (JMX) ─────────────────────────────────────────────
 
-    private record TargetInfo(
-            boolean usingZgc,
-            boolean generational,
-            String  gcAlgo,
-            String  jvmVersion,
-            long    maxHeapBytes,
-            long    softMaxHeapBytes) {}
+    private static final class TargetInfo {
+        final boolean usingZgc;
+        final boolean generational;
+        final String  gcAlgo;
+        final String  jvmVersion;
+        final long    maxHeapBytes;
+        final long    softMaxHeapBytes;
+        TargetInfo(boolean usingZgc, boolean generational, String gcAlgo, String jvmVersion,
+                   long maxHeapBytes, long softMaxHeapBytes) {
+            this.usingZgc = usingZgc;
+            this.generational = generational;
+            this.gcAlgo = gcAlgo;
+            this.jvmVersion = jvmVersion;
+            this.maxHeapBytes = maxHeapBytes;
+            this.softMaxHeapBytes = softMaxHeapBytes;
+        }
+        boolean usingZgc() { return usingZgc; }
+        boolean generational() { return generational; }
+        String gcAlgo() { return gcAlgo; }
+        String jvmVersion() { return jvmVersion; }
+        long maxHeapBytes() { return maxHeapBytes; }
+        long softMaxHeapBytes() { return softMaxHeapBytes; }
+    }
 
     private static TargetInfo inspectTarget(long pid) {
         boolean usingZgc = false;
@@ -529,9 +545,10 @@ public final class ZgcCommand implements Command {
             try {
                 ObjectName mem = new ObjectName("java.lang:type=Memory");
                 Object usage = mbs.getAttribute(mem, "HeapMemoryUsage");
-                if (usage instanceof CompositeData cd) {
+                if (usage instanceof CompositeData) {
+                    CompositeData cd = (CompositeData) usage;
                     Object max = cd.get("max");
-                    if (max instanceof Number n) maxHeap = n.longValue();
+                    if (max instanceof Number) maxHeap = ((Number) max).longValue();
                 }
             } catch (Exception ignored) {}
 
@@ -540,7 +557,8 @@ public final class ZgcCommand implements Command {
                 Object res = mbs.invoke(diag, "getVMOption",
                         new Object[]{"SoftMaxHeapSize"},
                         new String[]{"java.lang.String"});
-                if (res instanceof CompositeData cd) {
+                if (res instanceof CompositeData) {
+                    CompositeData cd = (CompositeData) res;
                     Object v = cd.get("value");
                     if (v != null) {
                         try {
@@ -654,11 +672,12 @@ public final class ZgcCommand implements Command {
         System.out.println();
 
         // Verdict line
-        String verdictColor = switch (verdict) {
-            case HEALTHY   -> grn;
-            case WARNING   -> yel;
-            case UNHEALTHY -> red;
-        };
+        String verdictColor;
+        switch (verdict) {
+            case HEALTHY:   verdictColor = grn; break;
+            case WARNING:   verdictColor = yel; break;
+            default:        verdictColor = red; break;
+        }
         String verdictReason = verdictReason(verdict, d, messages);
         System.out.println(bold + messages.get("cli.zgc.verdict.label") + " " + reset
                 + verdictColor + bold + verdict.name() + reset
@@ -673,25 +692,26 @@ public final class ZgcCommand implements Command {
     }
 
     private static String verdictReason(ZgcDiagnosis.Verdict v, ZgcDiagnosis d, Messages messages) {
-        return switch (v) {
-            case HEALTHY -> messages.get("cli.zgc.verdict.healthy");
-            case WARNING -> {
+        switch (v) {
+            case HEALTHY:
+                return messages.get("cli.zgc.verdict.healthy");
+            case WARNING: {
                 if (d.softMaxBreached && d.pauseMarkEndMs > 1.0) {
-                    yield messages.get("cli.zgc.verdict.warning.both");
+                    return messages.get("cli.zgc.verdict.warning.both");
                 }
-                if (d.softMaxBreached) yield messages.get("cli.zgc.verdict.warning.softmax");
-                yield messages.get("cli.zgc.verdict.warning.pause");
+                if (d.softMaxBreached) return messages.get("cli.zgc.verdict.warning.softmax");
+                return messages.get("cli.zgc.verdict.warning.pause");
             }
-            case UNHEALTHY -> {
+            default: {
                 if (!d.stalls.isEmpty() && d.cycleOverlap) {
-                    yield messages.get("cli.zgc.verdict.unhealthy.stalls.overlap");
+                    return messages.get("cli.zgc.verdict.unhealthy.stalls.overlap");
                 }
-                if (!d.stalls.isEmpty()) yield d.softMaxBreached
+                if (!d.stalls.isEmpty()) return d.softMaxBreached
                         ? messages.get("cli.zgc.verdict.unhealthy.stalls.softmax")
                         : messages.get("cli.zgc.verdict.unhealthy.stalls");
-                yield messages.get("cli.zgc.verdict.unhealthy.overlap");
+                return messages.get("cli.zgc.verdict.unhealthy.overlap");
             }
-        };
+        }
     }
 
     private static List<String> recommendations(ZgcDiagnosis d, Messages messages) {

--- a/argus-cli/src/main/java/io/argus/cli/doctor/DoctorEngine.java
+++ b/argus-cli/src/main/java/io/argus/cli/doctor/DoctorEngine.java
@@ -5,6 +5,7 @@ import io.argus.cli.doctor.rules.*;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * The doctor engine: collects JVM snapshot, runs all health rules,
@@ -85,7 +86,7 @@ public final class DoctorEngine {
         return findings.stream()
                 .flatMap(f -> f.suggestedFlags().stream())
                 .distinct()
-                .toList();
+                .collect(Collectors.toList());
     }
 
     /**

--- a/argus-cli/src/main/java/io/argus/cli/doctor/JvmSnapshotCollector.java
+++ b/argus-cli/src/main/java/io/argus/cli/doctor/JvmSnapshotCollector.java
@@ -62,7 +62,8 @@ public final class JvmSnapshotCollector {
             totalGcTime += gc.getCollectionTime();
             gcBeanNames.add(gc.getName());
             // Use com.sun.management extension to get duration of the last individual GC pause.
-            if (gc instanceof com.sun.management.GarbageCollectorMXBean sunGc) {
+            if (gc instanceof com.sun.management.GarbageCollectorMXBean) {
+                com.sun.management.GarbageCollectorMXBean sunGc = (com.sun.management.GarbageCollectorMXBean) gc;
                 com.sun.management.GcInfo lastGcInfo = sunGc.getLastGcInfo();
                 if (lastGcInfo != null) {
                     maxRecentPauseMs = Math.max(maxRecentPauseMs, lastGcInfo.getDuration());
@@ -78,9 +79,10 @@ public final class JvmSnapshotCollector {
         double processCpu = -1, systemCpu = -1;
         int processors = Runtime.getRuntime().availableProcessors();
         OperatingSystemMXBean os = ManagementFactory.getOperatingSystemMXBean();
-        if (os instanceof com.sun.management.OperatingSystemMXBean sunOs) {
+        if (os instanceof com.sun.management.OperatingSystemMXBean) {
+            com.sun.management.OperatingSystemMXBean sunOs = (com.sun.management.OperatingSystemMXBean) os;
             processCpu = sunOs.getProcessCpuLoad();
-            systemCpu = sunOs.getCpuLoad();
+            systemCpu = sunOs.getSystemCpuLoad();
         }
 
         Map<String, Integer> threadStates = new LinkedHashMap<>();
@@ -392,7 +394,14 @@ public final class JvmSnapshotCollector {
     }
 
     /** Heap-wide totals from the first summary line of GC.heap_info, if present. */
-    private record HeapTotals(long totalBytes, long usedBytes) {}
+    private static final class HeapTotals {
+        final long totalBytes;
+        final long usedBytes;
+        HeapTotals(long totalBytes, long usedBytes) {
+            this.totalBytes = totalBytes;
+            this.usedBytes = usedBytes;
+        }
+    }
 
     private static HeapTotals parseHeapTotals(String output) {
         if (output == null) return null;

--- a/argus-cli/src/main/java/io/argus/cli/doctor/ProfileRules.java
+++ b/argus-cli/src/main/java/io/argus/cli/doctor/ProfileRules.java
@@ -6,6 +6,7 @@ import io.argus.cli.model.ProfileSnapshot;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 /**
  * Profile-based diagnostic rules that analyse a {@link ProfileSnapshot} and produce
@@ -161,7 +162,7 @@ public final class ProfileRules {
             List<MethodSample> top = snap.methods().stream()
                     .sorted((a, b) -> Double.compare(b.percentage(), a.percentage()))
                     .limit(TOP_N)
-                    .toList();
+                    .collect(Collectors.toList());
 
             List<Finding> findings = new ArrayList<>();
             for (MethodSample m : top) {

--- a/argus-cli/src/main/java/io/argus/cli/export/HtmlExporter.java
+++ b/argus-cli/src/main/java/io/argus/cli/export/HtmlExporter.java
@@ -74,10 +74,10 @@ public final class HtmlExporter {
             } else {
                 char c = input.charAt(i);
                 switch (c) {
-                    case '<' -> out.append("&lt;");
-                    case '>' -> out.append("&gt;");
-                    case '&' -> out.append("&amp;");
-                    default -> out.append(c);
+                    case '<': out.append("&lt;"); break;
+                    case '>': out.append("&gt;"); break;
+                    case '&': out.append("&amp;"); break;
+                    default: out.append(c); break;
                 }
                 i++;
             }
@@ -91,23 +91,23 @@ public final class HtmlExporter {
         StringBuilder classes = new StringBuilder();
         for (String code : codes.split(";")) {
             switch (code.trim()) {
-                case "1" -> append(classes, "bold");
-                case "2" -> append(classes, "dim");
-                case "31" -> append(classes, "red");
-                case "32" -> append(classes, "green");
-                case "33" -> append(classes, "yellow");
-                case "34" -> append(classes, "blue");
-                case "35" -> append(classes, "magenta");
-                case "36" -> append(classes, "cyan");
-                case "37" -> append(classes, "white");
-                default -> {} // ignore unknown codes
+                case "1": append(classes, "bold"); break;
+                case "2": append(classes, "dim"); break;
+                case "31": append(classes, "red"); break;
+                case "32": append(classes, "green"); break;
+                case "33": append(classes, "yellow"); break;
+                case "34": append(classes, "blue"); break;
+                case "35": append(classes, "magenta"); break;
+                case "36": append(classes, "cyan"); break;
+                case "37": append(classes, "white"); break;
+                default: break; // ignore unknown codes
             }
         }
         return classes.toString();
     }
 
     private static void append(StringBuilder sb, String cls) {
-        if (!sb.isEmpty()) sb.append(' ');
+        if (sb.length() > 0) sb.append(' ');
         sb.append(cls);
     }
 

--- a/argus-cli/src/main/java/io/argus/cli/gclog/GcLeakDetector.java
+++ b/argus-cli/src/main/java/io/argus/cli/gclog/GcLeakDetector.java
@@ -20,8 +20,8 @@ public final class GcLeakDetector {
                     new double[0], 0, 0);
         }
 
-        double firstTs = pauses.getFirst().timestampSec();
-        double lastTs = pauses.getLast().timestampSec();
+        double firstTs = pauses.get(0).timestampSec();
+        double lastTs = pauses.get(pauses.size() - 1).timestampSec();
         double duration = Math.max(lastTs - firstTs, 0.001);
         double windowSize = duration / NUM_WINDOWS;
 
@@ -81,7 +81,7 @@ public final class GcLeakDetector {
 
         // OOM estimation
         long heapTotalKB = pauses.stream().mapToLong(GcEvent::heapTotalKB).max().orElse(0);
-        double lastMedian = points.getLast()[1];
+        double lastMedian = points.get(points.size() - 1)[1];
         double estimatedOomSec = -1;
         if (leakDetected && growthRateKBPerSec > 0 && heapTotalKB > lastMedian) {
             estimatedOomSec = (heapTotalKB - lastMedian) / growthRateKBPerSec;

--- a/argus-cli/src/main/java/io/argus/cli/gclog/GcLogAnalyzer.java
+++ b/argus-cli/src/main/java/io/argus/cli/gclog/GcLogAnalyzer.java
@@ -3,6 +3,7 @@ package io.argus.cli.gclog;
 import io.argus.cli.render.RichRenderer;
 
 import java.util.*;
+import java.util.stream.Collectors;
 
 /**
  * Analyzes parsed GC events and produces statistics, cause breakdown,
@@ -115,7 +116,7 @@ public final class GcLogAnalyzer {
         // Allocation Stall summary (ZGC only)
         List<GcEvent> stallEvents = events.stream()
                 .filter(e -> "ZGC Allocation Stall".equals(e.type()))
-                .toList();
+                .collect(Collectors.toList());
         GcLogAnalysis.AllocationStallSummary stallSummary = null;
         if (!stallEvents.isEmpty()) {
             double stallTotal = stallEvents.stream().mapToDouble(GcEvent::pauseMs).sum();

--- a/argus-cli/src/main/java/io/argus/cli/gclog/GcLogFollower.java
+++ b/argus-cli/src/main/java/io/argus/cli/gclog/GcLogFollower.java
@@ -199,12 +199,12 @@ public final class GcLogFollower {
     }
 
     private static long toKB(long value, String unit) {
-        return switch (unit) {
-            case "K" -> value;
-            case "M" -> value * 1024;
-            case "G" -> value * 1024 * 1024;
-            default  -> value;
-        };
+        switch (unit) {
+            case "K": return value;
+            case "M": return value * 1024;
+            case "G": return value * 1024 * 1024;
+            default:  return value;
+        }
     }
 
     public int maxEvents() { return maxEvents; }

--- a/argus-cli/src/main/java/io/argus/cli/gclog/GcLogParser.java
+++ b/argus-cli/src/main/java/io/argus/cli/gclog/GcLogParser.java
@@ -23,7 +23,37 @@ public final class GcLogParser {
     /**
      * Result container for phase-aware parsing.
      */
-    public record ParseResult(List<GcEvent> events, List<GcPhaseEvent> phases) {}
+    public static final class ParseResult {
+        private final List<GcEvent> events;
+        private final List<GcPhaseEvent> phases;
+
+        public ParseResult(List<GcEvent> events, List<GcPhaseEvent> phases) {
+            this.events = events;
+            this.phases = phases;
+        }
+
+        public List<GcEvent> events() { return events; }
+        public List<GcPhaseEvent> phases() { return phases; }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (!(o instanceof ParseResult)) return false;
+            ParseResult that = (ParseResult) o;
+            return java.util.Objects.equals(events, that.events)
+                    && java.util.Objects.equals(phases, that.phases);
+        }
+
+        @Override
+        public int hashCode() {
+            return java.util.Objects.hash(events, phases);
+        }
+
+        @Override
+        public String toString() {
+            return "ParseResult[events=" + events + ", phases=" + phases + "]";
+        }
+    }
 
     /**
      * Parse GC log file and also extract phase breakdown from debug gc,phases lines.
@@ -239,12 +269,12 @@ public final class GcLogParser {
     }
 
     private static long toKB(long value, String unit) {
-        return switch (unit) {
-            case "K" -> value;
-            case "M" -> value * 1024L;
-            case "G" -> value * 1024L * 1024L;
-            case "T" -> value * 1024L * 1024L * 1024L;
-            default -> value;
-        };
+        switch (unit) {
+            case "K": return value;
+            case "M": return value * 1024L;
+            case "G": return value * 1024L * 1024L;
+            case "T": return value * 1024L * 1024L * 1024L;
+            default: return value;
+        }
     }
 }

--- a/argus-cli/src/main/java/io/argus/cli/gclog/GcPhaseAnalyzer.java
+++ b/argus-cli/src/main/java/io/argus/cli/gclog/GcPhaseAnalyzer.java
@@ -48,7 +48,76 @@ public final class GcPhaseAnalyzer {
         return new PhaseAnalysis(Collections.unmodifiableList(stats), gcCount);
     }
 
-    public record PhaseAnalysis(List<PhaseStat> phases, int gcCount) {}
+    public static final class PhaseAnalysis {
+        private final List<PhaseStat> phases;
+        private final int gcCount;
 
-    public record PhaseStat(String phase, double avgMs, double maxMs, double percentOfTotal) {}
+        public PhaseAnalysis(List<PhaseStat> phases, int gcCount) {
+            this.phases = phases;
+            this.gcCount = gcCount;
+        }
+
+        public List<PhaseStat> phases() { return phases; }
+        public int gcCount() { return gcCount; }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (!(o instanceof PhaseAnalysis)) return false;
+            PhaseAnalysis that = (PhaseAnalysis) o;
+            return gcCount == that.gcCount
+                    && java.util.Objects.equals(phases, that.phases);
+        }
+
+        @Override
+        public int hashCode() {
+            return java.util.Objects.hash(phases, gcCount);
+        }
+
+        @Override
+        public String toString() {
+            return "PhaseAnalysis[phases=" + phases + ", gcCount=" + gcCount + "]";
+        }
+    }
+
+    public static final class PhaseStat {
+        private final String phase;
+        private final double avgMs;
+        private final double maxMs;
+        private final double percentOfTotal;
+
+        public PhaseStat(String phase, double avgMs, double maxMs, double percentOfTotal) {
+            this.phase = phase;
+            this.avgMs = avgMs;
+            this.maxMs = maxMs;
+            this.percentOfTotal = percentOfTotal;
+        }
+
+        public String phase() { return phase; }
+        public double avgMs() { return avgMs; }
+        public double maxMs() { return maxMs; }
+        public double percentOfTotal() { return percentOfTotal; }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (!(o instanceof PhaseStat)) return false;
+            PhaseStat that = (PhaseStat) o;
+            return Double.compare(that.avgMs, avgMs) == 0
+                    && Double.compare(that.maxMs, maxMs) == 0
+                    && Double.compare(that.percentOfTotal, percentOfTotal) == 0
+                    && java.util.Objects.equals(phase, that.phase);
+        }
+
+        @Override
+        public int hashCode() {
+            return java.util.Objects.hash(phase, avgMs, maxMs, percentOfTotal);
+        }
+
+        @Override
+        public String toString() {
+            return "PhaseStat[phase=" + phase + ", avgMs=" + avgMs + ", maxMs=" + maxMs
+                    + ", percentOfTotal=" + percentOfTotal + "]";
+        }
+    }
 }

--- a/argus-cli/src/main/java/io/argus/cli/gclog/GcRateAnalyzer.java
+++ b/argus-cli/src/main/java/io/argus/cli/gclog/GcRateAnalyzer.java
@@ -16,8 +16,8 @@ public final class GcRateAnalyzer {
                     new double[NUM_WINDOWS], new double[NUM_WINDOWS]);
         }
 
-        double firstTs = pauseEvents.getFirst().timestampSec();
-        double lastTs = pauseEvents.getLast().timestampSec();
+        double firstTs = pauseEvents.get(0).timestampSec();
+        double lastTs = pauseEvents.get(pauseEvents.size() - 1).timestampSec();
         double duration = Math.max(lastTs - firstTs, 0.001);
         double windowSize = duration / NUM_WINDOWS;
 

--- a/argus-cli/src/main/java/io/argus/cli/gclog/GcTimelineRenderer.java
+++ b/argus-cli/src/main/java/io/argus/cli/gclog/GcTimelineRenderer.java
@@ -4,6 +4,7 @@ import io.argus.cli.render.AnsiStyle;
 import io.argus.cli.render.RichRenderer;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * Renders an ASCII heatmap of GC pause events over time.
@@ -31,7 +32,7 @@ public final class GcTimelineRenderer {
         // Filter to only pause (non-concurrent) events
         List<GcEvent> pauses = events.stream()
                 .filter(e -> !e.isConcurrent())
-                .toList();
+                .collect(Collectors.toList());
 
         StringBuilder out = new StringBuilder();
 
@@ -44,8 +45,8 @@ public final class GcTimelineRenderer {
         // width - 4 (box border) - 7 (label + space) = width - 11, clamp min 10
         int chartWidth = Math.max(10, width - 11);
 
-        double firstTs = pauses.getFirst().timestampSec();
-        double lastTs = pauses.getLast().timestampSec();
+        double firstTs = pauses.get(0).timestampSec();
+        double lastTs = pauses.get(pauses.size() - 1).timestampSec();
         double rangeTs = lastTs - firstTs;
 
         // Handle degenerate case: all events at same timestamp

--- a/argus-cli/src/main/java/io/argus/cli/gclog/RollingGcAnalysis.java
+++ b/argus-cli/src/main/java/io/argus/cli/gclog/RollingGcAnalysis.java
@@ -92,8 +92,8 @@ public final class RollingGcAnalysis {
         double[] sorted = pauses.stream().mapToDouble(GcEvent::pauseMs).sorted().toArray();
         long totalPauseMs = (long) Arrays.stream(sorted).sum();
 
-        double firstTs = events.getFirst().timestampSec();
-        double lastTs  = events.getLast().timestampSec();
+        double firstTs = events.get(0).timestampSec();
+        double lastTs  = events.get(events.size() - 1).timestampSec();
         double durationSec = Math.max(lastTs - firstTs, 0.001);
         double throughput = Math.max(0, Math.min(100,
                 (1.0 - totalPauseMs / (durationSec * 1000)) * 100));
@@ -121,18 +121,87 @@ public final class RollingGcAnalysis {
         return sorted[Math.max(0, Math.min(idx, sorted.length - 1))];
     }
 
-    public record Snapshot(
-            long p50PauseMs,
-            long p95PauseMs,
-            long p99PauseMs,
-            long maxPauseMs,
-            long avgPauseMs,
-            long totalPauseMs,
-            double throughputPercent,
-            int fullGcCount,
-            long peakHeapKB,
-            double eventsPerSec,
-            double secsSinceLastFullGc,
-            int totalEventsEver
-    ) {}
+    public static final class Snapshot {
+        private final long p50PauseMs;
+        private final long p95PauseMs;
+        private final long p99PauseMs;
+        private final long maxPauseMs;
+        private final long avgPauseMs;
+        private final long totalPauseMs;
+        private final double throughputPercent;
+        private final int fullGcCount;
+        private final long peakHeapKB;
+        private final double eventsPerSec;
+        private final double secsSinceLastFullGc;
+        private final int totalEventsEver;
+
+        public Snapshot(long p50PauseMs, long p95PauseMs, long p99PauseMs,
+                        long maxPauseMs, long avgPauseMs, long totalPauseMs,
+                        double throughputPercent, int fullGcCount, long peakHeapKB,
+                        double eventsPerSec, double secsSinceLastFullGc,
+                        int totalEventsEver) {
+            this.p50PauseMs = p50PauseMs;
+            this.p95PauseMs = p95PauseMs;
+            this.p99PauseMs = p99PauseMs;
+            this.maxPauseMs = maxPauseMs;
+            this.avgPauseMs = avgPauseMs;
+            this.totalPauseMs = totalPauseMs;
+            this.throughputPercent = throughputPercent;
+            this.fullGcCount = fullGcCount;
+            this.peakHeapKB = peakHeapKB;
+            this.eventsPerSec = eventsPerSec;
+            this.secsSinceLastFullGc = secsSinceLastFullGc;
+            this.totalEventsEver = totalEventsEver;
+        }
+
+        public long p50PauseMs() { return p50PauseMs; }
+        public long p95PauseMs() { return p95PauseMs; }
+        public long p99PauseMs() { return p99PauseMs; }
+        public long maxPauseMs() { return maxPauseMs; }
+        public long avgPauseMs() { return avgPauseMs; }
+        public long totalPauseMs() { return totalPauseMs; }
+        public double throughputPercent() { return throughputPercent; }
+        public int fullGcCount() { return fullGcCount; }
+        public long peakHeapKB() { return peakHeapKB; }
+        public double eventsPerSec() { return eventsPerSec; }
+        public double secsSinceLastFullGc() { return secsSinceLastFullGc; }
+        public int totalEventsEver() { return totalEventsEver; }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (!(o instanceof Snapshot)) return false;
+            Snapshot that = (Snapshot) o;
+            return p50PauseMs == that.p50PauseMs
+                    && p95PauseMs == that.p95PauseMs
+                    && p99PauseMs == that.p99PauseMs
+                    && maxPauseMs == that.maxPauseMs
+                    && avgPauseMs == that.avgPauseMs
+                    && totalPauseMs == that.totalPauseMs
+                    && Double.compare(that.throughputPercent, throughputPercent) == 0
+                    && fullGcCount == that.fullGcCount
+                    && peakHeapKB == that.peakHeapKB
+                    && Double.compare(that.eventsPerSec, eventsPerSec) == 0
+                    && Double.compare(that.secsSinceLastFullGc, secsSinceLastFullGc) == 0
+                    && totalEventsEver == that.totalEventsEver;
+        }
+
+        @Override
+        public int hashCode() {
+            return java.util.Objects.hash(p50PauseMs, p95PauseMs, p99PauseMs, maxPauseMs,
+                    avgPauseMs, totalPauseMs, throughputPercent, fullGcCount, peakHeapKB,
+                    eventsPerSec, secsSinceLastFullGc, totalEventsEver);
+        }
+
+        @Override
+        public String toString() {
+            return "Snapshot[p50PauseMs=" + p50PauseMs + ", p95PauseMs=" + p95PauseMs
+                    + ", p99PauseMs=" + p99PauseMs + ", maxPauseMs=" + maxPauseMs
+                    + ", avgPauseMs=" + avgPauseMs + ", totalPauseMs=" + totalPauseMs
+                    + ", throughputPercent=" + throughputPercent + ", fullGcCount=" + fullGcCount
+                    + ", peakHeapKB=" + peakHeapKB + ", eventsPerSec=" + eventsPerSec
+                    + ", secsSinceLastFullGc=" + secsSinceLastFullGc
+                    + ", totalEventsEver=" + totalEventsEver + "]";
+        }
+    }
 }

--- a/argus-cli/src/main/java/io/argus/cli/gclog/TenuringAnalyzer.java
+++ b/argus-cli/src/main/java/io/argus/cli/gclog/TenuringAnalyzer.java
@@ -30,25 +30,114 @@ public final class TenuringAnalyzer {
     /**
      * Result of tenuring log analysis.
      */
-    public record TenuringAnalysis(
-            List<GcAgeSnapshot> snapshots,
-            List<String> insights,
-            List<String> recommendations,
-            boolean prematurePromotionDetected,
-            boolean survivorOverflowDetected,
-            int minThreshold,
-            int maxThresholdSeen,
-            int suggestedMaxTenuringThreshold
-    ) {}
+    public static final class TenuringAnalysis {
+        private final List<GcAgeSnapshot> snapshots;
+        private final List<String> insights;
+        private final List<String> recommendations;
+        private final boolean prematurePromotionDetected;
+        private final boolean survivorOverflowDetected;
+        private final int minThreshold;
+        private final int maxThresholdSeen;
+        private final int suggestedMaxTenuringThreshold;
+
+        public TenuringAnalysis(List<GcAgeSnapshot> snapshots, List<String> insights,
+                                List<String> recommendations,
+                                boolean prematurePromotionDetected,
+                                boolean survivorOverflowDetected,
+                                int minThreshold, int maxThresholdSeen,
+                                int suggestedMaxTenuringThreshold) {
+            this.snapshots = snapshots;
+            this.insights = insights;
+            this.recommendations = recommendations;
+            this.prematurePromotionDetected = prematurePromotionDetected;
+            this.survivorOverflowDetected = survivorOverflowDetected;
+            this.minThreshold = minThreshold;
+            this.maxThresholdSeen = maxThresholdSeen;
+            this.suggestedMaxTenuringThreshold = suggestedMaxTenuringThreshold;
+        }
+
+        public List<GcAgeSnapshot> snapshots() { return snapshots; }
+        public List<String> insights() { return insights; }
+        public List<String> recommendations() { return recommendations; }
+        public boolean prematurePromotionDetected() { return prematurePromotionDetected; }
+        public boolean survivorOverflowDetected() { return survivorOverflowDetected; }
+        public int minThreshold() { return minThreshold; }
+        public int maxThresholdSeen() { return maxThresholdSeen; }
+        public int suggestedMaxTenuringThreshold() { return suggestedMaxTenuringThreshold; }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (!(o instanceof TenuringAnalysis)) return false;
+            TenuringAnalysis that = (TenuringAnalysis) o;
+            return prematurePromotionDetected == that.prematurePromotionDetected
+                    && survivorOverflowDetected == that.survivorOverflowDetected
+                    && minThreshold == that.minThreshold
+                    && maxThresholdSeen == that.maxThresholdSeen
+                    && suggestedMaxTenuringThreshold == that.suggestedMaxTenuringThreshold
+                    && java.util.Objects.equals(snapshots, that.snapshots)
+                    && java.util.Objects.equals(insights, that.insights)
+                    && java.util.Objects.equals(recommendations, that.recommendations);
+        }
+
+        @Override
+        public int hashCode() {
+            return java.util.Objects.hash(snapshots, insights, recommendations,
+                    prematurePromotionDetected, survivorOverflowDetected,
+                    minThreshold, maxThresholdSeen, suggestedMaxTenuringThreshold);
+        }
+
+        @Override
+        public String toString() {
+            return "TenuringAnalysis[snapshots=" + snapshots + ", insights=" + insights
+                    + ", recommendations=" + recommendations
+                    + ", prematurePromotionDetected=" + prematurePromotionDetected
+                    + ", survivorOverflowDetected=" + survivorOverflowDetected
+                    + ", minThreshold=" + minThreshold
+                    + ", maxThresholdSeen=" + maxThresholdSeen
+                    + ", suggestedMaxTenuringThreshold=" + suggestedMaxTenuringThreshold + "]";
+        }
+    }
 
     /**
      * Age distribution captured at a single GC event.
      */
-    public record GcAgeSnapshot(
-            int gcId,
-            double timestampSec,
-            AgeDistribution distribution
-    ) {}
+    public static final class GcAgeSnapshot {
+        private final int gcId;
+        private final double timestampSec;
+        private final AgeDistribution distribution;
+
+        public GcAgeSnapshot(int gcId, double timestampSec, AgeDistribution distribution) {
+            this.gcId = gcId;
+            this.timestampSec = timestampSec;
+            this.distribution = distribution;
+        }
+
+        public int gcId() { return gcId; }
+        public double timestampSec() { return timestampSec; }
+        public AgeDistribution distribution() { return distribution; }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (!(o instanceof GcAgeSnapshot)) return false;
+            GcAgeSnapshot that = (GcAgeSnapshot) o;
+            return gcId == that.gcId
+                    && Double.compare(that.timestampSec, timestampSec) == 0
+                    && java.util.Objects.equals(distribution, that.distribution);
+        }
+
+        @Override
+        public int hashCode() {
+            return java.util.Objects.hash(gcId, timestampSec, distribution);
+        }
+
+        @Override
+        public String toString() {
+            return "GcAgeSnapshot[gcId=" + gcId + ", timestampSec=" + timestampSec
+                    + ", distribution=" + distribution + "]";
+        }
+    }
 
     /**
      * Parses a GC log file and returns tenuring analysis.
@@ -119,7 +208,7 @@ public final class TenuringAnalyzer {
     private static GcAgeSnapshot buildSnapshot(int gcId, double ts, int tt, int mtt,
                                                 long desiredSize,
                                                 List<AgeDistribution.AgeEntry> entries) {
-        long survivorCap = entries.isEmpty() ? 0 : entries.getLast().cumulativeBytes();
+        long survivorCap = entries.isEmpty() ? 0 : entries.get(entries.size() - 1).cumulativeBytes();
         AgeDistribution dist = new AgeDistribution(List.copyOf(entries), tt, mtt,
                 desiredSize, survivorCap);
         return new GcAgeSnapshot(gcId, ts, dist);
@@ -152,13 +241,13 @@ public final class TenuringAnalyzer {
         }
 
         // Analyze the last snapshot for current state
-        GcAgeSnapshot latest = snapshots.getLast();
+        GcAgeSnapshot latest = snapshots.get(snapshots.size() - 1);
         List<AgeDistribution.AgeEntry> entries = latest.distribution().entries();
 
         // Age-1 ratio insight
         if (!entries.isEmpty()) {
             long total = latest.distribution().survivorCapacity();
-            long age1 = entries.getFirst().bytes();
+            long age1 = entries.get(0).bytes();
             if (total > 0) {
                 int age1Pct = (int) (age1 * 100 / total);
                 if (age1Pct >= 60) {

--- a/argus-cli/src/main/java/io/argus/cli/gcscore/AxisScore.java
+++ b/argus-cli/src/main/java/io/argus/cli/gcscore/AxisScore.java
@@ -2,27 +2,65 @@ package io.argus.cli.gcscore;
 
 /**
  * Scored result for one KPI axis of the GC Health Score Card.
- *
- * @param name        axis display name (e.g. "Pause p99")
- * @param value       the axis value (e.g. 82.0 for 82 ms)
- * @param unit        human unit string (e.g. "ms", "%", "MB/s", "/hour")
- * @param target      short target-band description (e.g. "< 200 ms")
- * @param score       0–100 numeric score for this axis
- * @param verdict     Pass / Warn / Fail bucket
- * @param available   false if the underlying metric was missing (shown as N/A)
  */
-public record AxisScore(
-        String name,
-        double value,
-        String unit,
-        String target,
-        int score,
-        Verdict verdict,
-        boolean available) {
+public final class AxisScore {
 
     public enum Verdict { PASS, WARN, FAIL, NA }
 
+    private final String name;
+    private final double value;
+    private final String unit;
+    private final String target;
+    private final int score;
+    private final Verdict verdict;
+    private final boolean available;
+
+    public AxisScore(String name, double value, String unit, String target,
+                     int score, Verdict verdict, boolean available) {
+        this.name = name;
+        this.value = value;
+        this.unit = unit;
+        this.target = target;
+        this.score = score;
+        this.verdict = verdict;
+        this.available = available;
+    }
+
+    public String name() { return name; }
+    public double value() { return value; }
+    public String unit() { return unit; }
+    public String target() { return target; }
+    public int score() { return score; }
+    public Verdict verdict() { return verdict; }
+    public boolean available() { return available; }
+
     public static AxisScore na(String name, String target) {
         return new AxisScore(name, 0, "", target, 0, Verdict.NA, false);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof AxisScore)) return false;
+        AxisScore that = (AxisScore) o;
+        return Double.compare(that.value, value) == 0
+                && score == that.score
+                && available == that.available
+                && java.util.Objects.equals(name, that.name)
+                && java.util.Objects.equals(unit, that.unit)
+                && java.util.Objects.equals(target, that.target)
+                && verdict == that.verdict;
+    }
+
+    @Override
+    public int hashCode() {
+        return java.util.Objects.hash(name, value, unit, target, score, verdict, available);
+    }
+
+    @Override
+    public String toString() {
+        return "AxisScore[name=" + name + ", value=" + value + ", unit=" + unit
+                + ", target=" + target + ", score=" + score + ", verdict=" + verdict
+                + ", available=" + available + "]";
     }
 }

--- a/argus-cli/src/main/java/io/argus/cli/gcscore/GcScoreCalculator.java
+++ b/argus-cli/src/main/java/io/argus/cli/gcscore/GcScoreCalculator.java
@@ -237,13 +237,13 @@ public final class GcScoreCalculator {
     }
 
     static String summaryFor(String grade) {
-        return switch (grade) {
-            case "A" -> "excellent, no tuning required";
-            case "B" -> "good, minor tuning opportunities";
-            case "C" -> "acceptable, tuning recommended";
-            case "D" -> "poor, tuning required";
-            default -> "critical, immediate action required";
-        };
+        switch (grade) {
+            case "A": return "excellent, no tuning required";
+            case "B": return "good, minor tuning opportunities";
+            case "C": return "acceptable, tuning recommended";
+            case "D": return "poor, tuning required";
+            default: return "critical, immediate action required";
+        }
     }
 
     // ── Hint selection ──────────────────────────────────────────────────────
@@ -268,35 +268,28 @@ public final class GcScoreCalculator {
     }
 
     private static String hintFor(AxisScore ax) {
-        return switch (ax.name()) {
-            case "Pause p99" -> "Long p99 pauses — try -XX:MaxGCPauseMillis=200 or raise heap to absorb allocation bursts";
-            case "Pause tail (max)" -> "Long tail pauses suggest concurrent-mode failure or humongous allocation; consider G1/ZGC or increase heap";
-            case "Throughput" -> "Low throughput — raise -Xmx or consider a concurrent collector (G1/ZGC/Shenandoah)";
-            case "Full GC frequency" -> "Frequent Full GC — heap too small or memory leak; inspect with argus heap / argus diff";
-            case "Allocation rate" -> "Very high allocation rate — run argus flame --type=alloc to find hot allocation sites";
-            case "Promotion ratio" -> "Survivor overflow promoting short-lived objects; raise -XX:MaxTenuringThreshold or -XX:SurvivorRatio";
-            default -> null;
-        };
+        switch (ax.name()) {
+            case "Pause p99": return "Long p99 pauses — try -XX:MaxGCPauseMillis=200 or raise heap to absorb allocation bursts";
+            case "Pause tail (max)": return "Long tail pauses suggest concurrent-mode failure or humongous allocation; consider G1/ZGC or increase heap";
+            case "Throughput": return "Low throughput — raise -Xmx or consider a concurrent collector (G1/ZGC/Shenandoah)";
+            case "Full GC frequency": return "Frequent Full GC — heap too small or memory leak; inspect with argus heap / argus diff";
+            case "Allocation rate": return "Very high allocation rate — run argus flame --type=alloc to find hot allocation sites";
+            case "Promotion ratio": return "Survivor overflow promoting short-lived objects; raise -XX:MaxTenuringThreshold or -XX:SurvivorRatio";
+            default: return null;
+        }
     }
 
     private static String hintForZgc(AxisScore ax) {
-        return switch (ax.name()) {
-            case "Pause p99" ->
-                    "Elevated ZGC p99 pauses — raise -Xmx or set -XX:SoftMaxHeapSize to reduce GC pressure; consider -XX:ConcGCThreads";
-            case "Pause tail (max)" ->
-                    "Elevated ZGC max pause — check for allocation stalls; increase heap with -Xmx or tune -XX:SoftMaxHeapSize";
-            case "Throughput" ->
-                    "Low throughput under ZGC — raise -Xmx or increase -XX:ConcGCThreads to keep concurrent work ahead of mutators";
-            case "Full GC frequency" ->
-                    "Frequent Full GC — heap too small or memory leak; inspect with argus heap / argus diff";
-            case "Allocation rate" ->
-                    "Very high allocation rate under ZGC — run argus flame --type=alloc to find hot allocation sites";
-            case "Promotion ratio" ->
-                    "High promotion ratio under ZGC — review object lifetime patterns; consider raising -Xmx";
-            case "Allocation pressure (ZGC)" ->
-                    "ZGC cycle frequency too high (> 0.5/s) — heap is undersized; raise -Xmx or tune -XX:SoftMaxHeapSize and -XX:ConcGCThreads";
-            default -> null;
-        };
+        switch (ax.name()) {
+            case "Pause p99": return "Elevated ZGC p99 pauses — raise -Xmx or set -XX:SoftMaxHeapSize to reduce GC pressure; consider -XX:ConcGCThreads";
+            case "Pause tail (max)": return "Elevated ZGC max pause — check for allocation stalls; increase heap with -Xmx or tune -XX:SoftMaxHeapSize";
+            case "Throughput": return "Low throughput under ZGC — raise -Xmx or increase -XX:ConcGCThreads to keep concurrent work ahead of mutators";
+            case "Full GC frequency": return "Frequent Full GC — heap too small or memory leak; inspect with argus heap / argus diff";
+            case "Allocation rate": return "Very high allocation rate under ZGC — run argus flame --type=alloc to find hot allocation sites";
+            case "Promotion ratio": return "High promotion ratio under ZGC — review object lifetime patterns; consider raising -Xmx";
+            case "Allocation pressure (ZGC)": return "ZGC cycle frequency too high (> 0.5/s) — heap is undersized; raise -Xmx or tune -XX:SoftMaxHeapSize and -XX:ConcGCThreads";
+            default: return null;
+        }
     }
 
     // Expose for tests

--- a/argus-cli/src/main/java/io/argus/cli/gcscore/GcScoreResult.java
+++ b/argus-cli/src/main/java/io/argus/cli/gcscore/GcScoreResult.java
@@ -4,16 +4,49 @@ import java.util.List;
 
 /**
  * Full Health Score Card result: per-axis scores, overall grade, and hints.
- *
- * @param axes       per-axis scored results in display order
- * @param overall    0–100 weighted overall score
- * @param grade      "A"/"B"/"C"/"D"/"F"
- * @param summary    one-line verdict summary (e.g. "good, minor tuning opportunities")
- * @param hints      up to 3 prioritized improvement hints
  */
-public record GcScoreResult(
-        List<AxisScore> axes,
-        int overall,
-        String grade,
-        String summary,
-        List<String> hints) {}
+public final class GcScoreResult {
+    private final List<AxisScore> axes;
+    private final int overall;
+    private final String grade;
+    private final String summary;
+    private final List<String> hints;
+
+    public GcScoreResult(List<AxisScore> axes, int overall, String grade,
+                         String summary, List<String> hints) {
+        this.axes = axes;
+        this.overall = overall;
+        this.grade = grade;
+        this.summary = summary;
+        this.hints = hints;
+    }
+
+    public List<AxisScore> axes() { return axes; }
+    public int overall() { return overall; }
+    public String grade() { return grade; }
+    public String summary() { return summary; }
+    public List<String> hints() { return hints; }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof GcScoreResult)) return false;
+        GcScoreResult that = (GcScoreResult) o;
+        return overall == that.overall
+                && java.util.Objects.equals(axes, that.axes)
+                && java.util.Objects.equals(grade, that.grade)
+                && java.util.Objects.equals(summary, that.summary)
+                && java.util.Objects.equals(hints, that.hints);
+    }
+
+    @Override
+    public int hashCode() {
+        return java.util.Objects.hash(axes, overall, grade, summary, hints);
+    }
+
+    @Override
+    public String toString() {
+        return "GcScoreResult[axes=" + axes + ", overall=" + overall + ", grade=" + grade
+                + ", summary=" + summary + ", hints=" + hints + "]";
+    }
+}

--- a/argus-cli/src/main/java/io/argus/cli/gcwhy/GcWhyAnalyzer.java
+++ b/argus-cli/src/main/java/io/argus/cli/gcwhy/GcWhyAnalyzer.java
@@ -22,7 +22,7 @@ public final class GcWhyAnalyzer {
     public static GcWhyResult analyze(List<GcEvent> events, double windowSeconds) {
         if (events == null || events.isEmpty()) return GcWhyResult.empty();
 
-        double latestTs = events.getLast().timestampSec();
+        double latestTs = events.get(events.size() - 1).timestampSec();
         double cutoffTs = latestTs - windowSeconds;
 
         List<GcEvent> window = new ArrayList<>();

--- a/argus-cli/src/main/java/io/argus/cli/gcwhy/GcWhyJfrCollector.java
+++ b/argus-cli/src/main/java/io/argus/cli/gcwhy/GcWhyJfrCollector.java
@@ -63,14 +63,15 @@ public final class GcWhyJfrCollector {
                 }
 
                 switch (typeName) {
-                    case "jdk.GarbageCollection" -> {
+                    case "jdk.GarbageCollection": {
                         long gcId = safeGetLong(event, "gcId");
                         String name  = safeGetString(event, "name");   // e.g. "G1Young", "G1Full"
                         String cause = safeGetString(event, "cause");  // e.g. "G1 Evacuation Pause"
                         long durationNs = event.getDuration().toNanos();
                         collections.put(gcId, new GcCollectionInfo(gcId, name, cause, startTime, durationNs));
+                        break;
                     }
-                    case "jdk.GCHeapSummary" -> {
+                    case "jdk.GCHeapSummary": {
                         long gcId = safeGetLong(event, "gcId");
                         String when = safeGetString(event, "when"); // GCWhen enum: "Before GC" or "After GC"
                         long heapUsed = safeGetLong(event, "heapUsed"); // bytes
@@ -89,7 +90,10 @@ public final class GcWhyJfrCollector {
                         } else if (when != null && when.toLowerCase().contains("after")) {
                             heapAfter.put(gcId, new long[]{usedKB, committedKB});
                         }
+                        break;
                     }
+                    default:
+                        break;
                 }
             }
         }
@@ -162,10 +166,23 @@ public final class GcWhyJfrCollector {
 
     // ── Internal value type ──────────────────────────────────────────────────
 
-    private record GcCollectionInfo(
-            long gcId,
-            String name,
-            String cause,
-            Instant startTime,
-            long durationNs) {}
+    private static final class GcCollectionInfo {
+        final long gcId;
+        final String name;
+        final String cause;
+        final Instant startTime;
+        final long durationNs;
+        GcCollectionInfo(long gcId, String name, String cause, Instant startTime, long durationNs) {
+            this.gcId = gcId;
+            this.name = name;
+            this.cause = cause;
+            this.startTime = startTime;
+            this.durationNs = durationNs;
+        }
+        long gcId() { return gcId; }
+        String name() { return name; }
+        String cause() { return cause; }
+        Instant startTime() { return startTime; }
+        long durationNs() { return durationNs; }
+    }
 }

--- a/argus-cli/src/main/java/io/argus/cli/gcwhy/GcWhyResult.java
+++ b/argus-cli/src/main/java/io/argus/cli/gcwhy/GcWhyResult.java
@@ -7,15 +7,56 @@ import java.util.Map;
  * Result of the gcwhy correlation engine: the worst pause in the window,
  * a small set of "why" bullets, and a map of related counters to display.
  */
-public record GcWhyResult(
-        double timestampSec,
-        String type,
-        String cause,
-        double pauseMs,
-        List<String> bullets,
-        Map<String, String> counters) {
+public final class GcWhyResult {
+    private final double timestampSec;
+    private final String type;
+    private final String cause;
+    private final double pauseMs;
+    private final List<String> bullets;
+    private final Map<String, String> counters;
+
+    public GcWhyResult(double timestampSec, String type, String cause, double pauseMs,
+                      List<String> bullets, Map<String, String> counters) {
+        this.timestampSec = timestampSec;
+        this.type = type;
+        this.cause = cause;
+        this.pauseMs = pauseMs;
+        this.bullets = bullets;
+        this.counters = counters;
+    }
+
+    public double timestampSec() { return timestampSec; }
+    public String type() { return type; }
+    public String cause() { return cause; }
+    public double pauseMs() { return pauseMs; }
+    public List<String> bullets() { return bullets; }
+    public Map<String, String> counters() { return counters; }
 
     public static GcWhyResult empty() {
         return new GcWhyResult(0, "", "", 0, List.of(), Map.of());
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof GcWhyResult)) return false;
+        GcWhyResult that = (GcWhyResult) o;
+        return Double.compare(that.timestampSec, timestampSec) == 0
+                && Double.compare(that.pauseMs, pauseMs) == 0
+                && java.util.Objects.equals(type, that.type)
+                && java.util.Objects.equals(cause, that.cause)
+                && java.util.Objects.equals(bullets, that.bullets)
+                && java.util.Objects.equals(counters, that.counters);
+    }
+
+    @Override
+    public int hashCode() {
+        return java.util.Objects.hash(timestampSec, type, cause, pauseMs, bullets, counters);
+    }
+
+    @Override
+    public String toString() {
+        return "GcWhyResult[timestampSec=" + timestampSec + ", type=" + type + ", cause=" + cause
+                + ", pauseMs=" + pauseMs + ", bullets=" + bullets + ", counters=" + counters + "]";
     }
 }

--- a/argus-cli/src/main/java/io/argus/cli/heapanalyze/HprofParser.java
+++ b/argus-cli/src/main/java/io/argus/cli/heapanalyze/HprofParser.java
@@ -87,22 +87,25 @@ public final class HprofParser {
                 long length = Integer.toUnsignedLong(in.readInt());
 
                 switch (tag) {
-                    case TAG_STRING -> {
+                    case TAG_STRING: {
                         long id = readId(in, idSize);
                         int strLen = (int) (length - idSize);
                         byte[] buf = new byte[strLen];
                         in.readFully(buf);
                         strings.put(id, new String(buf, StandardCharsets.UTF_8));
+                        break;
                     }
-                    case TAG_LOAD_CLASS -> {
+                    case TAG_LOAD_CLASS: {
                         int serial = in.readInt();
                         long classObjId = readId(in, idSize);
                         in.readInt(); // stack trace serial
                         long nameId = readId(in, idSize);
                         classSerialToId.put((long) serial, classObjId);
                         classIdToNameId.put(classObjId, nameId);
+                        break;
                     }
-                    case TAG_HEAP_DUMP, TAG_HEAP_DUMP_SEG -> {
+                    case TAG_HEAP_DUMP:
+                    case TAG_HEAP_DUMP_SEG: {
                         // Parse sub-records within the heap dump segment
                         long remaining = length;
                         while (remaining > 0) {
@@ -110,7 +113,7 @@ public final class HprofParser {
                             remaining--;
 
                             switch (subTag) {
-                                case SUB_GC_CLASS_DUMP -> {
+                                case SUB_GC_CLASS_DUMP: {
                                     long classObjId = readId(in, idSize);
                                     in.readInt(); // stack trace serial
                                     long superClassId = readId(in, idSize);
@@ -158,8 +161,9 @@ public final class HprofParser {
                                     }
 
                                     classes.put(classObjId, new ClassInfo(instanceSize, superClassId, fieldsDataSize));
+                                    break;
                                 }
-                                case SUB_GC_INSTANCE_DUMP -> {
+                                case SUB_GC_INSTANCE_DUMP: {
                                     readId(in, idSize); // object ID
                                     in.readInt(); // stack trace serial
                                     long classId = readId(in, idSize);
@@ -179,8 +183,9 @@ public final class HprofParser {
                                     if ("java.lang.String".equals(className)) {
                                         stringCount++;
                                     }
+                                    break;
                                 }
-                                case SUB_GC_OBJ_ARRAY_DUMP -> {
+                                case SUB_GC_OBJ_ARRAY_DUMP: {
                                     readId(in, idSize); // array object ID
                                     in.readInt(); // stack trace serial
                                     int numElements = in.readInt();
@@ -196,8 +201,9 @@ public final class HprofParser {
                                     histogram.get(className)[1] += shallowSize;
                                     totalArrays++;
                                     totalArrayBytes += shallowSize;
+                                    break;
                                 }
-                                case SUB_GC_PRIM_ARRAY_DUMP -> {
+                                case SUB_GC_PRIM_ARRAY_DUMP: {
                                     readId(in, idSize); // array object ID
                                     in.readInt(); // stack trace serial
                                     int numElements = in.readInt();
@@ -220,56 +226,69 @@ public final class HprofParser {
                                         // We can't easily extract string values in streaming mode
                                         // without building a full reference graph
                                     }
+                                    break;
                                 }
                                 // GC roots — skip
-                                case SUB_GC_ROOT_UNKNOWN -> {
+                                case SUB_GC_ROOT_UNKNOWN: {
                                     readId(in, idSize);
                                     remaining -= idSize;
+                                    break;
                                 }
-                                case SUB_GC_ROOT_JNI_GLOBAL -> {
+                                case SUB_GC_ROOT_JNI_GLOBAL: {
                                     readId(in, idSize);
                                     readId(in, idSize);
                                     remaining -= idSize * 2;
+                                    break;
                                 }
-                                case SUB_GC_ROOT_JNI_LOCAL, SUB_GC_ROOT_JAVA_FRAME,
-                                     SUB_GC_ROOT_THREAD_BLOCK -> {
+                                case SUB_GC_ROOT_JNI_LOCAL:
+                                case SUB_GC_ROOT_JAVA_FRAME:
+                                case SUB_GC_ROOT_THREAD_BLOCK: {
                                     readId(in, idSize);
                                     in.readInt();
                                     in.readInt();
                                     remaining -= idSize + 8;
+                                    break;
                                 }
-                                case SUB_GC_ROOT_NATIVE_STACK, SUB_GC_ROOT_THREAD_OBJ -> {
+                                case SUB_GC_ROOT_NATIVE_STACK:
+                                case SUB_GC_ROOT_THREAD_OBJ: {
                                     readId(in, idSize);
                                     in.readInt();
                                     in.readInt();
                                     remaining -= idSize + 8;
+                                    break;
                                 }
-                                case SUB_GC_ROOT_STICKY_CLASS -> {
+                                case SUB_GC_ROOT_STICKY_CLASS: {
                                     readId(in, idSize);
                                     remaining -= idSize;
+                                    break;
                                 }
-                                case SUB_GC_ROOT_MONITOR_USED -> {
+                                case SUB_GC_ROOT_MONITOR_USED: {
                                     readId(in, idSize);
                                     remaining -= idSize;
+                                    break;
                                 }
-                                default -> {
+                                default: {
                                     // Unknown sub-record, skip remaining
                                     if (remaining > 0) {
                                         skipBytes(in, remaining);
                                         remaining = 0;
                                     }
+                                    break;
                                 }
                             }
                         }
+                        break;
                     }
-                    case TAG_HEAP_DUMP_END -> {
+                    case TAG_HEAP_DUMP_END: {
                         // No body
+                        break;
                     }
-                    default -> {
+                    default: {
                         // Skip unknown records
                         if (length > 0) {
                             skipBytes(in, length);
                         }
+                        break;
                     }
                 }
             }
@@ -318,32 +337,32 @@ public final class HprofParser {
     }
 
     private static int typeSize(int type, int idSize) {
-        return switch (type) {
-            case 2 -> idSize;  // object
-            case 4 -> 1;       // boolean
-            case 5 -> 2;       // char
-            case 6 -> 4;       // float
-            case 7 -> 8;       // double
-            case 8 -> 1;       // byte
-            case 9 -> 2;       // short
-            case 10 -> 4;      // int
-            case 11 -> 8;      // long
-            default -> idSize; // unknown, assume ID
-        };
+        switch (type) {
+            case 2: return idSize;  // object
+            case 4: return 1;       // boolean
+            case 5: return 2;       // char
+            case 6: return 4;       // float
+            case 7: return 8;       // double
+            case 8: return 1;       // byte
+            case 9: return 2;       // short
+            case 10: return 4;      // int
+            case 11: return 8;      // long
+            default: return idSize; // unknown, assume ID
+        }
     }
 
     private static String primArrayName(int type) {
-        return switch (type) {
-            case 4 -> "boolean[]";
-            case 5 -> "char[]";
-            case 6 -> "float[]";
-            case 7 -> "double[]";
-            case 8 -> "byte[]";
-            case 9 -> "short[]";
-            case 10 -> "int[]";
-            case 11 -> "long[]";
-            default -> "unknown[]";
-        };
+        switch (type) {
+            case 4: return "boolean[]";
+            case 5: return "char[]";
+            case 6: return "float[]";
+            case 7: return "double[]";
+            case 8: return "byte[]";
+            case 9: return "short[]";
+            case 10: return "int[]";
+            case 11: return "long[]";
+            default: return "unknown[]";
+        }
     }
 
     private static String resolveClassName(long classId, Map<Long, Long> classIdToNameId,
@@ -355,5 +374,14 @@ public final class HprofParser {
         return name.replace('/', '.');
     }
 
-    private record ClassInfo(int instanceSize, long superClassId, int fieldsDataSize) {}
+    private static final class ClassInfo {
+        final int instanceSize;
+        final long superClassId;
+        final int fieldsDataSize;
+        ClassInfo(int instanceSize, long superClassId, int fieldsDataSize) {
+            this.instanceSize = instanceSize;
+            this.superClassId = superClassId;
+            this.fieldsDataSize = fieldsDataSize;
+        }
+    }
 }

--- a/argus-cli/src/main/java/io/argus/cli/heapanalyze/HprofSummary.java
+++ b/argus-cli/src/main/java/io/argus/cli/heapanalyze/HprofSummary.java
@@ -6,18 +6,46 @@ import java.util.stream.Collectors;
 /**
  * Summary of an HPROF heap dump analysis.
  */
-public record HprofSummary(
-        String fileName,
-        long fileSize,
-        int idSize,
-        Map<String, long[]> histogram,   // className → [count, shallowBytes]
-        long totalInstances,
-        long totalBytes,
-        long totalArrays,
-        long totalArrayBytes,
-        long stringCount,
-        int classCount
-) {
+public final class HprofSummary {
+    private final String fileName;
+    private final long fileSize;
+    private final int idSize;
+    private final Map<String, long[]> histogram;   // className → [count, shallowBytes]
+    private final long totalInstances;
+    private final long totalBytes;
+    private final long totalArrays;
+    private final long totalArrayBytes;
+    private final long stringCount;
+    private final int classCount;
+
+    public HprofSummary(String fileName, long fileSize, int idSize,
+                        Map<String, long[]> histogram,
+                        long totalInstances, long totalBytes,
+                        long totalArrays, long totalArrayBytes,
+                        long stringCount, int classCount) {
+        this.fileName = fileName;
+        this.fileSize = fileSize;
+        this.idSize = idSize;
+        this.histogram = histogram;
+        this.totalInstances = totalInstances;
+        this.totalBytes = totalBytes;
+        this.totalArrays = totalArrays;
+        this.totalArrayBytes = totalArrayBytes;
+        this.stringCount = stringCount;
+        this.classCount = classCount;
+    }
+
+    public String fileName() { return fileName; }
+    public long fileSize() { return fileSize; }
+    public int idSize() { return idSize; }
+    public Map<String, long[]> histogram() { return histogram; }
+    public long totalInstances() { return totalInstances; }
+    public long totalBytes() { return totalBytes; }
+    public long totalArrays() { return totalArrays; }
+    public long totalArrayBytes() { return totalArrayBytes; }
+    public long stringCount() { return stringCount; }
+    public int classCount() { return classCount; }
+
     /**
      * Returns the top N classes by shallow size, descending.
      */
@@ -50,5 +78,38 @@ public record HprofSummary(
      */
     public long totalShallowBytes() {
         return totalBytes + totalArrayBytes;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof HprofSummary)) return false;
+        HprofSummary that = (HprofSummary) o;
+        return fileSize == that.fileSize
+                && idSize == that.idSize
+                && totalInstances == that.totalInstances
+                && totalBytes == that.totalBytes
+                && totalArrays == that.totalArrays
+                && totalArrayBytes == that.totalArrayBytes
+                && stringCount == that.stringCount
+                && classCount == that.classCount
+                && java.util.Objects.equals(fileName, that.fileName)
+                && java.util.Objects.equals(histogram, that.histogram);
+    }
+
+    @Override
+    public int hashCode() {
+        return java.util.Objects.hash(fileName, fileSize, idSize, histogram,
+                totalInstances, totalBytes, totalArrays, totalArrayBytes,
+                stringCount, classCount);
+    }
+
+    @Override
+    public String toString() {
+        return "HprofSummary[fileName=" + fileName + ", fileSize=" + fileSize
+                + ", idSize=" + idSize + ", histogram=" + histogram
+                + ", totalInstances=" + totalInstances + ", totalBytes=" + totalBytes
+                + ", totalArrays=" + totalArrays + ", totalArrayBytes=" + totalArrayBytes
+                + ", stringCount=" + stringCount + ", classCount=" + classCount + "]";
     }
 }

--- a/argus-cli/src/main/java/io/argus/cli/jfr/JfrAnalyzer.java
+++ b/argus-cli/src/main/java/io/argus/cli/jfr/JfrAnalyzer.java
@@ -21,6 +21,7 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 /**
  * Analyzes a JFR recording file and produces a comprehensive summary.
@@ -77,7 +78,7 @@ public final class JfrAnalyzer {
                 String eventType = event.getEventType().getName();
 
                 switch (eventType) {
-                    case "jdk.GarbageCollection" -> {
+                    case "jdk.GarbageCollection": {
                         gcEventCount++;
                         long durationNs = event.getDuration().toNanos();
                         totalGcPauseNs += durationNs;
@@ -86,13 +87,16 @@ public final class JfrAnalyzer {
                             String cause = event.getString("cause");
                             if (cause != null) gcCauses.merge(cause, 1, Integer::sum);
                         } catch (Exception ignored) {}
+                        break;
                     }
-                    case "jdk.GCPhasePause", "jdk.GCPhasePauseLevel1" -> {
+                    case "jdk.GCPhasePause":
+                    case "jdk.GCPhasePauseLevel1": {
                         long durationNs = event.getDuration().toNanos();
                         totalGcPauseNs += durationNs;
                         if (durationNs > maxGcPauseNs) maxGcPauseNs = durationNs;
+                        break;
                     }
-                    case "jdk.CPULoad" -> {
+                    case "jdk.CPULoad": {
                         try {
                             double jvmUser = event.getDouble("jvmUser");
                             double jvmSystem = event.getDouble("jvmSystem");
@@ -100,21 +104,25 @@ public final class JfrAnalyzer {
                             cpuLoadSamples.add(jvmUser + jvmSystem);
                             systemCpuSamples.add(machineTotal);
                         } catch (Exception ignored) {}
+                        break;
                     }
-                    case "jdk.ExecutionSample", "jdk.NativeMethodSample" -> {
+                    case "jdk.ExecutionSample":
+                    case "jdk.NativeMethodSample": {
                         totalSamples++;
                         RecordedStackTrace stack = event.getStackTrace();
                         if (stack != null && !stack.getFrames().isEmpty()) {
-                            RecordedFrame topFrame = stack.getFrames().getFirst();
+                            RecordedFrame topFrame = stack.getFrames().get(0);
                             RecordedMethod method = topFrame.getMethod();
                             if (method != null) {
                                 String methodName = method.getType().getName() + "." + method.getName();
                                 methodSamples.merge(methodName, 1, Integer::sum);
                             }
                         }
+                        break;
                     }
-                    case "jdk.ObjectAllocationInNewTLAB", "jdk.ObjectAllocationOutsideTLAB",
-                         "jdk.ObjectAllocationSample" -> {
+                    case "jdk.ObjectAllocationInNewTLAB":
+                    case "jdk.ObjectAllocationOutsideTLAB":
+                    case "jdk.ObjectAllocationSample": {
                         try {
                             String className = "unknown";
                             try { className = event.getClass("objectClass").getName(); } catch (Exception ignored2) {}
@@ -126,8 +134,9 @@ public final class JfrAnalyzer {
                             allocations.get(className)[0] += bytes;
                             allocations.get(className)[1]++;
                         } catch (Exception ignored) {}
+                        break;
                     }
-                    case "jdk.JavaMonitorEnter" -> {
+                    case "jdk.JavaMonitorEnter": {
                         try {
                             String monitorClass = "unknown";
                             try { monitorClass = event.getClass("monitorClass").getName(); } catch (Exception ignored2) {}
@@ -136,23 +145,33 @@ public final class JfrAnalyzer {
                             contentions.get(monitorClass)[0] += durationNs;
                             contentions.get(monitorClass)[1]++;
                         } catch (Exception ignored) {}
+                        break;
                     }
-                    case "jdk.JavaExceptionThrow" -> {
+                    case "jdk.JavaExceptionThrow": {
                         try {
                             String exClass = event.getClass("thrownClass").getName();
                             exceptions.merge(exClass, 1, Integer::sum);
                         } catch (Exception ignored) {}
+                        break;
                     }
-                    case "jdk.FileRead" -> {
+                    case "jdk.FileRead": {
                         fileReadCount++;
                         try { totalFileReadBytes += event.getLong("bytesRead"); } catch (Exception ignored) {}
+                        break;
                     }
-                    case "jdk.FileWrite" -> fileWriteCount++;
-                    case "jdk.SocketRead" -> {
+                    case "jdk.FileWrite":
+                        fileWriteCount++;
+                        break;
+                    case "jdk.SocketRead": {
                         socketReadCount++;
                         try { totalSocketReadBytes += event.getLong("bytesRead"); } catch (Exception ignored) {}
+                        break;
                     }
-                    case "jdk.SocketWrite" -> socketWriteCount++;
+                    case "jdk.SocketWrite":
+                        socketWriteCount++;
+                        break;
+                    default:
+                        break;
                 }
             }
         }
@@ -167,21 +186,21 @@ public final class JfrAnalyzer {
                 .limit(TOP_N)
                 .map(e -> new HotMethod(e.getKey(), e.getValue(),
                         finalTotalSamples > 0 ? (double) e.getValue() / finalTotalSamples * 100 : 0))
-                .toList();
+                .collect(Collectors.toList());
 
         // Build top allocations
         List<AllocationSite> topAllocations = allocations.entrySet().stream()
                 .sorted((a, b) -> Long.compare(b.getValue()[0], a.getValue()[0]))
                 .limit(TOP_N)
                 .map(e -> new AllocationSite(e.getKey(), e.getValue()[0], (int) e.getValue()[1]))
-                .toList();
+                .collect(Collectors.toList());
 
         // Build top contention
         List<ContentionSite> topContention = contentions.entrySet().stream()
                 .sorted((a, b) -> Long.compare(b.getValue()[0], a.getValue()[0]))
                 .limit(TOP_N)
                 .map(e -> new ContentionSite(e.getKey(), e.getValue()[0] / 1_000_000, (int) e.getValue()[1]))
-                .toList();
+                .collect(Collectors.toList());
 
         // Sort GC causes by count descending
         Map<String, Integer> sortedGcCauses = new LinkedHashMap<>();

--- a/argus-cli/src/main/java/io/argus/cli/model/AgeDistribution.java
+++ b/argus-cli/src/main/java/io/argus/cli/model/AgeDistribution.java
@@ -7,15 +7,92 @@ import java.util.List;
  * Age data is extracted from GC log debug output (-Xlog:gc+age=debug)
  * or from jcmd GC.heap_info when available.
  */
-public record AgeDistribution(
-        List<AgeEntry> entries,
-        int tenuringThreshold,
-        int maxTenuringThreshold,
-        long desiredSurvivorSize,
-        long survivorCapacity
-) {
+public final class AgeDistribution {
+    private final List<AgeEntry> entries;
+    private final int tenuringThreshold;
+    private final int maxTenuringThreshold;
+    private final long desiredSurvivorSize;
+    private final long survivorCapacity;
+
+    public AgeDistribution(List<AgeEntry> entries, int tenuringThreshold,
+                           int maxTenuringThreshold, long desiredSurvivorSize,
+                           long survivorCapacity) {
+        this.entries = entries;
+        this.tenuringThreshold = tenuringThreshold;
+        this.maxTenuringThreshold = maxTenuringThreshold;
+        this.desiredSurvivorSize = desiredSurvivorSize;
+        this.survivorCapacity = survivorCapacity;
+    }
+
+    public List<AgeEntry> entries() { return entries; }
+    public int tenuringThreshold() { return tenuringThreshold; }
+    public int maxTenuringThreshold() { return maxTenuringThreshold; }
+    public long desiredSurvivorSize() { return desiredSurvivorSize; }
+    public long survivorCapacity() { return survivorCapacity; }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof AgeDistribution)) return false;
+        AgeDistribution that = (AgeDistribution) o;
+        return tenuringThreshold == that.tenuringThreshold
+                && maxTenuringThreshold == that.maxTenuringThreshold
+                && desiredSurvivorSize == that.desiredSurvivorSize
+                && survivorCapacity == that.survivorCapacity
+                && java.util.Objects.equals(entries, that.entries);
+    }
+
+    @Override
+    public int hashCode() {
+        return java.util.Objects.hash(entries, tenuringThreshold, maxTenuringThreshold,
+                desiredSurvivorSize, survivorCapacity);
+    }
+
+    @Override
+    public String toString() {
+        return "AgeDistribution[entries=" + entries + ", tenuringThreshold=" + tenuringThreshold
+                + ", maxTenuringThreshold=" + maxTenuringThreshold
+                + ", desiredSurvivorSize=" + desiredSurvivorSize
+                + ", survivorCapacity=" + survivorCapacity + "]";
+    }
+
     /**
      * A single age bucket: objects of this age in the survivor space.
      */
-    public record AgeEntry(int age, long bytes, long cumulativeBytes) {}
+    public static final class AgeEntry {
+        private final int age;
+        private final long bytes;
+        private final long cumulativeBytes;
+
+        public AgeEntry(int age, long bytes, long cumulativeBytes) {
+            this.age = age;
+            this.bytes = bytes;
+            this.cumulativeBytes = cumulativeBytes;
+        }
+
+        public int age() { return age; }
+        public long bytes() { return bytes; }
+        public long cumulativeBytes() { return cumulativeBytes; }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (!(o instanceof AgeEntry)) return false;
+            AgeEntry that = (AgeEntry) o;
+            return age == that.age
+                    && bytes == that.bytes
+                    && cumulativeBytes == that.cumulativeBytes;
+        }
+
+        @Override
+        public int hashCode() {
+            return java.util.Objects.hash(age, bytes, cumulativeBytes);
+        }
+
+        @Override
+        public String toString() {
+            return "AgeEntry[age=" + age + ", bytes=" + bytes
+                    + ", cumulativeBytes=" + cumulativeBytes + "]";
+        }
+    }
 }

--- a/argus-cli/src/main/java/io/argus/cli/model/NmtBaseline.java
+++ b/argus-cli/src/main/java/io/argus/cli/model/NmtBaseline.java
@@ -88,14 +88,59 @@ public final class NmtBaseline {
         return new ArrayList<>(rows.values());
     }
 
-    public record DiffRow(String name,
-                          long baseReservedKB, long curReservedKB,
-                          long baseCommittedKB, long curCommittedKB) {
+    public static final class DiffRow {
+        private final String name;
+        private final long baseReservedKB;
+        private final long curReservedKB;
+        private final long baseCommittedKB;
+        private final long curCommittedKB;
+
+        public DiffRow(String name,
+                       long baseReservedKB, long curReservedKB,
+                       long baseCommittedKB, long curCommittedKB) {
+            this.name = name;
+            this.baseReservedKB = baseReservedKB;
+            this.curReservedKB = curReservedKB;
+            this.baseCommittedKB = baseCommittedKB;
+            this.curCommittedKB = curCommittedKB;
+        }
+
+        public String name() { return name; }
+        public long baseReservedKB() { return baseReservedKB; }
+        public long curReservedKB() { return curReservedKB; }
+        public long baseCommittedKB() { return baseCommittedKB; }
+        public long curCommittedKB() { return curCommittedKB; }
+
         public long reservedDeltaKB() { return curReservedKB - baseReservedKB; }
         public long committedDeltaKB() { return curCommittedKB - baseCommittedKB; }
         public double committedDeltaPct() {
             if (baseCommittedKB == 0) return curCommittedKB > 0 ? Double.POSITIVE_INFINITY : 0;
             return (committedDeltaKB() * 100.0) / baseCommittedKB;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (!(o instanceof DiffRow)) return false;
+            DiffRow that = (DiffRow) o;
+            return baseReservedKB == that.baseReservedKB
+                    && curReservedKB == that.curReservedKB
+                    && baseCommittedKB == that.baseCommittedKB
+                    && curCommittedKB == that.curCommittedKB
+                    && java.util.Objects.equals(name, that.name);
+        }
+
+        @Override
+        public int hashCode() {
+            return java.util.Objects.hash(name, baseReservedKB, curReservedKB,
+                    baseCommittedKB, curCommittedKB);
+        }
+
+        @Override
+        public String toString() {
+            return "DiffRow[name=" + name + ", baseReservedKB=" + baseReservedKB
+                    + ", curReservedKB=" + curReservedKB + ", baseCommittedKB=" + baseCommittedKB
+                    + ", curCommittedKB=" + curCommittedKB + "]";
         }
     }
 
@@ -138,15 +183,15 @@ public final class NmtBaseline {
         for (int i = 0; i < s.length(); i++) {
             char c = s.charAt(i);
             switch (c) {
-                case '"' -> sb.append("\\\"");
-                case '\\' -> sb.append("\\\\");
-                case '\n' -> sb.append("\\n");
-                case '\r' -> sb.append("\\r");
-                case '\t' -> sb.append("\\t");
-                default -> {
+                case '"': sb.append("\\\""); break;
+                case '\\': sb.append("\\\\"); break;
+                case '\n': sb.append("\\n"); break;
+                case '\r': sb.append("\\r"); break;
+                case '\t': sb.append("\\t"); break;
+                default:
                     if (c < 0x20) sb.append(String.format("\\u%04x", (int) c));
                     else sb.append(c);
-                }
+                    break;
             }
         }
         return sb.toString();

--- a/argus-cli/src/main/java/io/argus/cli/model/ProfileSnapshot.java
+++ b/argus-cli/src/main/java/io/argus/cli/model/ProfileSnapshot.java
@@ -112,12 +112,57 @@ public final class ProfileSnapshot {
     // Diff
     // -------------------------------------------------------------------------
 
-    public record DiffEntry(String method,
-                            long beforeSamples,
-                            long afterSamples,
-                            long deltaSamples,
-                            double deltaPct,
-                            String state) {}   // "changed" | "new" | "gone"
+    public static final class DiffEntry {
+        private final String method;
+        private final long beforeSamples;
+        private final long afterSamples;
+        private final long deltaSamples;
+        private final double deltaPct;
+        private final String state;   // "changed" | "new" | "gone"
+
+        public DiffEntry(String method, long beforeSamples, long afterSamples,
+                         long deltaSamples, double deltaPct, String state) {
+            this.method = method;
+            this.beforeSamples = beforeSamples;
+            this.afterSamples = afterSamples;
+            this.deltaSamples = deltaSamples;
+            this.deltaPct = deltaPct;
+            this.state = state;
+        }
+
+        public String method() { return method; }
+        public long beforeSamples() { return beforeSamples; }
+        public long afterSamples() { return afterSamples; }
+        public long deltaSamples() { return deltaSamples; }
+        public double deltaPct() { return deltaPct; }
+        public String state() { return state; }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (!(o instanceof DiffEntry)) return false;
+            DiffEntry that = (DiffEntry) o;
+            return beforeSamples == that.beforeSamples
+                    && afterSamples == that.afterSamples
+                    && deltaSamples == that.deltaSamples
+                    && Double.compare(that.deltaPct, deltaPct) == 0
+                    && java.util.Objects.equals(method, that.method)
+                    && java.util.Objects.equals(state, that.state);
+        }
+
+        @Override
+        public int hashCode() {
+            return java.util.Objects.hash(method, beforeSamples, afterSamples,
+                    deltaSamples, deltaPct, state);
+        }
+
+        @Override
+        public String toString() {
+            return "DiffEntry[method=" + method + ", beforeSamples=" + beforeSamples
+                    + ", afterSamples=" + afterSamples + ", deltaSamples=" + deltaSamples
+                    + ", deltaPct=" + deltaPct + ", state=" + state + "]";
+        }
+    }
 
     /**
      * Computes a diff between two snapshots, sorted by |delta| descending.
@@ -214,15 +259,15 @@ public final class ProfileSnapshot {
         for (int i = 0; i < s.length(); i++) {
             char c = s.charAt(i);
             switch (c) {
-                case '"'  -> sb.append("\\\"");
-                case '\\' -> sb.append("\\\\");
-                case '\n' -> sb.append("\\n");
-                case '\r' -> sb.append("\\r");
-                case '\t' -> sb.append("\\t");
-                default   -> {
+                case '"': sb.append("\\\""); break;
+                case '\\': sb.append("\\\\"); break;
+                case '\n': sb.append("\\n"); break;
+                case '\r': sb.append("\\r"); break;
+                case '\t': sb.append("\\t"); break;
+                default:
                     if (c < 0x20) sb.append(String.format("\\u%04x", (int) c));
                     else sb.append(c);
-                }
+                    break;
             }
         }
         return sb.toString();

--- a/argus-cli/src/main/java/io/argus/cli/profiler/AllocationProfiler.java
+++ b/argus-cli/src/main/java/io/argus/cli/profiler/AllocationProfiler.java
@@ -70,7 +70,7 @@ public final class AllocationProfiler {
                     continue;
                 }
 
-                RecordedFrame top = stack.getFrames().getFirst();
+                RecordedFrame top = stack.getFrames().get(0);
                 String className = top.getMethod().getType().getName();
                 String methodName = top.getMethod().getName();
                 int lineNumber = top.getLineNumber();
@@ -113,59 +113,187 @@ public final class AllocationProfiler {
 
     /**
      * Aggregated allocation profile from a JFR recording.
-     *
-     * @param sites            allocation sites sorted by total bytes descending
-     * @param totalBytes       total bytes allocated across all events
-     * @param totalAllocations total number of allocation events
-     * @param durationSec      recording duration in seconds
      */
-    public record AllocationProfile(
-            List<AllocationSite> sites,
-            long totalBytes,
-            long totalAllocations,
-            double durationSec
-    ) {}
+    public static final class AllocationProfile {
+        private final List<AllocationSite> sites;
+        private final long totalBytes;
+        private final long totalAllocations;
+        private final double durationSec;
+
+        public AllocationProfile(List<AllocationSite> sites, long totalBytes,
+                                 long totalAllocations, double durationSec) {
+            this.sites = sites;
+            this.totalBytes = totalBytes;
+            this.totalAllocations = totalAllocations;
+            this.durationSec = durationSec;
+        }
+
+        public List<AllocationSite> sites() { return sites; }
+        public long totalBytes() { return totalBytes; }
+        public long totalAllocations() { return totalAllocations; }
+        public double durationSec() { return durationSec; }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (!(o instanceof AllocationProfile)) return false;
+            AllocationProfile that = (AllocationProfile) o;
+            return totalBytes == that.totalBytes
+                    && totalAllocations == that.totalAllocations
+                    && Double.compare(that.durationSec, durationSec) == 0
+                    && java.util.Objects.equals(sites, that.sites);
+        }
+
+        @Override
+        public int hashCode() {
+            return java.util.Objects.hash(sites, totalBytes, totalAllocations, durationSec);
+        }
+
+        @Override
+        public String toString() {
+            return "AllocationProfile[sites=" + sites + ", totalBytes=" + totalBytes
+                    + ", totalAllocations=" + totalAllocations + ", durationSec=" + durationSec + "]";
+        }
+    }
 
     /**
      * A single allocation hotspot aggregated from JFR stack top frames.
-     *
-     * @param className       fully-qualified class name
-     * @param methodName      method name
-     * @param lineNumber      source line number (0 if unknown)
-     * @param totalBytes      total bytes allocated at this site
-     * @param allocationCount number of allocation events at this site
-     * @param bytesPerSec     allocation rate in bytes/second
      */
-    public record AllocationSite(
-            String className,
-            String methodName,
-            int lineNumber,
-            long totalBytes,
-            long allocationCount,
-            double bytesPerSec
-    ) {}
+    public static final class AllocationSite {
+        private final String className;
+        private final String methodName;
+        private final int lineNumber;
+        private final long totalBytes;
+        private final long allocationCount;
+        private final double bytesPerSec;
+
+        public AllocationSite(String className, String methodName, int lineNumber,
+                              long totalBytes, long allocationCount, double bytesPerSec) {
+            this.className = className;
+            this.methodName = methodName;
+            this.lineNumber = lineNumber;
+            this.totalBytes = totalBytes;
+            this.allocationCount = allocationCount;
+            this.bytesPerSec = bytesPerSec;
+        }
+
+        public String className() { return className; }
+        public String methodName() { return methodName; }
+        public int lineNumber() { return lineNumber; }
+        public long totalBytes() { return totalBytes; }
+        public long allocationCount() { return allocationCount; }
+        public double bytesPerSec() { return bytesPerSec; }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (!(o instanceof AllocationSite)) return false;
+            AllocationSite that = (AllocationSite) o;
+            return lineNumber == that.lineNumber
+                    && totalBytes == that.totalBytes
+                    && allocationCount == that.allocationCount
+                    && Double.compare(that.bytesPerSec, bytesPerSec) == 0
+                    && java.util.Objects.equals(className, that.className)
+                    && java.util.Objects.equals(methodName, that.methodName);
+        }
+
+        @Override
+        public int hashCode() {
+            return java.util.Objects.hash(className, methodName, lineNumber,
+                    totalBytes, allocationCount, bytesPerSec);
+        }
+
+        @Override
+        public String toString() {
+            return "AllocationSite[className=" + className + ", methodName=" + methodName
+                    + ", lineNumber=" + lineNumber + ", totalBytes=" + totalBytes
+                    + ", allocationCount=" + allocationCount + ", bytesPerSec=" + bytesPerSec + "]";
+        }
+    }
 
     /**
      * Aggregated allocation view grouped by the <em>allocated type</em> rather than stack frame.
      * Answers "which classes are burning allocation bytes".
-     *
-     * @param sites       allocated types sorted by total bytes descending
-     * @param totalBytes  total bytes allocated across all events
-     * @param durationSec recording duration in seconds
      */
-    public record AllocationByClass(
-            List<AllocatedType> sites,
-            long totalBytes,
-            double durationSec
-    ) {}
+    public static final class AllocationByClass {
+        private final List<AllocatedType> sites;
+        private final long totalBytes;
+        private final double durationSec;
+
+        public AllocationByClass(List<AllocatedType> sites, long totalBytes, double durationSec) {
+            this.sites = sites;
+            this.totalBytes = totalBytes;
+            this.durationSec = durationSec;
+        }
+
+        public List<AllocatedType> sites() { return sites; }
+        public long totalBytes() { return totalBytes; }
+        public double durationSec() { return durationSec; }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (!(o instanceof AllocationByClass)) return false;
+            AllocationByClass that = (AllocationByClass) o;
+            return totalBytes == that.totalBytes
+                    && Double.compare(that.durationSec, durationSec) == 0
+                    && java.util.Objects.equals(sites, that.sites);
+        }
+
+        @Override
+        public int hashCode() {
+            return java.util.Objects.hash(sites, totalBytes, durationSec);
+        }
+
+        @Override
+        public String toString() {
+            return "AllocationByClass[sites=" + sites + ", totalBytes=" + totalBytes
+                    + ", durationSec=" + durationSec + "]";
+        }
+    }
 
     /** A single allocated-type row: the class that was allocated, not the code that allocated it. */
-    public record AllocatedType(
-            String className,
-            long totalBytes,
-            long allocationCount,
-            double bytesPerSec
-    ) {}
+    public static final class AllocatedType {
+        private final String className;
+        private final long totalBytes;
+        private final long allocationCount;
+        private final double bytesPerSec;
+
+        public AllocatedType(String className, long totalBytes,
+                             long allocationCount, double bytesPerSec) {
+            this.className = className;
+            this.totalBytes = totalBytes;
+            this.allocationCount = allocationCount;
+            this.bytesPerSec = bytesPerSec;
+        }
+
+        public String className() { return className; }
+        public long totalBytes() { return totalBytes; }
+        public long allocationCount() { return allocationCount; }
+        public double bytesPerSec() { return bytesPerSec; }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (!(o instanceof AllocatedType)) return false;
+            AllocatedType that = (AllocatedType) o;
+            return totalBytes == that.totalBytes
+                    && allocationCount == that.allocationCount
+                    && Double.compare(that.bytesPerSec, bytesPerSec) == 0
+                    && java.util.Objects.equals(className, that.className);
+        }
+
+        @Override
+        public int hashCode() {
+            return java.util.Objects.hash(className, totalBytes, allocationCount, bytesPerSec);
+        }
+
+        @Override
+        public String toString() {
+            return "AllocatedType[className=" + className + ", totalBytes=" + totalBytes
+                    + ", allocationCount=" + allocationCount + ", bytesPerSec=" + bytesPerSec + "]";
+        }
+    }
 
     // -------------------------------------------------------------------------
     // New: group by allocated class

--- a/argus-cli/src/main/java/io/argus/cli/provider/jdk/JcmdExecutor.java
+++ b/argus-cli/src/main/java/io/argus/cli/provider/jdk/JcmdExecutor.java
@@ -105,7 +105,7 @@ public final class JcmdExecutor {
                 try (BufferedReader br = new BufferedReader(new InputStreamReader(process.getInputStream()))) {
                     String line;
                     while ((line = br.readLine()) != null) {
-                        if (!outputBuf.isEmpty()) outputBuf.append('\n');
+                        if (outputBuf.length() > 0) outputBuf.append('\n');
                         outputBuf.append(line);
                     }
                 } catch (Exception ignored) {}

--- a/argus-cli/src/main/java/io/argus/cli/provider/jdk/JdkCompilerProvider.java
+++ b/argus-cli/src/main/java/io/argus/cli/provider/jdk/JdkCompilerProvider.java
@@ -91,7 +91,7 @@ public final class JdkCompilerProvider implements CompilerProvider {
             if (Character.isDigit(c)) sb.append(c);
             else break;
         }
-        if (sb.isEmpty()) return 0;
+        if (sb.length() == 0) return 0;
         return Long.parseLong(sb.toString());
     }
 
@@ -104,7 +104,7 @@ public final class JdkCompilerProvider implements CompilerProvider {
             if (Character.isDigit(c)) sb.append(c);
             else break;
         }
-        if (sb.isEmpty()) return 0;
+        if (sb.length() == 0) return 0;
         return Integer.parseInt(sb.toString());
     }
 }

--- a/argus-cli/src/main/java/io/argus/cli/provider/jdk/JdkGcAgeProvider.java
+++ b/argus-cli/src/main/java/io/argus/cli/provider/jdk/JdkGcAgeProvider.java
@@ -95,7 +95,7 @@ public final class JdkGcAgeProvider implements GcAgeProvider {
         }
 
         long survivorCapacity = entries.isEmpty() ? 0
-                : entries.getLast().cumulativeBytes();
+                : entries.get(entries.size() - 1).cumulativeBytes();
         return new AgeDistribution(entries, tenuringThreshold, maxTenuringThreshold,
                 desiredSurvivorSize, survivorCapacity);
     }

--- a/argus-cli/src/main/java/io/argus/cli/provider/jdk/JdkInfoProvider.java
+++ b/argus-cli/src/main/java/io/argus/cli/provider/jdk/JdkInfoProvider.java
@@ -159,9 +159,10 @@ public final class JdkInfoProvider implements InfoProvider {
                     java.lang.management.ManagementFactory.getOperatingSystemMXBean();
             availableProcessors = availableProcessors > 0 ? availableProcessors : os.getAvailableProcessors();
             systemLoadAverage = os.getSystemLoadAverage();
-            if (os instanceof com.sun.management.OperatingSystemMXBean sunOs) {
+            if (os instanceof com.sun.management.OperatingSystemMXBean) {
+                com.sun.management.OperatingSystemMXBean sunOs = (com.sun.management.OperatingSystemMXBean) os;
                 processCpuLoad = sunOs.getProcessCpuLoad();
-                systemCpuLoad = sunOs.getCpuLoad();
+                systemCpuLoad = sunOs.getSystemCpuLoad();
             }
         } catch (Exception ignored) {}
 

--- a/argus-cli/src/main/java/io/argus/cli/provider/jdk/JdkMetaspaceProvider.java
+++ b/argus-cli/src/main/java/io/argus/cli/provider/jdk/JdkMetaspaceProvider.java
@@ -166,12 +166,12 @@ public final class JdkMetaspaceProvider implements MetaspaceProvider {
     private static long parseSize(String numStr, String unit) {
         try {
             double value = Double.parseDouble(numStr);
-            return switch (unit) {
-                case "KB" -> (long) (value * 1024);
-                case "MB" -> (long) (value * 1024 * 1024);
-                case "GB" -> (long) (value * 1024L * 1024 * 1024);
-                default -> (long) value;
-            };
+            switch (unit) {
+                case "KB": return (long) (value * 1024);
+                case "MB": return (long) (value * 1024 * 1024);
+                case "GB": return (long) (value * 1024L * 1024 * 1024);
+                default: return (long) value;
+            }
         } catch (NumberFormatException e) {
             return 0;
         }

--- a/argus-cli/src/main/java/io/argus/cli/provider/jdk/JdkSearchClassProvider.java
+++ b/argus-cli/src/main/java/io/argus/cli/provider/jdk/JdkSearchClassProvider.java
@@ -108,15 +108,15 @@ public final class JdkSearchClassProvider implements SearchClassProvider {
         for (int i = 0; i < glob.length(); i++) {
             char c = glob.charAt(i);
             switch (c) {
-                case '*' -> regex.append(".*");
-                case '?' -> regex.append(".");
-                case '.' -> regex.append("\\.");
-                case '$' -> regex.append("\\$");
-                case '[' -> regex.append("\\[");
-                case ']' -> regex.append("\\]");
-                case '(' -> regex.append("\\(");
-                case ')' -> regex.append("\\)");
-                default -> regex.append(c);
+                case '*': regex.append(".*"); break;
+                case '?': regex.append("."); break;
+                case '.': regex.append("\\."); break;
+                case '$': regex.append("\\$"); break;
+                case '[': regex.append("\\["); break;
+                case ']': regex.append("\\]"); break;
+                case '(': regex.append("\\("); break;
+                case ')': regex.append("\\)"); break;
+                default: regex.append(c); break;
             }
         }
         return Pattern.compile(regex.toString(), Pattern.CASE_INSENSITIVE);

--- a/argus-cli/src/main/java/io/argus/cli/suggest/ProfileSuggestions.java
+++ b/argus-cli/src/main/java/io/argus/cli/suggest/ProfileSuggestions.java
@@ -247,19 +247,55 @@ public final class ProfileSuggestions {
 
     /**
      * A single profile-driven recommendation.
-     *
-     * @param ruleName    internal identifier for the rule that fired
-     * @param confidence  LOW / MED / HIGH
-     * @param flag        JVM flag string, or empty string for non-flag hints
-     * @param rationale   one-line explanation
-     * @param evidence    hot method name that triggered the rule
-     * @param evidencePct percentage of total samples attributed to the evidence method
      */
-    public record ProfileRecommendation(
-            String ruleName,
-            Confidence confidence,
-            String flag,
-            String rationale,
-            String evidence,
-            double evidencePct) {}
+    public static final class ProfileRecommendation {
+        private final String ruleName;
+        private final Confidence confidence;
+        private final String flag;
+        private final String rationale;
+        private final String evidence;
+        private final double evidencePct;
+
+        public ProfileRecommendation(String ruleName, Confidence confidence, String flag,
+                                     String rationale, String evidence, double evidencePct) {
+            this.ruleName = ruleName;
+            this.confidence = confidence;
+            this.flag = flag;
+            this.rationale = rationale;
+            this.evidence = evidence;
+            this.evidencePct = evidencePct;
+        }
+
+        public String ruleName() { return ruleName; }
+        public Confidence confidence() { return confidence; }
+        public String flag() { return flag; }
+        public String rationale() { return rationale; }
+        public String evidence() { return evidence; }
+        public double evidencePct() { return evidencePct; }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (!(o instanceof ProfileRecommendation)) return false;
+            ProfileRecommendation that = (ProfileRecommendation) o;
+            return Double.compare(that.evidencePct, evidencePct) == 0
+                    && java.util.Objects.equals(ruleName, that.ruleName)
+                    && confidence == that.confidence
+                    && java.util.Objects.equals(flag, that.flag)
+                    && java.util.Objects.equals(rationale, that.rationale)
+                    && java.util.Objects.equals(evidence, that.evidence);
+        }
+
+        @Override
+        public int hashCode() {
+            return java.util.Objects.hash(ruleName, confidence, flag, rationale, evidence, evidencePct);
+        }
+
+        @Override
+        public String toString() {
+            return "ProfileRecommendation[ruleName=" + ruleName + ", confidence=" + confidence
+                    + ", flag=" + flag + ", rationale=" + rationale + ", evidence=" + evidence
+                    + ", evidencePct=" + evidencePct + "]";
+        }
+    }
 }

--- a/argus-cli/src/main/java/io/argus/cli/tui/TuiApp.java
+++ b/argus-cli/src/main/java/io/argus/cli/tui/TuiApp.java
@@ -123,9 +123,9 @@ public final class TuiApp {
                 StringBuilder sb = new StringBuilder(H * (W + 40));
                 sb.append("\033[1;").append(H).append("r\033[H");
                 switch (phase) {
-                    case PS -> drawPS(sb, W, H, ml);
-                    case CMD -> drawCMD(sb, W, H, ml);
-                    case OUT -> drawOUT(sb, W, H, ml);
+                    case PS: drawPS(sb, W, H, ml); break;
+                    case CMD: drawCMD(sb, W, H, ml); break;
+                    case OUT: drawOUT(sb, W, H, ml); break;
                 }
                 byte[] frame = sb.toString().getBytes(java.nio.charset.StandardCharsets.UTF_8);
                 rawOut.write(frame);
@@ -157,10 +157,13 @@ public final class TuiApp {
         }
         if (langSelect) {
             switch (key) {
-                case 'j' -> { if (langSelIdx < LANGS.length-1) langSelIdx++; }
-                case 'k' -> { if (langSelIdx > 0) langSelIdx--; }
-                case 10, 13 -> { langIdx = langSelIdx; messages = new Messages(LANGS[langIdx]); langSelect = false; }
-                case 'q', 'Q' -> langSelect = false;
+                case 'j': if (langSelIdx < LANGS.length-1) langSelIdx++; break;
+                case 'k': if (langSelIdx > 0) langSelIdx--; break;
+                case 10:
+                case 13: langIdx = langSelIdx; messages = new Messages(LANGS[langIdx]); langSelect = false; break;
+                case 'q':
+                case 'Q': langSelect = false; break;
+                default: break;
             }
             return;
         }
@@ -171,26 +174,33 @@ public final class TuiApp {
             return;
         }
         switch (key) {
-            case 'q','Q' -> back();
-            case 'j' -> dn(); case 'k' -> up();
-            case '/' -> { if (phase == Phase.CMD) { searching = true; sq = ""; } }
-            case 'r','R' -> { if (phase == Phase.PS) refreshPs(); }
-            case 'l','L' -> { langSelect = true; langSelIdx = langIdx; }
-            case 't','T' -> themeIdx = (themeIdx+1) % THEME_NAMES.length;
-            case 'w','W' -> { if (phase == Phase.CMD) writePopup = !writePopup; }
-            case 10, 13 -> enter();
-            default -> {}
+            case 'q':
+            case 'Q': back(); break;
+            case 'j': dn(); break;
+            case 'k': up(); break;
+            case '/': if (phase == Phase.CMD) { searching = true; sq = ""; } break;
+            case 'r':
+            case 'R': if (phase == Phase.PS) refreshPs(); break;
+            case 'l':
+            case 'L': langSelect = true; langSelIdx = langIdx; break;
+            case 't':
+            case 'T': themeIdx = (themeIdx+1) % THEME_NAMES.length; break;
+            case 'w':
+            case 'W': if (phase == Phase.CMD) writePopup = !writePopup; break;
+            case 10:
+            case 13: enter(); break;
+            default: break;
         }
     }
 
-    private void back() { switch(phase){ case OUT->{stopExec();phase=Phase.CMD;oScr=0;} case CMD->{if(!sq.isEmpty()){sq="";filter();}else{phase=Phase.PS;psIdx=0;}} case PS->running=false; }}
+    private void back() { switch(phase){ case OUT: stopExec();phase=Phase.CMD;oScr=0; break; case CMD: if(!sq.isEmpty()){sq="";filter();}else{phase=Phase.PS;psIdx=0;} break; case PS: running=false; break; }}
     private void stopExec() { if(execThread!=null&&execThread.isAlive()){execThread.interrupt();execRunning=false;} }
-    private void dn() { switch(phase){ case PS->{if(psIdx<procs.size()-1)psIdx++;} case CMD->{int n=cIdx+1;while(n<fCmds.size()&&fCmds.get(n).h)n++;if(n<fCmds.size())cIdx=n;} case OUT->oScr++; }}
-    private void up() { switch(phase){ case PS->{if(psIdx>0)psIdx--;} case CMD->{int p=cIdx-1;while(p>=0&&fCmds.get(p).h)p--;if(p>=0)cIdx=p;} case OUT->{if(oScr>0)oScr--;} }}
+    private void dn() { switch(phase){ case PS: if(psIdx<procs.size()-1)psIdx++; break; case CMD: {int n=cIdx+1;while(n<fCmds.size()&&fCmds.get(n).h)n++;if(n<fCmds.size())cIdx=n;} break; case OUT: oScr++; break; }}
+    private void up() { switch(phase){ case PS: if(psIdx>0)psIdx--; break; case CMD: {int p=cIdx-1;while(p>=0&&fCmds.get(p).h)p--;if(p>=0)cIdx=p;} break; case OUT: if(oScr>0)oScr--; break; }}
     private void enter() { switch(phase){
-        case PS->{if(psIdx<procs.size()){pid=procs.get(psIdx).pid();pidName=procs.get(psIdx).mainClass();phase=Phase.CMD;cIdx=0;cScr=0;sq="";filter();while(cIdx<fCmds.size()&&fCmds.get(cIdx).h)cIdx++;}}
-        case CMD->{if(cIdx<fCmds.size()&&!fCmds.get(cIdx).h)exec(fCmds.get(cIdx));}
-        case OUT->phase=Phase.CMD;
+        case PS: if(psIdx<procs.size()){pid=procs.get(psIdx).pid();pidName=procs.get(psIdx).mainClass();phase=Phase.CMD;cIdx=0;cScr=0;sq="";filter();while(cIdx<fCmds.size()&&fCmds.get(cIdx).h)cIdx++;} break;
+        case CMD: if(cIdx<fCmds.size()&&!fCmds.get(cIdx).h)exec(fCmds.get(cIdx)); break;
+        case OUT: phase=Phase.CMD; break;
     }}
     private volatile Thread execThread;
     private volatile ByteArrayOutputStream execCap;
@@ -428,11 +438,51 @@ public final class TuiApp {
     }
 
     private static String langLabel(int i) {
-        return switch(i) { case 0->"English"; case 1->"한국어"; case 2->"日本語"; case 3->"中文"; default->""; };
+        switch(i) {
+            case 0: return "English";
+            case 1: return "한국어";
+            case 2: return "日本語";
+            case 3: return "中文";
+            default: return "";
+        }
     }
 
     private static String pad(String s, int w) { return s.length()>=w?s.substring(0,w):s+" ".repeat(w-s.length()); }
     private static String trn(String s, int m) { return m<=0?"":s.length()<=m?s:s.substring(0,m-1)+"…"; }
 
-    record CE(Command c, String n, boolean h) {}
+    static final class CE {
+        final Command c;
+        final String n;
+        final boolean h;
+
+        CE(Command c, String n, boolean h) {
+            this.c = c;
+            this.n = n;
+            this.h = h;
+        }
+
+        Command c() { return c; }
+        String n() { return n; }
+        boolean h() { return h; }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (!(o instanceof CE)) return false;
+            CE that = (CE) o;
+            return h == that.h
+                    && java.util.Objects.equals(c, that.c)
+                    && java.util.Objects.equals(n, that.n);
+        }
+
+        @Override
+        public int hashCode() {
+            return java.util.Objects.hash(c, n, h);
+        }
+
+        @Override
+        public String toString() {
+            return "CE[c=" + c + ", n=" + n + ", h=" + h + "]";
+        }
+    }
 }

--- a/argus-cli/src/main/java/io/argus/cli/zgc/ZgcBaseline.java
+++ b/argus-cli/src/main/java/io/argus/cli/zgc/ZgcBaseline.java
@@ -106,11 +106,52 @@ public final class ZgcBaseline {
 
     public enum Severity { INFO, WARN, REGRESSION }
 
-    public record DiffRow(String label,
-                          String baselineValue,
-                          String currentValue,
-                          String delta,
-                          Severity severity) {}
+    public static final class DiffRow {
+        private final String label;
+        private final String baselineValue;
+        private final String currentValue;
+        private final String delta;
+        private final Severity severity;
+
+        public DiffRow(String label, String baselineValue, String currentValue,
+                       String delta, Severity severity) {
+            this.label = label;
+            this.baselineValue = baselineValue;
+            this.currentValue = currentValue;
+            this.delta = delta;
+            this.severity = severity;
+        }
+
+        public String label() { return label; }
+        public String baselineValue() { return baselineValue; }
+        public String currentValue() { return currentValue; }
+        public String delta() { return delta; }
+        public Severity severity() { return severity; }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (!(o instanceof DiffRow)) return false;
+            DiffRow that = (DiffRow) o;
+            return java.util.Objects.equals(label, that.label)
+                    && java.util.Objects.equals(baselineValue, that.baselineValue)
+                    && java.util.Objects.equals(currentValue, that.currentValue)
+                    && java.util.Objects.equals(delta, that.delta)
+                    && severity == that.severity;
+        }
+
+        @Override
+        public int hashCode() {
+            return java.util.Objects.hash(label, baselineValue, currentValue, delta, severity);
+        }
+
+        @Override
+        public String toString() {
+            return "DiffRow[label=" + label + ", baselineValue=" + baselineValue
+                    + ", currentValue=" + currentValue + ", delta=" + delta
+                    + ", severity=" + severity + "]";
+        }
+    }
 
     // ── save ─────────────────────────────────────────────────────────────────
 

--- a/argus-cli/src/main/java/io/argus/cli/zgc/ZgcDiagnosis.java
+++ b/argus-cli/src/main/java/io/argus/cli/zgc/ZgcDiagnosis.java
@@ -24,13 +24,77 @@ public final class ZgcDiagnosis {
     public enum Verdict { HEALTHY, WARNING, UNHEALTHY }
 
     /** Allocation stall captured from {@code jdk.ZAllocationStall}. */
-    public record Stall(String thread, double durationMs) {}
+    public static final class Stall {
+        private final String thread;
+        private final double durationMs;
+
+        public Stall(String thread, double durationMs) {
+            this.thread = thread;
+            this.durationMs = durationMs;
+        }
+
+        public String thread() { return thread; }
+        public double durationMs() { return durationMs; }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (!(o instanceof Stall)) return false;
+            Stall that = (Stall) o;
+            return Double.compare(that.durationMs, durationMs) == 0
+                    && java.util.Objects.equals(thread, that.thread);
+        }
+
+        @Override
+        public int hashCode() {
+            return java.util.Objects.hash(thread, durationMs);
+        }
+
+        @Override
+        public String toString() {
+            return "Stall[thread=" + thread + ", durationMs=" + durationMs + "]";
+        }
+    }
 
     /**
      * Top allocation call site correlated with stalls, derived from
      * {@code jdk.ObjectAllocationInNewTLAB} / {@code jdk.ObjectAllocationOutsideTLAB} events.
      */
-    public record AllocHotspot(String frame, long count, double pct) {}
+    public static final class AllocHotspot {
+        private final String frame;
+        private final long count;
+        private final double pct;
+
+        public AllocHotspot(String frame, long count, double pct) {
+            this.frame = frame;
+            this.count = count;
+            this.pct = pct;
+        }
+
+        public String frame() { return frame; }
+        public long count() { return count; }
+        public double pct() { return pct; }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (!(o instanceof AllocHotspot)) return false;
+            AllocHotspot that = (AllocHotspot) o;
+            return count == that.count
+                    && Double.compare(that.pct, pct) == 0
+                    && java.util.Objects.equals(frame, that.frame);
+        }
+
+        @Override
+        public int hashCode() {
+            return java.util.Objects.hash(frame, count, pct);
+        }
+
+        @Override
+        public String toString() {
+            return "AllocHotspot[frame=" + frame + ", count=" + count + ", pct=" + pct + "]";
+        }
+    }
 
     // ── Process / GC identity ───────────────────────────────────────────────
     public boolean usingZgc;

--- a/argus-cli/src/main/java/io/argus/cli/zgc/ZgcJfrCollector.java
+++ b/argus-cli/src/main/java/io/argus/cli/zgc/ZgcJfrCollector.java
@@ -69,7 +69,7 @@ public final class ZgcJfrCollector {
                 String typeName = event.getEventType().getName();
 
                 switch (typeName) {
-                    case "jdk.ZAllocationStall" -> {
+                    case "jdk.ZAllocationStall": {
                         String threadName = "";
                         try {
                             RecordedObject thread = event.getValue("thread");
@@ -83,9 +83,9 @@ public final class ZgcJfrCollector {
                         double durMs = event.getDuration().toNanos() / 1_000_000.0;
                         d.stalls.add(new ZgcDiagnosis.Stall(
                                 threadName == null ? "" : threadName, durMs));
+                        break;
                     }
-
-                    case "jdk.ZYoungGarbageCollection" -> {
+                    case "jdk.ZYoungGarbageCollection": {
                         d.generational = true;
                         d.minorCycles++;
                         Instant start = event.getStartTime();
@@ -98,9 +98,9 @@ public final class ZgcJfrCollector {
                             d.cycleOverlap = true;
                         }
                         prevZEnd = end;
+                        break;
                     }
-
-                    case "jdk.ZOldGarbageCollection" -> {
+                    case "jdk.ZOldGarbageCollection": {
                         d.generational = true;
                         d.majorCycles++;
                         Instant start = event.getStartTime();
@@ -113,9 +113,9 @@ public final class ZgcJfrCollector {
                             d.cycleOverlap = true;
                         }
                         prevZEnd = end;
+                        break;
                     }
-
-                    case "jdk.ZGarbageCollection" -> {
+                    case "jdk.ZGarbageCollection": {
                         // Non-generational cycle: counts toward majorCycles only when
                         // generational events haven't been observed; treat as cycle-count
                         // input so we still report something.
@@ -132,9 +132,9 @@ public final class ZgcJfrCollector {
                             d.cycleOverlap = true;
                         }
                         prevZEnd = end;
+                        break;
                     }
-
-                    case "jdk.GarbageCollection" -> {
+                    case "jdk.GarbageCollection": {
                         // The "name" field carries the pause label for ZGC STW phases.
                         String name = safeGetString(event, "name");
                         long durNs = event.getDuration().toNanos();
@@ -146,9 +146,9 @@ public final class ZgcJfrCollector {
                         } else if (name.contains("Pause Relocate Start")) {
                             relocStartNs += durNs; relocStartCount++;
                         }
+                        break;
                     }
-
-                    case "jdk.GCHeapSummary" -> {
+                    case "jdk.GCHeapSummary": {
                         try {
                             RecordedObject heapSpace = event.getValue("heapSpace");
                             if (heapSpace != null) {
@@ -161,14 +161,18 @@ public final class ZgcJfrCollector {
                                 }
                             }
                         } catch (Exception ignored) {}
+                        break;
                     }
-
-                    case "jdk.ObjectAllocationInNewTLAB", "jdk.ObjectAllocationOutsideTLAB" -> {
+                    case "jdk.ObjectAllocationInNewTLAB":
+                    case "jdk.ObjectAllocationOutsideTLAB": {
                         String topFrame = extractTopUserFrame(event);
                         if (topFrame != null) {
                             allocCounts.merge(topFrame, 1L, Long::sum);
                         }
+                        break;
                     }
+                    default:
+                        break;
                 }
             }
         }

--- a/argus-cli/src/test/java/io/argus/cli/classleak/ClassLeakDiffTest.java
+++ b/argus-cli/src/test/java/io/argus/cli/classleak/ClassLeakDiffTest.java
@@ -156,16 +156,15 @@ class ClassLeakDiffTest {
 
     @Test
     void parserHandlesActualJcmdOutput() {
-        String raw = """
-                ClassLoader         Parent              CLD*               Classes   ChunkSz   BlockSz  Type
-                0x0000000000000000  0x0000000000000000  0x0000000cb30b8e60    2447   8028160   7669896  <boot class loader>
-                                                                                62    191488    123512   + hidden classes
-                0x0000000500068770  0x0000000500069008  0x0000000cb30b9400     735   5586944   5581408  jdk.internal.loader.ClassLoaders$AppClassLoader
-                0x0000000500069008  0x0000000000000000  0x0000000cb30b9360       3     41984     39576  jdk.internal.loader.ClassLoaders$PlatformClassLoader
-                Total = 3                                                      3247  13848576  13414392
-                ChunkSz: Total size of all allocated metaspace chunks
-                BlockSz: Total size of all allocated metaspace blocks (each chunk has several blocks)
-                """;
+        String raw =
+                "ClassLoader         Parent              CLD*               Classes   ChunkSz   BlockSz  Type\n" +
+                "0x0000000000000000  0x0000000000000000  0x0000000cb30b8e60    2447   8028160   7669896  <boot class loader>\n" +
+                "                                                                62    191488    123512   + hidden classes\n" +
+                "0x0000000500068770  0x0000000500069008  0x0000000cb30b9400     735   5586944   5581408  jdk.internal.loader.ClassLoaders$AppClassLoader\n" +
+                "0x0000000500069008  0x0000000000000000  0x0000000cb30b9360       3     41984     39576  jdk.internal.loader.ClassLoaders$PlatformClassLoader\n" +
+                "Total = 3                                                      3247  13848576  13414392\n" +
+                "ChunkSz: Total size of all allocated metaspace chunks\n" +
+                "BlockSz: Total size of all allocated metaspace blocks (each chunk has several blocks)\n";
 
         List<ClassLoaderEntry> entries = ClassLeakAnalyzer.parse(raw);
 

--- a/argus-cli/src/test/java/io/argus/cli/cluster/PrometheusTextParserTest.java
+++ b/argus-cli/src/test/java/io/argus/cli/cluster/PrometheusTextParserTest.java
@@ -8,31 +8,29 @@ import static org.junit.jupiter.api.Assertions.*;
 
 class PrometheusTextParserTest {
 
-    private static final String SAMPLE = """
-            # HELP argus_heap_used_percent Heap used percent
-            # TYPE argus_heap_used_percent gauge
-            argus_heap_used_percent 56.3
-            # HELP argus_gc_overhead_percent GC overhead percent
-            # TYPE argus_gc_overhead_percent gauge
-            argus_gc_overhead_percent 2.1
-            # HELP argus_cpu_process_percent Process CPU percent
-            # TYPE argus_cpu_process_percent gauge
-            argus_cpu_process_percent 12.0
-            # HELP argus_virtual_threads_active Active virtual threads
-            # TYPE argus_virtual_threads_active gauge
-            argus_virtual_threads_active 1234.0
-            # HELP argus_memory_leak_suspected Memory leak flag
-            # TYPE argus_memory_leak_suspected gauge
-            argus_memory_leak_suspected 0.0
-            """;
+    private static final String SAMPLE =
+            "# HELP argus_heap_used_percent Heap used percent\n" +
+            "# TYPE argus_heap_used_percent gauge\n" +
+            "argus_heap_used_percent 56.3\n" +
+            "# HELP argus_gc_overhead_percent GC overhead percent\n" +
+            "# TYPE argus_gc_overhead_percent gauge\n" +
+            "argus_gc_overhead_percent 2.1\n" +
+            "# HELP argus_cpu_process_percent Process CPU percent\n" +
+            "# TYPE argus_cpu_process_percent gauge\n" +
+            "argus_cpu_process_percent 12.0\n" +
+            "# HELP argus_virtual_threads_active Active virtual threads\n" +
+            "# TYPE argus_virtual_threads_active gauge\n" +
+            "argus_virtual_threads_active 1234.0\n" +
+            "# HELP argus_memory_leak_suspected Memory leak flag\n" +
+            "# TYPE argus_memory_leak_suspected gauge\n" +
+            "argus_memory_leak_suspected 0.0\n";
 
-    private static final String SAMPLE_WITH_LABELS = """
-            # HELP jvm_memory_used_bytes Memory used
-            # TYPE jvm_memory_used_bytes gauge
-            jvm_memory_used_bytes{area="heap",id="G1 Eden Space"} 12345678.0
-            jvm_gc_overhead_percent{gc="G1"} 8.3
-            process_cpu_usage 0.67
-            """;
+    private static final String SAMPLE_WITH_LABELS =
+            "# HELP jvm_memory_used_bytes Memory used\n" +
+            "# TYPE jvm_memory_used_bytes gauge\n" +
+            "jvm_memory_used_bytes{area=\"heap\",id=\"G1 Eden Space\"} 12345678.0\n" +
+            "jvm_gc_overhead_percent{gc=\"G1\"} 8.3\n" +
+            "process_cpu_usage 0.67\n";
 
     @Test
     void parsesBasicMetrics() {

--- a/argus-cli/src/test/java/io/argus/cli/doctor/DoctorEngineTest.java
+++ b/argus-cli/src/test/java/io/argus/cli/doctor/DoctorEngineTest.java
@@ -135,7 +135,7 @@ class DoctorEngineTest {
         List<Finding> findings = DoctorEngine.diagnose(s);
         assertFalse(findings.isEmpty());
         // First finding should be CRITICAL
-        assertEquals(Severity.CRITICAL, findings.getFirst().severity());
+        assertEquals(Severity.CRITICAL, findings.get(0).severity());
     }
 
     @Test

--- a/argus-cli/src/test/java/io/argus/cli/doctor/rules/MaxPauseRuleTest.java
+++ b/argus-cli/src/test/java/io/argus/cli/doctor/rules/MaxPauseRuleTest.java
@@ -35,8 +35,8 @@ class MaxPauseRuleTest {
         JvmSnapshot s = snapshotWithPause(500L); // exactly at default warn threshold
         List<Finding> findings = new MaxPauseRule().evaluate(s);
         assertEquals(1, findings.size());
-        assertEquals(Severity.WARNING, findings.getFirst().severity());
-        assertEquals("GC", findings.getFirst().category());
+        assertEquals(Severity.WARNING, findings.get(0).severity());
+        assertEquals("GC", findings.get(0).category());
     }
 
     @Test
@@ -44,8 +44,8 @@ class MaxPauseRuleTest {
         JvmSnapshot s = snapshotWithPause(1000L); // 1000ms: warn >= 500, critical < 2000
         List<Finding> findings = new MaxPauseRule().evaluate(s);
         assertEquals(1, findings.size());
-        assertEquals(Severity.WARNING, findings.getFirst().severity());
-        assertTrue(findings.getFirst().title().contains("1000ms"));
+        assertEquals(Severity.WARNING, findings.get(0).severity());
+        assertTrue(findings.get(0).title().contains("1000ms"));
     }
 
     // --- critical band ---
@@ -55,7 +55,7 @@ class MaxPauseRuleTest {
         JvmSnapshot s = snapshotWithPause(2000L); // exactly at default critical threshold
         List<Finding> findings = new MaxPauseRule().evaluate(s);
         assertEquals(1, findings.size());
-        assertEquals(Severity.CRITICAL, findings.getFirst().severity());
+        assertEquals(Severity.CRITICAL, findings.get(0).severity());
     }
 
     @Test
@@ -63,8 +63,8 @@ class MaxPauseRuleTest {
         JvmSnapshot s = snapshotWithPause(5000L);
         List<Finding> findings = new MaxPauseRule().evaluate(s);
         assertEquals(1, findings.size());
-        assertEquals(Severity.CRITICAL, findings.getFirst().severity());
-        assertTrue(findings.getFirst().title().contains("5000ms"));
+        assertEquals(Severity.CRITICAL, findings.get(0).severity());
+        assertTrue(findings.get(0).title().contains("5000ms"));
     }
 
     // --- custom threshold via constructor ---
@@ -83,7 +83,7 @@ class MaxPauseRuleTest {
         JvmSnapshot s = snapshotWithPause(1500L); // 1500ms >= custom warn of 1000ms, < critical 4000ms
         List<Finding> findings = rule.evaluate(s);
         assertEquals(1, findings.size());
-        assertEquals(Severity.WARNING, findings.getFirst().severity());
+        assertEquals(Severity.WARNING, findings.get(0).severity());
     }
 
     @Test
@@ -92,7 +92,7 @@ class MaxPauseRuleTest {
         JvmSnapshot s = snapshotWithPause(4500L); // 4500ms >= custom critical of 4000ms
         List<Finding> findings = rule.evaluate(s);
         assertEquals(1, findings.size());
-        assertEquals(Severity.CRITICAL, findings.getFirst().severity());
+        assertEquals(Severity.CRITICAL, findings.get(0).severity());
     }
 
     // --- missing data ---
@@ -109,7 +109,7 @@ class MaxPauseRuleTest {
     @Test
     void warningFinding_containsRecommendations() {
         JvmSnapshot s = snapshotWithPause(600L);
-        Finding f = new MaxPauseRule().evaluate(s).getFirst();
+        Finding f = new MaxPauseRule().evaluate(s).get(0);
         assertFalse(f.recommendations().isEmpty(), "Finding should include recommendations");
         assertTrue(f.recommendations().stream().anyMatch(r -> r.contains("ZGC")),
                 "Should recommend ZGC for sub-ms pauses");

--- a/argus-cli/src/test/java/io/argus/cli/doctor/rules/ZgcCycleOverlapRuleTest.java
+++ b/argus-cli/src/test/java/io/argus/cli/doctor/rules/ZgcCycleOverlapRuleTest.java
@@ -28,7 +28,7 @@ class ZgcCycleOverlapRuleTest {
 
         List<Finding> findings = new ZgcCycleOverlapRule().evaluate(s);
         assertEquals(1, findings.size());
-        Finding f = findings.getFirst();
+        Finding f = findings.get(0);
         assertEquals(Severity.CRITICAL, f.severity());
         assertEquals("GC", f.category());
         assertTrue(f.title().contains("overlap"), "Title should mention overlap risk");
@@ -113,7 +113,7 @@ class ZgcCycleOverlapRuleTest {
 
         List<Finding> findings = new ZgcCycleOverlapRule().evaluate(s);
         assertEquals(1, findings.size());
-        assertEquals(Severity.CRITICAL, findings.getFirst().severity());
+        assertEquals(Severity.CRITICAL, findings.get(0).severity());
     }
 
     // --- helpers ---

--- a/argus-cli/src/test/java/io/argus/cli/doctor/rules/ZgcSoftMaxBreachRuleTest.java
+++ b/argus-cli/src/test/java/io/argus/cli/doctor/rules/ZgcSoftMaxBreachRuleTest.java
@@ -20,7 +20,7 @@ class ZgcSoftMaxBreachRuleTest {
         JvmSnapshot s = snapshot("ZGC", 5 * GB, List.of("-XX:SoftMaxHeapSize=" + (4 * GB)));
         List<Finding> findings = new ZgcSoftMaxBreachRule().evaluate(s);
         assertEquals(1, findings.size());
-        Finding f = findings.getFirst();
+        Finding f = findings.get(0);
         assertEquals(Severity.WARNING, f.severity());
         assertEquals("GC", f.category());
         assertTrue(f.title().contains("SoftMaxHeapSize"), "Title should mention SoftMaxHeapSize");
@@ -73,7 +73,7 @@ class ZgcSoftMaxBreachRuleTest {
                 List.of("-XX:SoftMaxHeapSize=" + (4 * GB)));
         List<Finding> findings = new ZgcSoftMaxBreachRule().evaluate(s);
         assertEquals(1, findings.size());
-        assertEquals(Severity.WARNING, findings.getFirst().severity());
+        assertEquals(Severity.WARNING, findings.get(0).severity());
     }
 
     // --- parseSoftMaxHeapSize helper ---

--- a/argus-cli/src/test/java/io/argus/cli/gclog/GcLeakDetectorTest.java
+++ b/argus-cli/src/test/java/io/argus/cli/gclog/GcLeakDetectorTest.java
@@ -4,6 +4,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -93,7 +94,7 @@ class GcLeakDetectorTest {
                     0, 0, 8192));
         }
         // Caller is responsible for filtering; pass only pause events
-        List<GcEvent> pauseEvents = events.stream().filter(e -> !e.isConcurrent()).toList();
+        List<GcEvent> pauseEvents = events.stream().filter(e -> !e.isConcurrent()).collect(Collectors.toList());
         GcLeakDetector.LeakAnalysis r = GcLeakDetector.analyze(pauseEvents);
         assertNotNull(r);
         // Pattern should reflect only the pause events

--- a/argus-cli/src/test/java/io/argus/cli/gclog/GcLogParserTest.java
+++ b/argus-cli/src/test/java/io/argus/cli/gclog/GcLogParserTest.java
@@ -16,12 +16,11 @@ class GcLogParserTest {
 
     @Test
     void parseG1UnifiedLog() throws IOException {
-        String log = """
-                [0.234s][info][gc] GC(0) Pause Young (Normal) (G1 Evacuation Pause) 24M->8M(256M) 3.456ms
-                [0.567s][info][gc] GC(1) Pause Young (Normal) (G1 Evacuation Pause) 32M->12M(256M) 5.123ms
-                [1.234s][info][gc] GC(2) Pause Young (Concurrent Start) (G1 Humongous Allocation) 64M->32M(256M) 12.345ms
-                [5.678s][info][gc] GC(3) Concurrent Mark 45.678ms
-                """;
+        String log =
+                "[0.234s][info][gc] GC(0) Pause Young (Normal) (G1 Evacuation Pause) 24M->8M(256M) 3.456ms\n" +
+                "[0.567s][info][gc] GC(1) Pause Young (Normal) (G1 Evacuation Pause) 32M->12M(256M) 5.123ms\n" +
+                "[1.234s][info][gc] GC(2) Pause Young (Concurrent Start) (G1 Humongous Allocation) 64M->32M(256M) 12.345ms\n" +
+                "[5.678s][info][gc] GC(3) Concurrent Mark 45.678ms\n";
         Path file = tempDir.resolve("g1.log");
         Files.writeString(file, log);
 
@@ -29,7 +28,7 @@ class GcLogParserTest {
         assertEquals(4, events.size());
 
         // First event
-        GcEvent first = events.getFirst();
+        GcEvent first = events.get(0);
         assertEquals(0.234, first.timestampSec(), 0.001);
         assertTrue(first.pauseMs() > 3.0 && first.pauseMs() < 4.0);
         assertEquals(24 * 1024, first.heapBeforeKB());
@@ -38,28 +37,27 @@ class GcLogParserTest {
         assertFalse(first.isConcurrent());
 
         // Concurrent event
-        GcEvent concurrent = events.getLast();
+        GcEvent concurrent = events.get(events.size() - 1);
         assertTrue(concurrent.isConcurrent());
     }
 
     @Test
     void parseLegacyFormat() throws IOException {
-        String log = """
-                1.234: [GC (Allocation Failure) [PSYoungGen: 65536K->8192K(76288K)] 65536K->8200K(251392K), 0.0123456 secs]
-                5.678: [Full GC (Ergonomics) [PSYoungGen: 0K->0K(76288K)] 180000K->120000K(251392K), 0.5678901 secs]
-                """;
+        String log =
+                "1.234: [GC (Allocation Failure) [PSYoungGen: 65536K->8192K(76288K)] 65536K->8200K(251392K), 0.0123456 secs]\n" +
+                "5.678: [Full GC (Ergonomics) [PSYoungGen: 0K->0K(76288K)] 180000K->120000K(251392K), 0.5678901 secs]\n";
         Path file = tempDir.resolve("legacy.log");
         Files.writeString(file, log);
 
         List<GcEvent> events = GcLogParser.parse(file);
         assertEquals(2, events.size());
 
-        GcEvent young = events.getFirst();
+        GcEvent young = events.get(0);
         assertEquals("Young", young.type());
         assertEquals("Allocation Failure", young.cause());
         assertFalse(young.isFullGc());
 
-        GcEvent full = events.getLast();
+        GcEvent full = events.get(events.size() - 1);
         assertTrue(full.isFullGc());
         assertTrue(full.pauseMs() > 500);
     }
@@ -69,18 +67,17 @@ class GcLogParserTest {
         // Two events 5s apart across an ISO baseline. The first event's relative time is 0
         // (it IS the baseline); subsequent events are deltas. This semantics replaces the old
         // seconds-of-day extraction which silently wrapped at midnight.
-        String log = """
-                [2024-01-15T10:30:45.123+0000][info][gc] GC(0) Pause Young (G1 Evacuation Pause) 24M->8M(256M) 3.456ms
-                [2024-01-15T10:30:50.123+0000][info][gc] GC(1) Pause Young (G1 Evacuation Pause) 32M->12M(256M) 5.123ms
-                """;
+        String log =
+                "[2024-01-15T10:30:45.123+0000][info][gc] GC(0) Pause Young (G1 Evacuation Pause) 24M->8M(256M) 3.456ms\n" +
+                "[2024-01-15T10:30:50.123+0000][info][gc] GC(1) Pause Young (G1 Evacuation Pause) 32M->12M(256M) 5.123ms\n";
         Path file = tempDir.resolve("decorated.log");
         Files.writeString(file, log);
 
         List<GcEvent> events = GcLogParser.parse(file);
         assertEquals(2, events.size());
-        assertEquals(0.0, events.getFirst().timestampSec(), 0.001,
+        assertEquals(0.0, events.get(0).timestampSec(), 0.001,
                 "first ISO event sets baseline → relative timestamp is zero");
-        assertEquals(5.0, events.getLast().timestampSec(), 0.5,
+        assertEquals(5.0, events.get(events.size() - 1).timestampSec(), 0.5,
                 "second event is ~5s after the baseline");
     }
 
@@ -88,26 +85,24 @@ class GcLogParserTest {
     void parseShenandoahPause() throws IOException {
         // Real Shenandoah unified logs carry the [gc,shenandoah] tag; without that gate, a
         // bare "Pause Init Mark" line (which G1 also emits in some configs) would misclassify.
-        String log = """
-                [0.500s][info][gc,shenandoah] GC(0) Pause Init Mark 0.123ms
-                [0.600s][info][gc,shenandoah] GC(1) Pause Final Mark 0.456ms
-                """;
+        String log =
+                "[0.500s][info][gc,shenandoah] GC(0) Pause Init Mark 0.123ms\n" +
+                "[0.600s][info][gc,shenandoah] GC(1) Pause Final Mark 0.456ms\n";
         Path file = tempDir.resolve("shenandoah.log");
         Files.writeString(file, log);
 
         List<GcEvent> events = GcLogParser.parse(file);
         assertEquals(2, events.size());
-        assertTrue(events.getFirst().type().contains("Shenandoah"));
-        assertTrue(events.getFirst().pauseMs() < 1.0); // sub-ms precision
+        assertTrue(events.get(0).type().contains("Shenandoah"));
+        assertTrue(events.get(0).pauseMs() < 1.0); // sub-ms precision
     }
 
     @Test
     void parseZgcAllocationStalls() throws IOException {
-        String log = """
-                [1282.654s][info][gc] Allocation Stall (http-worker-347) 508.772ms
-                [1283.100s][info][gc] Allocation Stall (http-worker-348) 123.456ms
-                [1284.200s][info][gc] Allocation Stall (http-worker-347) 200.000ms
-                """;
+        String log =
+                "[1282.654s][info][gc] Allocation Stall (http-worker-347) 508.772ms\n" +
+                "[1283.100s][info][gc] Allocation Stall (http-worker-348) 123.456ms\n" +
+                "[1284.200s][info][gc] Allocation Stall (http-worker-347) 200.000ms\n";
         Path file = tempDir.resolve("zgc-stall.log");
         Files.writeString(file, log);
 
@@ -136,12 +131,11 @@ class GcLogParserTest {
     @Test
     void nonGcLines_ignored() throws IOException {
         // First line must hint unified format for auto-detection
-        String log = """
-                [0.001s][info][os] Application started in 2.345 seconds
-                [0.234s][info][gc] GC(0) Pause Young (Normal) (G1 Evacuation Pause) 24M->8M(256M) 3.456ms
-                [0.300s][info][os] Some random log line
-                [0.400s][info][os] Another non-GC line
-                """;
+        String log =
+                "[0.001s][info][os] Application started in 2.345 seconds\n" +
+                "[0.234s][info][gc] GC(0) Pause Young (Normal) (G1 Evacuation Pause) 24M->8M(256M) 3.456ms\n" +
+                "[0.300s][info][os] Some random log line\n" +
+                "[0.400s][info][os] Another non-GC line\n";
         Path file = tempDir.resolve("mixed.log");
         Files.writeString(file, log);
 

--- a/argus-cli/src/test/java/io/argus/cli/gclog/GcPhaseAnalyzerTest.java
+++ b/argus-cli/src/test/java/io/argus/cli/gclog/GcPhaseAnalyzerTest.java
@@ -16,14 +16,13 @@ class GcPhaseAnalyzerTest {
 
     @Test
     void parsePhaseEvents_fromDebugLog() throws IOException {
-        String log = """
-                [0.234s][debug][gc,phases] GC(0) Pre Evacuate Collection Set: 0.1ms
-                [0.234s][debug][gc,phases] GC(0) Merge Heap Roots: 0.3ms
-                [0.234s][debug][gc,phases] GC(0) Evacuate Collection Set: 5.2ms
-                [0.234s][debug][gc,phases] GC(0) Post Evacuate Collection Set: 1.1ms
-                [0.234s][debug][gc,phases] GC(0) Other: 0.8ms
-                [0.234s][info][gc] GC(0) Pause Young (Normal) (G1 Evacuation Pause) 24M->8M(256M) 7.500ms
-                """;
+        String log =
+                "[0.234s][debug][gc,phases] GC(0) Pre Evacuate Collection Set: 0.1ms\n" +
+                "[0.234s][debug][gc,phases] GC(0) Merge Heap Roots: 0.3ms\n" +
+                "[0.234s][debug][gc,phases] GC(0) Evacuate Collection Set: 5.2ms\n" +
+                "[0.234s][debug][gc,phases] GC(0) Post Evacuate Collection Set: 1.1ms\n" +
+                "[0.234s][debug][gc,phases] GC(0) Other: 0.8ms\n" +
+                "[0.234s][info][gc] GC(0) Pause Young (Normal) (G1 Evacuation Pause) 24M->8M(256M) 7.500ms\n";
         Path file = tempDir.resolve("phases.log");
         Files.writeString(file, log);
 
@@ -41,14 +40,13 @@ class GcPhaseAnalyzerTest {
 
     @Test
     void parsePhaseEvents_multipleGcCycles() throws IOException {
-        String log = """
-                [0.234s][debug][gc,phases] GC(0) Evacuate Collection Set: 5.2ms
-                [0.234s][debug][gc,phases] GC(0) Other: 0.8ms
-                [0.500s][debug][gc,phases] GC(1) Evacuate Collection Set: 7.4ms
-                [0.500s][debug][gc,phases] GC(1) Other: 1.2ms
-                [0.234s][info][gc] GC(0) Pause Young (Normal) (G1 Evacuation Pause) 24M->8M(256M) 6.0ms
-                [0.500s][info][gc] GC(1) Pause Young (Normal) (G1 Evacuation Pause) 32M->10M(256M) 8.6ms
-                """;
+        String log =
+                "[0.234s][debug][gc,phases] GC(0) Evacuate Collection Set: 5.2ms\n" +
+                "[0.234s][debug][gc,phases] GC(0) Other: 0.8ms\n" +
+                "[0.500s][debug][gc,phases] GC(1) Evacuate Collection Set: 7.4ms\n" +
+                "[0.500s][debug][gc,phases] GC(1) Other: 1.2ms\n" +
+                "[0.234s][info][gc] GC(0) Pause Young (Normal) (G1 Evacuation Pause) 24M->8M(256M) 6.0ms\n" +
+                "[0.500s][info][gc] GC(1) Pause Young (Normal) (G1 Evacuation Pause) 32M->10M(256M) 8.6ms\n";
         Path file = tempDir.resolve("multi.log");
         Files.writeString(file, log);
 
@@ -68,11 +66,10 @@ class GcPhaseAnalyzerTest {
 
     @Test
     void percentageCalculation_sumsTo100() throws IOException {
-        String log = """
-                [0.234s][debug][gc,phases] GC(0) Phase A: 3.0ms
-                [0.234s][debug][gc,phases] GC(0) Phase B: 7.0ms
-                [0.234s][info][gc] GC(0) Pause Young (Normal) (G1 Evacuation Pause) 24M->8M(256M) 10.0ms
-                """;
+        String log =
+                "[0.234s][debug][gc,phases] GC(0) Phase A: 3.0ms\n" +
+                "[0.234s][debug][gc,phases] GC(0) Phase B: 7.0ms\n" +
+                "[0.234s][info][gc] GC(0) Pause Young (Normal) (G1 Evacuation Pause) 24M->8M(256M) 10.0ms\n";
         Path file = tempDir.resolve("pct.log");
         Files.writeString(file, log);
 
@@ -100,10 +97,9 @@ class GcPhaseAnalyzerTest {
 
     @Test
     void nonPhaseLines_notParsedAsPhases() throws IOException {
-        String log = """
-                [0.234s][info][gc] GC(0) Pause Young (Normal) (G1 Evacuation Pause) 24M->8M(256M) 7.500ms
-                [0.235s][info][gc,heap] GC(0) Eden regions: 10->0(20)
-                """;
+        String log =
+                "[0.234s][info][gc] GC(0) Pause Young (Normal) (G1 Evacuation Pause) 24M->8M(256M) 7.500ms\n" +
+                "[0.235s][info][gc,heap] GC(0) Eden regions: 10->0(20)\n";
         Path file = tempDir.resolve("nophases.log");
         Files.writeString(file, log);
 

--- a/argus-cli/src/test/java/io/argus/cli/gclog/GcRateAnalyzerTest.java
+++ b/argus-cli/src/test/java/io/argus/cli/gclog/GcRateAnalyzerTest.java
@@ -3,13 +3,14 @@ package io.argus.cli.gclog;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 import static org.junit.jupiter.api.Assertions.*;
 
 class GcRateAnalyzerTest {
 
     private static List<GcEvent> pauseOnly(List<GcEvent> events) {
-        return events.stream().filter(e -> !e.isConcurrent()).toList();
+        return events.stream().filter(e -> !e.isConcurrent()).collect(Collectors.toList());
     }
 
     @Test

--- a/argus-cli/src/test/java/io/argus/cli/profiler/AllocationProfilerTest.java
+++ b/argus-cli/src/test/java/io/argus/cli/profiler/AllocationProfilerTest.java
@@ -114,7 +114,7 @@ class AllocationProfilerTest {
         AllocationProfile profile = agg.build(10);
 
         assertEquals(1000, profile.totalBytes());
-        AllocationSite top = profile.sites().getFirst();
+        AllocationSite top = profile.sites().get(0);
         assertEquals(700, top.totalBytes());
 
         double pct = (double) top.totalBytes() / profile.totalBytes() * 100;
@@ -129,7 +129,7 @@ class AllocationProfilerTest {
 
         AllocationProfile profile = agg.build(10);
 
-        AllocationSite site = profile.sites().getFirst();
+        AllocationSite site = profile.sites().get(0);
         assertEquals(200_000.0, site.bytesPerSec(), 1.0, "Rate should be 200KB/s");
     }
 
@@ -143,8 +143,8 @@ class AllocationProfilerTest {
         AllocationProfile profile = agg.build(10);
 
         assertEquals(1, profile.sites().size(), "Same site should be aggregated into one");
-        assertEquals(600, profile.sites().getFirst().totalBytes());
-        assertEquals(3, profile.sites().getFirst().allocationCount());
+        assertEquals(600, profile.sites().get(0).totalBytes());
+        assertEquals(3, profile.sites().get(0).allocationCount());
     }
 
     @Test
@@ -235,7 +235,7 @@ class AllocationProfilerTest {
         agg.add("java.lang.String", 400_000); // 200 KB/s
 
         AllocationByClass result = agg.build();
-        assertEquals(200_000, result.sites().getFirst().bytesPerSec(), 1);
+        assertEquals(200_000, result.sites().get(0).bytesPerSec(), 1);
     }
 
     @Test
@@ -331,7 +331,7 @@ class AllocationProfilerTest {
         agg.add("com.example.Service", "process", 88, 400);
 
         AllocationProfile profile = agg.build(10);
-        AllocationSite site = profile.sites().getFirst();
+        AllocationSite site = profile.sites().get(0);
 
         assertEquals("com.example.Service", site.className());
         assertEquals("process", site.methodName());

--- a/argus-core/build.gradle.kts
+++ b/argus-core/build.gradle.kts
@@ -5,3 +5,7 @@ plugins {
 dependencies {
     testImplementation("org.junit.jupiter:junit-jupiter:${project.findProperty("junitVersion")}")
 }
+
+tasks.withType<JavaCompile> {
+    options.release.set(11)
+}

--- a/argus-core/src/main/java/io/argus/core/command/CommandContext.java
+++ b/argus-core/src/main/java/io/argus/core/command/CommandContext.java
@@ -3,27 +3,30 @@ package io.argus.core.command;
 /**
  * Execution context for diagnostic commands.
  *
- * <p>Sealed to exactly two variants:
+ * <p>Two variants:
  * <ul>
  *   <li>{@link InProcess} — command runs inside the target JVM (MXBeans, direct API access)</li>
  *   <li>{@link External} — command runs from outside, targeting a remote JVM by PID</li>
  * </ul>
  *
- * <p>Command implementations use pattern matching to handle each context:
+ * <p>Command implementations dispatch on context type:
  * <pre>
- * switch (ctx) {
- *     case InProcess ip -> ip.getBufferPoolMXBeans();
- *     case External ex  -> JcmdExecutor.execute(ex.pid(), "VM.info");
+ * if (ctx instanceof CommandContext.InProcess) {
+ *     CommandContext.InProcess ip = (CommandContext.InProcess) ctx;
+ *     ip.getBufferPoolMXBeans();
+ * } else if (ctx instanceof CommandContext.External) {
+ *     CommandContext.External ex = (CommandContext.External) ctx;
+ *     JcmdExecutor.execute(ex.pid(), "VM.info");
  * }
  * </pre>
  */
-public sealed interface CommandContext permits CommandContext.InProcess, CommandContext.External {
+public interface CommandContext {
 
     /**
      * In-process context: the command executes inside the monitored JVM.
      * Has direct access to MXBeans, Runtime APIs, and the current JVM state.
      */
-    non-sealed interface InProcess extends CommandContext {
+    interface InProcess extends CommandContext {
         /** Current JVM PID. */
         long pid();
     }
@@ -32,7 +35,7 @@ public sealed interface CommandContext permits CommandContext.InProcess, Command
      * External context: the command targets a remote JVM by PID.
      * Uses jcmd, jstat, or attach API to gather data.
      */
-    non-sealed interface External extends CommandContext {
+    interface External extends CommandContext {
         /** Target JVM PID. */
         long pid();
     }

--- a/argus-core/src/main/java/io/argus/core/command/CommandRegistry.java
+++ b/argus-core/src/main/java/io/argus/core/command/CommandRegistry.java
@@ -6,6 +6,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.ServiceLoader;
+import java.util.stream.Collectors;
 
 /**
  * Central registry for diagnostic commands. Discovers commands via {@link ServiceLoader}
@@ -73,21 +74,21 @@ public final class CommandRegistry {
     public List<DiagnosticCommand> byGroup(CommandGroup group) {
         return commands.values().stream()
                 .filter(cmd -> cmd.group() == group)
-                .toList();
+                .collect(Collectors.toList());
     }
 
     /** Commands that support in-process execution. */
     public List<DiagnosticCommand> inProcessCommands() {
         return commands.values().stream()
                 .filter(DiagnosticCommand::supportsInProcess)
-                .toList();
+                .collect(Collectors.toList());
     }
 
     /** Commands that support external execution. */
     public List<DiagnosticCommand> externalCommands() {
         return commands.values().stream()
                 .filter(DiagnosticCommand::supportsExternal)
-                .toList();
+                .collect(Collectors.toList());
     }
 
     /** Number of registered commands. */

--- a/argus-core/src/main/java/io/argus/core/event/EventType.java
+++ b/argus-core/src/main/java/io/argus/core/event/EventType.java
@@ -75,19 +75,19 @@ public enum EventType {
     }
 
     public static EventType fromCode(int code) {
-        return switch (code) {
-            case 1 -> VIRTUAL_THREAD_START;
-            case 2 -> VIRTUAL_THREAD_END;
-            case 3 -> VIRTUAL_THREAD_PINNED;
-            case 4 -> VIRTUAL_THREAD_SUBMIT_FAILED;
-            case 10 -> GC_PAUSE;
-            case 11 -> GC_HEAP_SUMMARY;
-            case 20 -> CPU_LOAD;
-            case 30 -> ALLOCATION;
-            case 31 -> METASPACE_SUMMARY;
-            case 40 -> EXECUTION_SAMPLE;
-            case 41 -> CONTENTION;
-            default -> throw new IllegalArgumentException("Unknown event type code: " + code);
-        };
+        switch (code) {
+            case 1: return VIRTUAL_THREAD_START;
+            case 2: return VIRTUAL_THREAD_END;
+            case 3: return VIRTUAL_THREAD_PINNED;
+            case 4: return VIRTUAL_THREAD_SUBMIT_FAILED;
+            case 10: return GC_PAUSE;
+            case 11: return GC_HEAP_SUMMARY;
+            case 20: return CPU_LOAD;
+            case 30: return ALLOCATION;
+            case 31: return METASPACE_SUMMARY;
+            case 40: return EXECUTION_SAMPLE;
+            case 41: return CONTENTION;
+            default: throw new IllegalArgumentException("Unknown event type code: " + code);
+        }
     }
 }

--- a/argus-frontend/build.gradle.kts
+++ b/argus-frontend/build.gradle.kts
@@ -4,3 +4,7 @@ plugins {
 
 // Frontend module contains only static resources (HTML, CSS, JS)
 // No Java code, just resources that will be included in argus-server's classpath
+
+java {
+    targetCompatibility = JavaVersion.VERSION_17
+}

--- a/argus-micrometer/build.gradle.kts
+++ b/argus-micrometer/build.gradle.kts
@@ -10,3 +10,7 @@ dependencies {
     testImplementation("io.micrometer:micrometer-core:1.12.0")
     testImplementation("org.junit.jupiter:junit-jupiter:${property("junitVersion")}")
 }
+
+tasks.withType<JavaCompile> {
+    options.release.set(17)
+}

--- a/argus-server/build.gradle.kts
+++ b/argus-server/build.gradle.kts
@@ -11,6 +11,10 @@ dependencies {
     testImplementation("org.junit.jupiter:junit-jupiter:${project.findProperty("junitVersion")}")
 }
 
+tasks.withType<JavaCompile> {
+    options.release.set(17)
+}
+
 application {
     mainClass.set("io.argus.server.ArgusServer")
 }

--- a/argus-spring-boot-starter/build.gradle.kts
+++ b/argus-spring-boot-starter/build.gradle.kts
@@ -17,3 +17,7 @@ dependencies {
 
     testImplementation("org.junit.jupiter:junit-jupiter:${property("junitVersion")}")
 }
+
+tasks.withType<JavaCompile> {
+    options.release.set(17)
+}


### PR DESCRIPTION
## Summary

The CLI advertised "works on Java 11+" but actually required Java 21 (bytecode 65.0). On Java 11 or 17 the very first invocation crashed with `UnsupportedClassVersionError`, while `install.sh` silently let users through. This change makes the claim true.

## What changed

- **argus-core, argus-cli**: bytecode target → Java 11 (`options.release.set(11)`).
- **argus-agent, argus-server, argus-micrometer, argus-spring-boot-starter**: bytecode target → Java 17 (Spring Boot 3 baseline; agent uses JFR streaming events that exist only on 17+).
- **argus-frontend**: no Java sources, but `targetCompatibility = VERSION_17` so the artifact resolves cleanly when `argus-server` (release 17) depends on it.

Source-level Java-14-through-21 features that prevented `--release 11` were removed from argus-core / argus-cli:

- ~30 records → final classes preserving record-style accessors (`field()` not `getField()`), with `Objects.equals/hash`-based `equals/hashCode/toString`.
- Switch expressions and arrow-rule switches → traditional `case X:` + `break`/`return`.
- `Stream.toList()` → `.collect(Collectors.toList())`.
- `List.getFirst()` / `getLast()` → `.get(0)` / `.get(size() - 1)`.
- `instanceof Foo foo` pattern bindings → `instanceof Foo` + explicit cast.
- `sealed interface` (argus-core CommandContext) → plain interface.
- Single text block in `ArgusAgent` banner → string concatenation.
- `StringBuilder.isEmpty()` → `length() > 0`.
- `SlowlogCommand.streamLocal()` rewritten to load `jdk.jfr.consumer.RecordingStream` reflectively, gated on `Runtime.version().feature() < 14` (this command intentionally still requires Java 14+; everything else works on 11+).

## CI

Adds a `runtime-compat` job that builds the fat JAR with JDK 21, then runs `java -jar argus-cli-*-all.jar --version` and `... ps` on JDK 11, 17, 21 in a matrix. Future regressions where a Java-12+ API or syntax sneaks in will be caught here, not by the user.

## Verification

- `./gradlew clean build` → SUCCESS
- Local smoke test: `argus 1.2.1` reported on Java 17 and Java 21
- `argus ps` renders correctly on Java 17

## Notes

- Public-facing docs already say "Java 11+ CLI" — that statement is now accurate, so no doc churn.
- Some advanced commands (virtual thread analysis, Generational ZGC features) require their *target* JVM to be Java 21+; those runtime gates already exist in the relevant providers and are unchanged.
- This is feature-equivalent to v1.2.1 + multi-Java support, which is a minor (not patch) bump per semver. Recommend cutting v1.3.0 after merge.