### PR TITLE
fix(ci): native-image distro rename + workflow_dispatch tag upload + Formula sha256 v1.3.0

### DIFF
--- a/.github/workflows/native-image.yml
+++ b/.github/workflows/native-image.yml
@@ -16,12 +16,14 @@ jobs:
           - os: macos-latest
             artifact: argus-macos-aarch64
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v4
       - uses: graalvm/setup-graalvm@v1
         with:
           java-version: '21'
-          distribution: 'graalce'
+          distribution: 'graalvm-community'
       - name: Build fat JAR
         run: ./gradlew :argus-cli:fatJar
       - name: Build native image
@@ -31,13 +33,24 @@ jobs:
             -o argus \
             --enable-url-protocols=http \
             -H:+ReportExceptionStackTraces
+      - name: Rename for platform-specific upload
+        run: mv argus ${{ matrix.artifact }}
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.artifact }}
-          path: argus
+          path: ${{ matrix.artifact }}
+      - name: Resolve release tag
+        id: tag
+        if: github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && startsWith(github.ref, 'refs/tags/'))
+        run: |
+          if [ "${{ github.event_name }}" = "release" ]; then
+            echo "name=${{ github.event.release.tag_name }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "name=${{ github.ref_name }}" >> "$GITHUB_OUTPUT"
+          fi
       - name: Upload to release
-        if: github.event_name == 'release'
+        if: steps.tag.outputs.name != ''
         env:
           GH_TOKEN: ${{ github.token }}
-        run: gh release upload ${{ github.event.release.tag_name }} argus --clobber
+        run: gh release upload ${{ steps.tag.outputs.name }} ${{ matrix.artifact }} --clobber

--- a/Formula/argus.rb
+++ b/Formula/argus.rb
@@ -2,7 +2,7 @@ class Argus < Formula
   desc "JVM diagnostic toolkit — 66 commands, health diagnosis, GC analysis, profiling, interactive TUI"
   homepage "https://github.com/rlaope/Argus"
   url "https://github.com/rlaope/Argus/releases/download/v1.3.0/argus-cli-1.3.0-all.jar"
-  sha256 "f0bb79ef3a599c206fa26a86012b9e0f4236d7750a2b789652472ea8aaf3d0ee"
+  sha256 "f2e3ce15bf8f95a8c0e4d0d5da26c6d5ae8321295de41af1758e8516c8627a4e"
   license "Apache-2.0"
 
   depends_on "openjdk@21"


### PR DESCRIPTION
## Summary

Three v1.3.0 release-pipeline follow-ups in one PR.

### native-image.yml

- **distribution: \`graalce\` → \`graalvm-community\`** — \`graalvm/setup-graalvm@v1\` deprecated the legacy \`graalce\` alias. The v1.3.0 native-image build (auto-dispatched by release.yml from #164) failed with \`Unsupported distribution: graalce\`. \`graalvm-community\` is the upstream-blessed identifier for GraalVM CE.
- **Upload step now fires on \`workflow_dispatch\` + tag ref**, not only \`release: published\`. The auto-trigger from release.yml uses workflow_dispatch, so without this fix the build runs but the binary never lands on the GitHub Release.
- **Per-platform artifact rename** before upload. Both matrix jobs were uploading as \`argus\` and clobbering each other. \`install.sh\` already expects \`argus-linux-amd64\` / \`argus-macos-aarch64\` on the release page, so we rename to those names before upload.
- Adds \`permissions: contents: write\` so \`gh release upload\` is authorized.

### Formula/argus.rb

\`sha256\` recomputed against the published v1.3.0 JAR (\`f2e3ce15…\`). Without this, \`brew install\` fails with a checksum mismatch. Same well-understood pattern from #161.

## Test plan

- [x] GHCR images for v1.3.0 verified present (CLI + agent both 200)
- [x] sha256 computed by fetching the published artifact and running \`shasum -a 256\`
- [ ] After merge: re-dispatch \`native-image.yml\` against the v1.3.0 tag and confirm both \`argus-linux-amd64\` and \`argus-macos-aarch64\` end up as v1.3.0 release assets