### PR TITLE
chore(release): bump to v1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to Argus are documented here. Format follows [Keep a Changel
 
 ## [Unreleased]
 
+## [1.3.0] - 2026-05-08
+
+### Added
+- **Java 11 / 17 / 21 multi-runtime support** — the CLI now genuinely runs on Java 11+ as advertised. `argus-core` and `argus-cli` compile to Java 11 bytecode; `argus-agent`, `argus-server`, `argus-micrometer`, and `argus-spring-boot-starter` compile to Java 17 (Spring Boot 3 baseline). One command (`argus slowlog`) gates on `Runtime.version().feature() < 14` because it uses `jdk.jfr.consumer.RecordingStream`. Until 1.2.1 the CLI silently required Java 21, throwing `UnsupportedClassVersionError` on Java 11/17.
+- CI `runtime-compat` matrix that builds the fat JAR on JDK 21 and smoke-tests it on JDK 11, 17, and 21 — so future regressions where Java-12+ APIs sneak in will be caught in CI rather than by users.
+- Per-subcommand `--help`. `argus <cmd> --help` now prints the command's description and a Usage hint; previously the parser misread `--help` as a positional `<pid>` and errored out.
+- `install.sh` and `install.ps1` SHA-256 verification. After downloading each JAR the installer fetches `checksums.txt` from the same release, looks up the entry by original filename, and aborts on mismatch. Releases that don't publish `checksums.txt` (anything before this version) get a clear "skipping integrity check" warning so the legacy path still works.
+- `argus-spring-boot-starter` real Spring-context integration tests via `ApplicationContextRunner` — covers `@ConfigurationProperties` binding, the `argus.enabled=false` short-circuit, and the `matchIfMissing=true` default activation. Adds three tests alongside the existing two pure unit tests.
+- `release.yml` writes `checksums.txt` next to the JARs and dispatches `native-image.yml` after the GitHub Release is created (the `release: published` event does not fire for releases created via `GITHUB_TOKEN`, which is why native-image runs were skipped on v1.1.0/v1.2.0/v1.2.1 unless dispatched manually).
+
+### Fixed
+- `argus info <pid>` no longer shows the literal "<pid>:" string for "VM Name". The bug came from `JdkInfoProvider` taking the first non-empty line of `jcmd VM.version` output, which is always `<pid>:`.
+- `argus info <bad-pid>` now exits 1 with `PID <n> not found. Run \`argus ps\` to list running JVMs.` instead of silently rendering an empty info card and exiting 0. CI scripts can now detect the failure.
+- All Java 19/21 APIs that had leaked into the Java-17-baseline modules: `Thread.ofPlatform()`, `Thread.threadId()`, `Thread.isVirtual()`, `RecordedThread.isVirtual()`, `List.removeFirst()`, `List.getFirst()` — replaced with traditional equivalents or, for virtual-thread checks, reflective helpers that return the real value on Java 21+ runtimes and `false` on 17.
+
 ## [1.2.1] - 2026-05-08
 
 ### Fixed
@@ -69,7 +84,8 @@ First major release — production-ready JVM diagnostic CLI.
 
 ---
 
-[Unreleased]: https://github.com/rlaope/Argus/compare/v1.2.1...HEAD
+[Unreleased]: https://github.com/rlaope/Argus/compare/v1.3.0...HEAD
+[1.3.0]: https://github.com/rlaope/Argus/compare/v1.2.1...v1.3.0
 [1.2.1]: https://github.com/rlaope/Argus/compare/v1.2.0...v1.2.1
 [1.2.0]: https://github.com/rlaope/Argus/compare/v1.1.0...v1.2.0
 [1.1.0]: https://github.com/rlaope/Argus/compare/v1.0.0...v1.1.0

--- a/Formula/argus.rb
+++ b/Formula/argus.rb
@@ -1,14 +1,14 @@
 class Argus < Formula
   desc "JVM diagnostic toolkit — 66 commands, health diagnosis, GC analysis, profiling, interactive TUI"
   homepage "https://github.com/rlaope/Argus"
-  url "https://github.com/rlaope/Argus/releases/download/v1.2.1/argus-cli-1.2.1-all.jar"
+  url "https://github.com/rlaope/Argus/releases/download/v1.3.0/argus-cli-1.3.0-all.jar"
   sha256 "f0bb79ef3a599c206fa26a86012b9e0f4236d7750a2b789652472ea8aaf3d0ee"
   license "Apache-2.0"
 
   depends_on "openjdk@21"
 
   def install
-    libexec.install "argus-cli-1.2.1-all.jar" => "argus-cli.jar"
+    libexec.install "argus-cli-1.3.0-all.jar" => "argus-cli.jar"
 
     (bin/"argus").write <<~EOS
       #!/bin/bash

--- a/charts/argus/Chart.yaml
+++ b/charts/argus/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: argus
 description: Argus JVM Observability — Prometheus metrics, Grafana dashboards, and alerting for JVM applications
 type: application
-version: 1.2.1
-appVersion: "1.2.1"
+version: 1.3.0
+appVersion: "1.3.0"
 kubeVersion: ">=1.23.0-0"
 home: https://github.com/rlaope/Argus
 sources:

--- a/charts/argus/README.md
+++ b/charts/argus/README.md
@@ -63,13 +63,13 @@ env:
 <dependency>
   <groupId>io.github.rlaope</groupId>
   <artifactId>argus-spring-boot-starter</artifactId>
-  <version>1.2.1</version>
+  <version>1.3.0</version>
 </dependency>
 ```
 
 ```groovy
 // Gradle
-implementation 'io.github.rlaope:argus-spring-boot-starter:1.2.1'
+implementation 'io.github.rlaope:argus-spring-boot-starter:1.3.0'
 ```
 
 ### Step 3 — Expose the metrics port

--- a/deploy/sdkman/README.md
+++ b/deploy/sdkman/README.md
@@ -13,7 +13,7 @@ This directory contains the candidate definition for submitting Argus to the [SD
 Once the candidate is registered, publish each release via the SDKMAN Vendor API:
 
 ```bash
-VERSION="1.2.1"
+VERSION="1.3.0"
 CONSUMER_KEY="<your-key>"
 CONSUMER_SECRET="<your-secret>"
 
@@ -59,7 +59,7 @@ sdk install argus
 Or a specific version:
 
 ```bash
-sdk install argus 1.2.1
+sdk install argus 1.3.0
 ```
 
 ## Notes

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -43,15 +43,15 @@ argus report 12345
 
 ```bash
 # Install a specific version
-curl -fsSL https://raw.githubusercontent.com/rlaope/argus/master/install.sh | bash -s -- v1.2.1
+curl -fsSL https://raw.githubusercontent.com/rlaope/argus/master/install.sh | bash -s -- v1.3.0
 ```
 
 ### Option 2: Manual Download
 
 ```bash
 # Download JARs from GitHub Releases
-curl -LO https://github.com/rlaope/argus/releases/latest/download/argus-agent-1.2.1.jar
-curl -LO https://github.com/rlaope/argus/releases/latest/download/argus-cli-1.2.1-all.jar
+curl -LO https://github.com/rlaope/argus/releases/latest/download/argus-agent-1.3.0.jar
+curl -LO https://github.com/rlaope/argus/releases/latest/download/argus-cli-1.3.0-all.jar
 ```
 
 ### Option 3: Build from Source
@@ -63,8 +63,8 @@ cd argus
 ./gradlew :argus-cli:fatJar
 
 # JARs:
-# argus-agent/build/libs/argus-agent-1.2.1.jar
-# argus-cli/build/libs/argus-cli-1.2.1-all.jar
+# argus-agent/build/libs/argus-agent-1.3.0.jar
+# argus-cli/build/libs/argus-cli-1.3.0-all.jar
 ```
 
 ## Quick Start with Sample Project
@@ -119,7 +119,7 @@ argus info <pid>               # JVM information
 argus top
 
 # Or run directly
-java -jar argus-cli/build/libs/argus-cli-1.2.1-all.jar --help
+java -jar argus-cli/build/libs/argus-cli-1.3.0-all.jar --help
 ```
 
 The CLI auto-detects the best data source: Argus agent (HTTP) when available, JDK tools (`jcmd`) as fallback. Use `--source=agent|jdk` to override.

--- a/docs/kubernetes.md
+++ b/docs/kubernetes.md
@@ -68,7 +68,7 @@ Use an init container to inject the agent JAR via a shared volume. This avoids m
 ```yaml
 initContainers:
   - name: argus-init
-    image: ghcr.io/rlaope/argus:1.2.1
+    image: ghcr.io/rlaope/argus:1.3.0
     command: ["cp", "/opt/argus/argus-cli.jar", "/argus-volume/argus-cli.jar"]
     volumeMounts:
       - name: argus-volume
@@ -98,13 +98,13 @@ Add the Argus Spring Boot starter to `pom.xml` or `build.gradle`. No `-javaagent
 <dependency>
   <groupId>io.argus</groupId>
   <artifactId>argus-spring-boot-starter</artifactId>
-  <version>1.2.1</version>
+  <version>1.3.0</version>
 </dependency>
 ```
 
 **Gradle:**
 ```groovy
-implementation 'io.argus:argus-spring-boot-starter:1.2.1'
+implementation 'io.argus:argus-spring-boot-starter:1.3.0'
 ```
 
 The `/prometheus` and `/argus` endpoints are auto-registered alongside your application's existing endpoints.
@@ -279,7 +279,7 @@ spec:
               mountPath: /argus
       initContainers:
         - name: argus-init
-          image: ghcr.io/rlaope/argus:1.2.1
+          image: ghcr.io/rlaope/argus:1.3.0
           command: ["cp", "/opt/argus/argus-cli.jar", "/argus-volume/argus-cli.jar"]
           volumeMounts:
             - name: argus-volume

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -119,7 +119,7 @@ All settings are passed as `-D` system properties:
 Add `argus-spring-boot-starter` to your Spring Boot 3.2+ application for zero-config JVM monitoring:
 
 ```kotlin
-implementation("io.argus:argus-spring-boot-starter:1.2.1")
+implementation("io.argus:argus-spring-boot-starter:1.3.0")
 ```
 
 Configure via `application.yml`:

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
-argusVersion=1.2.1
+argusVersion=1.3.0
 nettyVersion=4.1.115.Final
 junitVersion=5.11.4

--- a/install.ps1
+++ b/install.ps1
@@ -11,7 +11,7 @@
     irm https://raw.githubusercontent.com/rlaope/argus/master/install.ps1 | iex
 
 .EXAMPLE
-    .\install.ps1 -Version v1.2.1
+    .\install.ps1 -Version v1.3.0
 #>
 
 param(
@@ -55,8 +55,8 @@ if ($Version -eq "latest") {
         $Release = Invoke-RestMethod "https://api.github.com/repos/$Repo/releases/latest" -UseBasicParsing
         $Version = $Release.tag_name
     } catch {
-        Write-Warn "Could not resolve latest release. Using 'v1.2.1' as fallback."
-        $Version = "v1.2.1"
+        Write-Warn "Could not resolve latest release. Using 'v1.3.0' as fallback."
+        $Version = "v1.3.0"
     }
 }
 

--- a/install.sh
+++ b/install.sh
@@ -85,8 +85,8 @@ if [ "$VERSION" = "latest" ]; then
         | grep '"tag_name"' | head -1 | sed 's/.*"tag_name"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/')
 
     if [ -z "$VERSION" ]; then
-        warn "Could not resolve latest release. Using 'v1.2.1' as fallback."
-        VERSION="v1.2.1"
+        warn "Could not resolve latest release. Using 'v1.3.0' as fallback."
+        VERSION="v1.3.0"
     fi
 fi
 

--- a/site/index.html
+++ b/site/index.html
@@ -633,7 +633,7 @@
                         <span class="badge green">Java 21+ Full Features</span>
                         <span class="badge">66 Commands</span>
                         <span class="badge">Zero Dependencies</span>
-                        <span class="badge green">v1.2.1</span>
+                        <span class="badge green">v1.3.0</span>
                     </div>
                 </div>
 
@@ -967,7 +967,7 @@ $ argus zgc 12345 --watch=10 --interval=60</code></pre>
                 <h3>Setup</h3>
 
                 <pre><code>// build.gradle.kts
-implementation("io.argus:argus-spring-boot-starter:1.2.1")</code></pre>
+implementation("io.argus:argus-spring-boot-starter:1.3.0")</code></pre>
 
                 <p>When your Spring Boot application starts, Argus will:</p>
                 <ul>


### PR DESCRIPTION
## Summary

Minor release reflecting the multi-Java runtime support and the release-pipeline hardening landed since v1.2.1.

`gradle.properties` `argusVersion` 1.2.1 → 1.3.0. Mirror references updated across 11 files per the project's "version sync on release, never skip" rule. Validated by grepping the entire repo for `1.2.1` and finding only the intentional CHANGELOG history references that remain.

`CHANGELOG.md` grows a 1.3.0 entry covering:
- Java 11/17/21 multi-runtime support (the headline feature; was previously claimed but broken)
- Per-subcommand `--help`
- Install-script SHA-256 verification
- `checksums.txt` + native-image auto-trigger in `release.yml`
- Spring Boot starter `ApplicationContextRunner` integration tests
- The bug fixes (VM Name "<pid>:" leak, bad-PID exit code, Java 21 API leakage in agent/server/starter)

## Known follow-up

`Formula/argus.rb` `sha256` still references the v1.2.1 artifact. After this PR is tagged v1.3.0 and `release.yml` uploads `argus-cli-1.3.0-all.jar`, a separate small PR will recompute the hash. `brew install` will fail with a checksum mismatch until that follow-up is merged — same well-understood pattern we used for v1.2.1 (#161).

## Test plan

- [x] `grep -rn '1\\.2\\.1'` returns no live references (only CHANGELOG history)
- [x] `./gradlew compileJava :argus-cli:test` → exit 0
- [ ] After tag: `release.yml` uploads JARs + `checksums.txt`
- [ ] After tag: `docker.yml` publishes both `argus:1.3.0` and `argus-agent:1.3.0` to GHCR (the docker.yml fix from #159 is now well exercised)
- [ ] After tag: `native-image.yml` auto-fires (the auto-trigger from #164 gets its first real test)