### PR TITLE
fix: remove Java 21 APIs leaked into agent/server/starter modules

### DIFF
--- a/argus-agent/src/main/java/io/argus/agent/jfr/ExecutionSampleExtractor.java
+++ b/argus-agent/src/main/java/io/argus/agent/jfr/ExecutionSampleExtractor.java
@@ -32,7 +32,7 @@ public final class ExecutionSampleExtractor {
         String threadName = extractThreadName(event);
 
         // Get the top frame
-        RecordedFrame topFrame = stackTrace.getFrames().getFirst();
+        RecordedFrame topFrame = stackTrace.getFrames().get(0);
         String methodName = extractMethodName(topFrame);
         String className = extractClassName(topFrame);
         int lineNumber = topFrame.getLineNumber();

--- a/argus-agent/src/main/java/io/argus/agent/jfr/JfrEventExtractor.java
+++ b/argus-agent/src/main/java/io/argus/agent/jfr/JfrEventExtractor.java
@@ -124,7 +124,7 @@ public final class JfrEventExtractor {
         // The OS thread ID represents the carrier thread for virtual threads
         try {
             RecordedThread eventThread = event.getValue("eventThread");
-            if (eventThread != null && eventThread.isVirtual()) {
+            if (eventThread != null && isVirtualRecordedThread(eventThread)) {
                 // For virtual threads, the OS thread ID is the carrier's thread ID
                 long osThreadId = eventThread.getOSThreadId();
                 if (osThreadId > 0) {
@@ -135,6 +135,21 @@ public final class JfrEventExtractor {
         }
 
         return -1;
+    }
+
+    /**
+     * Reflective {@code RecordedThread.isVirtual()} call so this module compiles
+     * under {@code --release 17} but still detects virtual threads when the
+     * recorded JFR was produced on Java 21+. Returns {@code false} on Java 17/20.
+     */
+    private static boolean isVirtualRecordedThread(RecordedThread t) {
+        try {
+            java.lang.reflect.Method m = RecordedThread.class.getMethod("isVirtual");
+            Object r = m.invoke(t);
+            return r instanceof Boolean && (Boolean) r;
+        } catch (Throwable ignored) {
+            return false;
+        }
     }
 
     /**

--- a/argus-agent/src/main/java/io/argus/agent/jfr/JfrStreamingEngine.java
+++ b/argus-agent/src/main/java/io/argus/agent/jfr/JfrStreamingEngine.java
@@ -224,10 +224,9 @@ public final class JfrStreamingEngine {
             return;
         }
 
-        streamThread = Thread.ofPlatform()
-                .name("argus-jfr-stream")
-                .daemon(true)
-                .start(this::runStream);
+        streamThread = new Thread(this::runStream, "argus-jfr-stream");
+        streamThread.setDaemon(true);
+        streamThread.start();
 
         // Wait for JFR streaming to actually start before returning
         try {

--- a/argus-server/src/main/java/io/argus/server/analysis/AllocationAnalyzer.java
+++ b/argus-server/src/main/java/io/argus/server/analysis/AllocationAnalyzer.java
@@ -73,7 +73,7 @@ public final class AllocationAnalyzer {
             );
             history.add(snapshot);
             while (history.size() > MAX_HISTORY_SIZE) {
-                history.removeFirst();
+                history.remove(0);
             }
 
             // Reset window

--- a/argus-server/src/main/java/io/argus/server/analysis/CPUAnalyzer.java
+++ b/argus-server/src/main/java/io/argus/server/analysis/CPUAnalyzer.java
@@ -64,7 +64,7 @@ public final class CPUAnalyzer {
 
         history.add(snapshot);
         while (history.size() > MAX_HISTORY_SIZE) {
-            history.removeFirst();
+            history.remove(0);
         }
     }
 

--- a/argus-server/src/main/java/io/argus/server/analysis/CorrelationAnalyzer.java
+++ b/argus-server/src/main/java/io/argus/server/analysis/CorrelationAnalyzer.java
@@ -215,7 +215,7 @@ public final class CorrelationAnalyzer {
 
     private void trimList(List<?> list) {
         while (list.size() > MAX_CORRELATIONS) {
-            list.removeFirst();
+            list.remove(0);
         }
     }
 

--- a/argus-server/src/main/java/io/argus/server/analysis/GCAnalyzer.java
+++ b/argus-server/src/main/java/io/argus/server/analysis/GCAnalyzer.java
@@ -82,7 +82,7 @@ public final class GCAnalyzer {
 
         recentGCs.add(summary);
         while (recentGCs.size() > MAX_HISTORY_SIZE) {
-            recentGCs.removeFirst();
+            recentGCs.remove(0);
         }
     }
 

--- a/argus-server/src/main/java/io/argus/server/analysis/MetaspaceAnalyzer.java
+++ b/argus-server/src/main/java/io/argus/server/analysis/MetaspaceAnalyzer.java
@@ -71,7 +71,7 @@ public final class MetaspaceAnalyzer {
 
         history.add(snapshot);
         while (history.size() > MAX_HISTORY_SIZE) {
-            history.removeFirst();
+            history.remove(0);
         }
     }
 

--- a/argus-server/src/main/java/io/argus/server/handler/ArgusChannelHandler.java
+++ b/argus-server/src/main/java/io/argus/server/handler/ArgusChannelHandler.java
@@ -216,7 +216,7 @@ public final class ArgusChannelHandler extends SimpleChannelInboundHandler<Objec
         // Run profiling asynchronously
         final int dur = duration;
         final String pType = type;
-        Thread.ofPlatform().name("argus-profile").daemon(true).start(() -> {
+        Thread profileThread = new Thread(() -> {
             try {
                 long pid = ProcessHandle.current().pid();
                 String tmpDir = System.getProperty("java.io.tmpdir");
@@ -245,7 +245,9 @@ public final class ArgusChannelHandler extends SimpleChannelInboundHandler<Objec
                 String errJson = "{\"status\":\"error\",\"message\":\"" + escapeJson(e.getMessage()) + "\"}";
                 HttpResponseHelper.sendJson(ctx, request, errJson);
             }
-        });
+        }, "argus-profile");
+        profileThread.setDaemon(true);
+        profileThread.start();
 
         // Immediate response that profiling has started
         String startJson = "{\"status\":\"started\",\"type\":\"" + pType + "\",\"duration\":" + dur + "}";
@@ -486,7 +488,7 @@ public final class ArgusChannelHandler extends SimpleChannelInboundHandler<Objec
         if (targetThread != null) {
             sb.append("\"threadName\":\"").append(escapeJson(targetThread.getName())).append("\",");
             sb.append("\"state\":\"").append(targetThread.getState()).append("\",");
-            sb.append("\"isVirtual\":").append(targetThread.isVirtual()).append(",");
+            sb.append("\"isVirtual\":").append(isVirtualThread(targetThread)).append(",");
             sb.append("\"stackTrace\":\"").append(escapeJson(formatStackTrace(targetThread.getStackTrace()))).append("\"");
         } else {
             sb.append("\"error\":\"Thread not found or already terminated\"");
@@ -977,10 +979,10 @@ public final class ArgusChannelHandler extends SimpleChannelInboundHandler<Objec
             first = false;
 
             sb.append("{");
-            sb.append("\"threadId\":").append(thread.threadId()).append(",");
+            sb.append("\"threadId\":").append(thread.getId()).append(",");
             sb.append("\"threadName\":\"").append(escapeJson(thread.getName())).append("\",");
             sb.append("\"state\":\"").append(thread.getState()).append("\",");
-            sb.append("\"isVirtual\":").append(thread.isVirtual()).append(",");
+            sb.append("\"isVirtual\":").append(isVirtualThread(thread)).append(",");
             sb.append("\"stackTrace\":\"").append(escapeJson(formatStackTrace(stackTrace))).append("\"");
             sb.append("}");
         }
@@ -990,9 +992,24 @@ public final class ArgusChannelHandler extends SimpleChannelInboundHandler<Objec
         HttpResponseHelper.sendJson(ctx, request, sb.toString());
     }
 
+    /**
+     * Reflective {@code Thread.isVirtual()} call so this module compiles
+     * under {@code --release 17} but still reports virtual-thread status
+     * when running on Java 21+. Returns {@code false} on Java 17/20.
+     */
+    private static boolean isVirtualThread(Thread t) {
+        try {
+            java.lang.reflect.Method m = Thread.class.getMethod("isVirtual");
+            Object r = m.invoke(t);
+            return r instanceof Boolean && (Boolean) r;
+        } catch (Throwable ignored) {
+            return false;
+        }
+    }
+
     private Thread findThreadById(long threadId) {
         return Thread.getAllStackTraces().keySet().stream()
-                .filter(t -> t.threadId() == threadId)
+                .filter(t -> t.getId() == threadId)
                 .findFirst()
                 .orElse(null);
     }

--- a/argus-server/src/main/java/io/argus/server/state/RecentEventsBuffer.java
+++ b/argus-server/src/main/java/io/argus/server/state/RecentEventsBuffer.java
@@ -41,7 +41,7 @@ public final class RecentEventsBuffer {
     public void add(String eventJson) {
         recentEvents.addLast(eventJson);
         while (recentEvents.size() > maxSize) {
-            recentEvents.removeFirst();
+            recentEvents.remove(0);
         }
     }
 

--- a/argus-server/src/main/java/io/argus/server/state/ThreadEventsBuffer.java
+++ b/argus-server/src/main/java/io/argus/server/state/ThreadEventsBuffer.java
@@ -51,7 +51,7 @@ public final class ThreadEventsBuffer {
 
         // Limit events per thread
         while (events.size() > maxEventsPerThread) {
-            events.removeFirst();
+            events.remove(0);
         }
 
         // Limit total threads tracked (remove oldest if needed)

--- a/argus-spring-boot-starter/src/main/java/io/argus/spring/ArgusAutoConfiguration.java
+++ b/argus-spring-boot-starter/src/main/java/io/argus/spring/ArgusAutoConfiguration.java
@@ -114,19 +114,18 @@ public class ArgusAutoConfiguration implements DisposableBean {
                 config.isCorrelationEnabled(),
                 config
         );
-        Thread.ofPlatform()
-                .name("argus-server")
-                .daemon(true)
-                .start(() -> {
-                    try {
-                        server.start();
-                    } catch (InterruptedException e) {
-                        Thread.currentThread().interrupt();
-                    } catch (Exception e) {
-                        System.getLogger(ArgusAutoConfiguration.class.getName())
-                                .log(System.Logger.Level.ERROR, "Argus server failed to start", e);
-                    }
-                });
+        Thread serverThread = new Thread(() -> {
+            try {
+                server.start();
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            } catch (Exception e) {
+                System.getLogger(ArgusAutoConfiguration.class.getName())
+                        .log(System.Logger.Level.ERROR, "Argus server failed to start", e);
+            }
+        }, "argus-server");
+        serverThread.setDaemon(true);
+        serverThread.start();
         return server;
     }
 


### PR DESCRIPTION
## Summary

PR #162 set argus-agent / argus-server / argus-spring-boot-starter / argus-micrometer to `--release 17`, but missed several Java 19/21-only API call sites in those modules. Master CI on the previous merge went red across all 6 build cells. This PR finishes the cleanup.

## Changes

**`List.removeFirst()` (Java 21+) → `list.remove(0)`** in
- `argus-server/analysis/{CorrelationAnalyzer,MetaspaceAnalyzer,AllocationAnalyzer,CPUAnalyzer,GCAnalyzer}.java`
- `argus-server/state/{ThreadEventsBuffer,RecentEventsBuffer}.java`

**`Thread.ofPlatform()...start(...)` (Java 21+) → `new Thread(runnable, name)` + `setDaemon` + `start`** in
- `argus-server/handler/ArgusChannelHandler.java`
- `argus-agent/jfr/JfrStreamingEngine.java`
- `argus-spring-boot-starter/.../ArgusAutoConfiguration.java`

**`Thread.threadId()` (Java 19+) → `Thread.getId()`** in `ArgusChannelHandler.java` (2 sites).

**`Thread.isVirtual()` (Java 21+) → reflective helper** in `ArgusChannelHandler.java` (2 sites). The helper returns `false` on Java 17/20 and the real value on Java 21+, so the dashboard's `isVirtual` field is honest under both baselines.

**`RecordedThread.isVirtual()` (Java 21+) → reflective helper** in `argus-agent/jfr/JfrEventExtractor.java`. Same pattern.

**`List.getFirst()` (Java 21+) → `list.get(0)`** in `argus-agent/jfr/ExecutionSampleExtractor.java`.

## Verification

`./gradlew clean build` → **BUILD SUCCESSFUL**. The new CI `runtime-compat` matrix from #162 will independently verify Java 11 / 17 / 21 runtime smoke tests after merge.