### PR TITLE
refactor(cli): collapse provider-null check into Providers.require helper

### DIFF
--- a/argus-cli/src/main/java/io/argus/cli/command/BuffersCommand.java
+++ b/argus-cli/src/main/java/io/argus/cli/command/BuffersCommand.java
@@ -48,11 +48,7 @@ public final class BuffersCommand implements Command {
         }
 
         String source = sourceOverride != null ? sourceOverride : config.defaultSource();
-        BuffersProvider provider = registry.findBuffersProvider(pid, sourceOverride);
-        if (provider == null) {
-            System.err.println(messages.get("error.provider.none", pid));
-            return;
-        }
+        BuffersProvider provider = Providers.require(registry.findBuffersProvider(pid, sourceOverride), pid, messages);
 
         BuffersResult result = provider.getBuffers(pid);
 

--- a/argus-cli/src/main/java/io/argus/cli/command/ClassLoaderCommand.java
+++ b/argus-cli/src/main/java/io/argus/cli/command/ClassLoaderCommand.java
@@ -46,11 +46,7 @@ public final class ClassLoaderCommand implements Command {
         }
 
         String source = sourceOverride != null ? sourceOverride : config.defaultSource();
-        ClassLoaderProvider provider = registry.findClassLoaderProvider(pid, sourceOverride);
-        if (provider == null) {
-            System.err.println(messages.get("error.provider.none", pid));
-            return;
-        }
+        ClassLoaderProvider provider = Providers.require(registry.findClassLoaderProvider(pid, sourceOverride), pid, messages);
 
         ClassLoaderResult result = provider.getClassLoaders(pid);
 

--- a/argus-cli/src/main/java/io/argus/cli/command/ClassStatCommand.java
+++ b/argus-cli/src/main/java/io/argus/cli/command/ClassStatCommand.java
@@ -39,8 +39,7 @@ public final class ClassStatCommand implements Command {
         }
 
         String source = sourceOverride != null ? sourceOverride : config.defaultSource();
-        ClassStatProvider provider = registry.findClassStatProvider(pid, sourceOverride);
-        if (provider == null) { System.err.println(messages.get("error.provider.none", pid)); return; }
+        ClassStatProvider provider = Providers.require(registry.findClassStatProvider(pid, sourceOverride), pid, messages);
 
         ClassStatResult result = provider.getClassStats(pid);
 

--- a/argus-cli/src/main/java/io/argus/cli/command/CompilerCommand.java
+++ b/argus-cli/src/main/java/io/argus/cli/command/CompilerCommand.java
@@ -40,8 +40,7 @@ public final class CompilerCommand implements Command {
         }
 
         String source = sourceOverride != null ? sourceOverride : config.defaultSource();
-        CompilerProvider provider = registry.findCompilerProvider(pid, sourceOverride);
-        if (provider == null) { System.err.println(messages.get("error.provider.none", pid)); return; }
+        CompilerProvider provider = Providers.require(registry.findCompilerProvider(pid, sourceOverride), pid, messages);
 
         CompilerResult result = provider.getCompilerInfo(pid);
 

--- a/argus-cli/src/main/java/io/argus/cli/command/DeadlockCommand.java
+++ b/argus-cli/src/main/java/io/argus/cli/command/DeadlockCommand.java
@@ -46,11 +46,7 @@ public final class DeadlockCommand implements Command {
         }
 
         String source = sourceOverride != null ? sourceOverride : config.defaultSource();
-        DeadlockProvider provider = registry.findDeadlockProvider(pid, sourceOverride);
-        if (provider == null) {
-            System.err.println(messages.get("error.provider.none", pid));
-            return;
-        }
+        DeadlockProvider provider = Providers.require(registry.findDeadlockProvider(pid, sourceOverride), pid, messages);
 
         DeadlockResult result = provider.detectDeadlocks(pid);
 

--- a/argus-cli/src/main/java/io/argus/cli/command/DiffCommand.java
+++ b/argus-cli/src/main/java/io/argus/cli/command/DiffCommand.java
@@ -70,11 +70,7 @@ public final class DiffCommand implements Command {
         }
 
         String source = sourceOverride != null ? sourceOverride : config.defaultSource();
-        HistoProvider provider = registry.findHistoProvider(pid, sourceOverride);
-        if (provider == null) {
-            System.err.println(messages.get("error.provider.none", pid));
-            return;
-        }
+        HistoProvider provider = Providers.require(registry.findHistoProvider(pid, sourceOverride), pid, messages);
 
         System.out.println("Taking first snapshot... waiting " + intervalSeconds + "s for second snapshot");
 

--- a/argus-cli/src/main/java/io/argus/cli/command/DynLibsCommand.java
+++ b/argus-cli/src/main/java/io/argus/cli/command/DynLibsCommand.java
@@ -41,8 +41,7 @@ public final class DynLibsCommand implements Command {
         }
 
         String source = sourceOverride != null ? sourceOverride : config.defaultSource();
-        DynLibsProvider provider = registry.findDynLibsProvider(pid, sourceOverride);
-        if (provider == null) { System.err.println(messages.get("error.provider.none", pid)); return; }
+        DynLibsProvider provider = Providers.require(registry.findDynLibsProvider(pid, sourceOverride), pid, messages);
 
         DynLibsResult result = provider.getDynLibs(pid);
 

--- a/argus-cli/src/main/java/io/argus/cli/command/EnvCommand.java
+++ b/argus-cli/src/main/java/io/argus/cli/command/EnvCommand.java
@@ -39,8 +39,7 @@ public final class EnvCommand implements Command {
         }
 
         String source = sourceOverride != null ? sourceOverride : config.defaultSource();
-        EnvProvider provider = registry.findEnvProvider(pid, sourceOverride);
-        if (provider == null) { System.err.println(messages.get("error.provider.none", pid)); return; }
+        EnvProvider provider = Providers.require(registry.findEnvProvider(pid, sourceOverride), pid, messages);
 
         EnvResult result = provider.getEnv(pid);
 

--- a/argus-cli/src/main/java/io/argus/cli/command/FinalizerCommand.java
+++ b/argus-cli/src/main/java/io/argus/cli/command/FinalizerCommand.java
@@ -39,8 +39,7 @@ public final class FinalizerCommand implements Command {
         }
 
         String source = sourceOverride != null ? sourceOverride : config.defaultSource();
-        FinalizerProvider provider = registry.findFinalizerProvider(pid, sourceOverride);
-        if (provider == null) { System.err.println(messages.get("error.provider.none", pid)); return; }
+        FinalizerProvider provider = Providers.require(registry.findFinalizerProvider(pid, sourceOverride), pid, messages);
 
         FinalizerResult result = provider.getFinalizerInfo(pid);
 

--- a/argus-cli/src/main/java/io/argus/cli/command/GcCauseCommand.java
+++ b/argus-cli/src/main/java/io/argus/cli/command/GcCauseCommand.java
@@ -40,8 +40,7 @@ public final class GcCauseCommand implements Command {
         }
 
         String source = sourceOverride != null ? sourceOverride : config.defaultSource();
-        GcCauseProvider provider = registry.findGcCauseProvider(pid, sourceOverride);
-        if (provider == null) { System.err.println(messages.get("error.provider.none", pid)); return; }
+        GcCauseProvider provider = Providers.require(registry.findGcCauseProvider(pid, sourceOverride), pid, messages);
 
         GcCauseResult result = provider.getGcCause(pid);
 

--- a/argus-cli/src/main/java/io/argus/cli/command/GcCommand.java
+++ b/argus-cli/src/main/java/io/argus/cli/command/GcCommand.java
@@ -46,11 +46,7 @@ public final class GcCommand implements Command {
         }
 
         String source = sourceOverride != null ? sourceOverride : config.defaultSource();
-        GcProvider provider = registry.findGcProvider(pid, sourceOverride);
-        if (provider == null) {
-            System.err.println(messages.get("error.provider.none", pid));
-            return;
-        }
+        GcProvider provider = Providers.require(registry.findGcProvider(pid, sourceOverride), pid, messages);
 
         GcResult result = provider.getGcInfo(pid);
 

--- a/argus-cli/src/main/java/io/argus/cli/command/GcNewCommand.java
+++ b/argus-cli/src/main/java/io/argus/cli/command/GcNewCommand.java
@@ -48,8 +48,7 @@ public final class GcNewCommand implements Command {
         }
 
         String source = sourceOverride != null ? sourceOverride : config.defaultSource();
-        GcNewProvider provider = registry.findGcNewProvider(pid, sourceOverride);
-        if (provider == null) { System.err.println(messages.get("error.provider.none", pid)); return; }
+        GcNewProvider provider = Providers.require(registry.findGcNewProvider(pid, sourceOverride), pid, messages);
 
         GcNewResult result = provider.getGcNew(pid);
 

--- a/argus-cli/src/main/java/io/argus/cli/command/GcUtilCommand.java
+++ b/argus-cli/src/main/java/io/argus/cli/command/GcUtilCommand.java
@@ -54,11 +54,7 @@ public final class GcUtilCommand implements Command {
         }
 
         String source = sourceOverride != null ? sourceOverride : config.defaultSource();
-        GcUtilProvider provider = registry.findGcUtilProvider(pid, sourceOverride);
-        if (provider == null) {
-            System.err.println(messages.get("error.provider.none", pid));
-            return;
-        }
+        GcUtilProvider provider = Providers.require(registry.findGcUtilProvider(pid, sourceOverride), pid, messages);
 
         if (watchInterval > 0) {
             runWatchMode(pid, provider, source, useColor, watchInterval, messages);

--- a/argus-cli/src/main/java/io/argus/cli/command/HeapCommand.java
+++ b/argus-cli/src/main/java/io/argus/cli/command/HeapCommand.java
@@ -51,11 +51,7 @@ public final class HeapCommand implements Command {
         }
 
         String source = sourceOverride != null ? sourceOverride : config.defaultSource();
-        HeapProvider provider = registry.findHeapProvider(pid, sourceOverride);
-        if (provider == null) {
-            System.err.println(messages.get("error.provider.none", pid));
-            return;
-        }
+        HeapProvider provider = Providers.require(registry.findHeapProvider(pid, sourceOverride), pid, messages);
 
         HeapResult result = provider.getHeapInfo(pid);
 

--- a/argus-cli/src/main/java/io/argus/cli/command/HeapDumpCommand.java
+++ b/argus-cli/src/main/java/io/argus/cli/command/HeapDumpCommand.java
@@ -114,11 +114,7 @@ public final class HeapDumpCommand implements Command {
             }
         }
 
-        HeapDumpProvider provider = registry.findHeapDumpProvider(pid, sourceOverride);
-        if (provider == null) {
-            System.err.println(messages.get("error.provider.none", pid));
-            return;
-        }
+        HeapDumpProvider provider = Providers.require(registry.findHeapDumpProvider(pid, sourceOverride), pid, messages);
 
         HeapDumpResult result = provider.heapDump(pid, filePath, liveOnly);
 

--- a/argus-cli/src/main/java/io/argus/cli/command/HistoCommand.java
+++ b/argus-cli/src/main/java/io/argus/cli/command/HistoCommand.java
@@ -51,11 +51,7 @@ public final class HistoCommand implements Command {
         }
 
         String source = sourceOverride != null ? sourceOverride : config.defaultSource();
-        HistoProvider provider = registry.findHistoProvider(pid, sourceOverride);
-        if (provider == null) {
-            System.err.println(messages.get("error.provider.none", pid));
-            return;
-        }
+        HistoProvider provider = Providers.require(registry.findHistoProvider(pid, sourceOverride), pid, messages);
 
         HistoResult result = provider.getHistogram(pid, topN);
 

--- a/argus-cli/src/main/java/io/argus/cli/command/InfoCommand.java
+++ b/argus-cli/src/main/java/io/argus/cli/command/InfoCommand.java
@@ -47,11 +47,7 @@ public final class InfoCommand implements Command {
             }
         }
 
-        InfoProvider provider = registry.findInfoProvider(pid, sourceOverride);
-        if (provider == null) {
-            System.err.println(messages.get("error.provider.none", pid));
-            return;
-        }
+        InfoProvider provider = Providers.require(registry.findInfoProvider(pid, sourceOverride), pid, messages);
 
         InfoResult result = provider.getVmInfo(pid);
 

--- a/argus-cli/src/main/java/io/argus/cli/command/JfrCommand.java
+++ b/argus-cli/src/main/java/io/argus/cli/command/JfrCommand.java
@@ -63,11 +63,7 @@ public final class JfrCommand implements Command {
             }
         }
 
-        JfrProvider provider = registry.findJfrProvider(pid, sourceOverride);
-        if (provider == null) {
-            System.err.println(messages.get("error.provider.none", pid));
-            return;
-        }
+        JfrProvider provider = Providers.require(registry.findJfrProvider(pid, sourceOverride), pid, messages);
 
         JfrResult result;
         switch (subcommand) {

--- a/argus-cli/src/main/java/io/argus/cli/command/LoggerCommand.java
+++ b/argus-cli/src/main/java/io/argus/cli/command/LoggerCommand.java
@@ -61,11 +61,7 @@ public final class LoggerCommand implements Command {
             }
         }
 
-        LoggerProvider provider = registry.findLoggerProvider(pid, sourceOverride);
-        if (provider == null) {
-            System.err.println(messages.get("error.provider.none", pid));
-            return;
-        }
+        LoggerProvider provider = Providers.require(registry.findLoggerProvider(pid, sourceOverride), pid, messages);
 
         // Set mode: change log level
         if (loggerName != null && level != null) {

--- a/argus-cli/src/main/java/io/argus/cli/command/MetaspaceCommand.java
+++ b/argus-cli/src/main/java/io/argus/cli/command/MetaspaceCommand.java
@@ -40,8 +40,7 @@ public final class MetaspaceCommand implements Command {
         }
 
         String source = sourceOverride != null ? sourceOverride : config.defaultSource();
-        MetaspaceProvider provider = registry.findMetaspaceProvider(pid, sourceOverride);
-        if (provider == null) { System.err.println(messages.get("error.provider.none", pid)); return; }
+        MetaspaceProvider provider = Providers.require(registry.findMetaspaceProvider(pid, sourceOverride), pid, messages);
 
         MetaspaceResult result = provider.getMetaspaceInfo(pid);
 

--- a/argus-cli/src/main/java/io/argus/cli/command/NmtCommand.java
+++ b/argus-cli/src/main/java/io/argus/cli/command/NmtCommand.java
@@ -71,11 +71,7 @@ public final class NmtCommand implements Command {
             }
         }
 
-        NmtProvider provider = registry.findNmtProvider(pid, sourceOverride);
-        if (provider == null) {
-            System.err.println(messages.get("error.provider.none", pid));
-            return;
-        }
+        NmtProvider provider = Providers.require(registry.findNmtProvider(pid, sourceOverride), pid, messages);
 
         // Watch mode — live delta loop, short-circuits everything else
         if (watchInterval > 0) {

--- a/argus-cli/src/main/java/io/argus/cli/command/PoolCommand.java
+++ b/argus-cli/src/main/java/io/argus/cli/command/PoolCommand.java
@@ -46,8 +46,7 @@ public final class PoolCommand implements Command {
         }
 
         String source = sourceOverride != null ? sourceOverride : config.defaultSource();
-        PoolProvider provider = registry.findPoolProvider(pid, sourceOverride);
-        if (provider == null) { System.err.println(messages.get("error.provider.none", pid)); return; }
+        PoolProvider provider = Providers.require(registry.findPoolProvider(pid, sourceOverride), pid, messages);
 
         PoolResult result = provider.getPoolInfo(pid);
 

--- a/argus-cli/src/main/java/io/argus/cli/command/ProfileCommand.java
+++ b/argus-cli/src/main/java/io/argus/cli/command/ProfileCommand.java
@@ -259,11 +259,7 @@ public final class ProfileCommand implements Command {
             return;
         }
 
-        ProfileProvider provider = registry.findProfileProvider(pid, sourceOverride);
-        if (provider == null) {
-            System.err.println(messages.get("error.provider.none", pid));
-            return;
-        }
+        ProfileProvider provider = Providers.require(registry.findProfileProvider(pid, sourceOverride), pid, messages);
 
         boolean useColor = config.color();
 
@@ -394,11 +390,7 @@ public final class ProfileCommand implements Command {
             }
         }
 
-        ProfileProvider provider = registry.findProfileProvider(pid, sourceOverride);
-        if (provider == null) {
-            System.err.println(messages.get("error.provider.none", pid));
-            return;
-        }
+        ProfileProvider provider = Providers.require(registry.findProfileProvider(pid, sourceOverride), pid, messages);
 
         // Create output dir if needed
         final String snapDir = outputDir;
@@ -864,11 +856,7 @@ public final class ProfileCommand implements Command {
             return;
         }
 
-        ProfileProvider provider = registry.findProfileProvider(pid, sourceOverride);
-        if (provider == null) {
-            System.err.println(messages.get("error.provider.none", pid));
-            return;
-        }
+        ProfileProvider provider = Providers.require(registry.findProfileProvider(pid, sourceOverride), pid, messages);
 
         ProfileResult result;
         switch (subcommand) {

--- a/argus-cli/src/main/java/io/argus/cli/command/Providers.java
+++ b/argus-cli/src/main/java/io/argus/cli/command/Providers.java
@@ -1,0 +1,30 @@
+package io.argus.cli.command;
+
+import io.argus.cli.config.Messages;
+import io.argus.cli.provider.DiagnosticProvider;
+
+/**
+ * Resolution helpers for {@link DiagnosticProvider} lookups.
+ *
+ * <p>Most CLI commands do the same thing on a missing provider: print the
+ * localized {@code error.provider.none} message and bail out. This helper
+ * folds that 5-line block into a single call that throws
+ * {@link CommandExitException} with exit code 1.
+ */
+public final class Providers {
+
+    private Providers() {}
+
+    /**
+     * Returns {@code provider}, or throws {@link CommandExitException}{@code (1)}
+     * after printing the localized "no provider available" message to stderr
+     * if {@code provider} is {@code null}.
+     */
+    public static <T extends DiagnosticProvider> T require(T provider, long pid, Messages messages) {
+        if (provider == null) {
+            System.err.println(messages.get("error.provider.none", pid));
+            throw new CommandExitException(1);
+        }
+        return provider;
+    }
+}

--- a/argus-cli/src/main/java/io/argus/cli/command/SearchClassCommand.java
+++ b/argus-cli/src/main/java/io/argus/cli/command/SearchClassCommand.java
@@ -63,11 +63,7 @@ public final class SearchClassCommand implements Command {
             }
         }
 
-        SearchClassProvider provider = registry.findSearchClassProvider(pid, sourceOverride);
-        if (provider == null) {
-            System.err.println(messages.get("error.provider.none", pid));
-            return;
-        }
+        SearchClassProvider provider = Providers.require(registry.findSearchClassProvider(pid, sourceOverride), pid, messages);
 
         SearchClassResult result = provider.searchClasses(pid, pattern);
 

--- a/argus-cli/src/main/java/io/argus/cli/command/StringTableCommand.java
+++ b/argus-cli/src/main/java/io/argus/cli/command/StringTableCommand.java
@@ -39,8 +39,7 @@ public final class StringTableCommand implements Command {
         }
 
         String source = sourceOverride != null ? sourceOverride : config.defaultSource();
-        StringTableProvider provider = registry.findStringTableProvider(pid, sourceOverride);
-        if (provider == null) { System.err.println(messages.get("error.provider.none", pid)); return; }
+        StringTableProvider provider = Providers.require(registry.findStringTableProvider(pid, sourceOverride), pid, messages);
 
         StringTableResult result = provider.getStringTableInfo(pid);
 

--- a/argus-cli/src/main/java/io/argus/cli/command/SymbolTableCommand.java
+++ b/argus-cli/src/main/java/io/argus/cli/command/SymbolTableCommand.java
@@ -39,8 +39,7 @@ public final class SymbolTableCommand implements Command {
         }
 
         String source = sourceOverride != null ? sourceOverride : config.defaultSource();
-        SymbolTableProvider provider = registry.findSymbolTableProvider(pid, sourceOverride);
-        if (provider == null) { System.err.println(messages.get("error.provider.none", pid)); return; }
+        SymbolTableProvider provider = Providers.require(registry.findSymbolTableProvider(pid, sourceOverride), pid, messages);
 
         SymbolTableResult result = provider.getSymbolTableInfo(pid);
 

--- a/argus-cli/src/main/java/io/argus/cli/command/SysPropsCommand.java
+++ b/argus-cli/src/main/java/io/argus/cli/command/SysPropsCommand.java
@@ -51,11 +51,7 @@ public final class SysPropsCommand implements Command {
             }
         }
 
-        SysPropsProvider provider = registry.findSysPropsProvider(pid, sourceOverride);
-        if (provider == null) {
-            System.err.println(messages.get("error.provider.none", pid));
-            return;
-        }
+        SysPropsProvider provider = Providers.require(registry.findSysPropsProvider(pid, sourceOverride), pid, messages);
 
         SysPropsResult result = provider.getSystemProperties(pid);
 

--- a/argus-cli/src/main/java/io/argus/cli/command/ThreadDumpCommand.java
+++ b/argus-cli/src/main/java/io/argus/cli/command/ThreadDumpCommand.java
@@ -59,11 +59,7 @@ public final class ThreadDumpCommand implements Command {
         }
 
         String source = sourceOverride != null ? sourceOverride : config.defaultSource();
-        ThreadDumpProvider provider = registry.findThreadDumpProvider(pid, sourceOverride);
-        if (provider == null) {
-            System.err.println(messages.get("error.provider.none", pid));
-            return;
-        }
+        ThreadDumpProvider provider = Providers.require(registry.findThreadDumpProvider(pid, sourceOverride), pid, messages);
 
         ThreadDumpResult result = provider.dumpThreads(pid);
 

--- a/argus-cli/src/main/java/io/argus/cli/command/ThreadsCommand.java
+++ b/argus-cli/src/main/java/io/argus/cli/command/ThreadsCommand.java
@@ -84,11 +84,7 @@ public final class ThreadsCommand implements Command {
         }
 
         String source = sourceOverride != null ? sourceOverride : config.defaultSource();
-        ThreadProvider provider = registry.findThreadProvider(pid, sourceOverride);
-        if (provider == null) {
-            System.err.println(messages.get("error.provider.none", pid));
-            return;
-        }
+        ThreadProvider provider = Providers.require(registry.findThreadProvider(pid, sourceOverride), pid, messages);
 
         ThreadResult result = provider.getThreadDump(pid);
 

--- a/argus-cli/src/main/java/io/argus/cli/command/VmFlagCommand.java
+++ b/argus-cli/src/main/java/io/argus/cli/command/VmFlagCommand.java
@@ -59,11 +59,7 @@ public final class VmFlagCommand implements Command {
             }
         }
 
-        VmFlagProvider provider = registry.findVmFlagProvider(pid, sourceOverride);
-        if (provider == null) {
-            System.err.println(messages.get("error.provider.none", pid));
-            return;
-        }
+        VmFlagProvider provider = Providers.require(registry.findVmFlagProvider(pid, sourceOverride), pid, messages);
 
         if (setExpr != null) {
             executeSet(pid, setExpr, provider, useColor, messages);

--- a/argus-cli/src/test/java/io/argus/cli/command/ProvidersTest.java
+++ b/argus-cli/src/test/java/io/argus/cli/command/ProvidersTest.java
@@ -1,0 +1,41 @@
+package io.argus.cli.command;
+
+import io.argus.cli.config.Messages;
+import io.argus.cli.provider.GcProvider;
+import io.argus.cli.provider.jdk.JdkGcProvider;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ProvidersTest {
+
+    private static final Messages EN = new Messages("en");
+
+    @Test
+    void requireReturnsProviderWhenNonNull() {
+        GcProvider provider = new JdkGcProvider();
+        assertSame(provider, Providers.require(provider, 12345L, EN));
+    }
+
+    @Test
+    void requireThrowsWithExitCodeOneWhenNull() {
+        PrintStream originalErr = System.err;
+        ByteArrayOutputStream captured = new ByteArrayOutputStream();
+        System.setErr(new PrintStream(captured, true, StandardCharsets.UTF_8));
+        try {
+            CommandExitException ex = assertThrows(
+                    CommandExitException.class,
+                    () -> Providers.require((GcProvider) null, 12345L, EN));
+            assertEquals(1, ex.exitCode());
+            String stderr = captured.toString(StandardCharsets.UTF_8);
+            assertTrue(stderr.contains("12345"),
+                    "stderr should mention the pid; was: " + stderr);
+        } finally {
+            System.setErr(originalErr);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Every CLI command that resolves a typed provider repeated the same 5-line block:

```java
GcProvider provider = registry.findGcProvider(pid, sourceOverride);
if (provider == null) {
    System.err.println(messages.get("error.provider.none", pid));
    return;
}
```

The block returned with exit 0, so missing-provider runs silently looked like success to scripts piping argus output.

This PR introduces a single `Providers.require(provider, pid, messages)` static helper in the command package. It prints the localized error and throws `CommandExitException(1)`, which `ArgusCli` already converts to a non-zero exit. 32 call sites across 31 command files shrink from 5 lines to 1, and missing-provider runs now correctly exit 1.

- New file: `argus-cli/src/main/java/io/argus/cli/command/Providers.java` (~30 LOC, single static helper)
- 31 commands migrated to `Providers.require(...)`
- Net change: −95 lines from command files (after counting the +30 new helper and +41 unit test, total diff is +103 / −127)
- Unit test: `ProvidersTest` covers both branches (non-null pass-through, null → throws `CommandExitException(1)` + writes to stderr)

## Out of scope

Sites that don't fit the helper shape are left alone:

- `ClassLeak/CompilerQueue/Events/GcRunCommand` — check `JcmdExecutor.isJcmdAvailable()` directly, not a typed provider.
- `ProfileCommand`'s parallel fan-out callable wraps the message into a `ProfileResult.error` rather than printing/exiting.
- `PsCommand` passes `"ps"` instead of a pid.

## Behaviour change

CLI commands that previously printed `error.provider.none` to stderr and exited **0** now exit **1**. This is the correct behaviour for shell pipelines and CI gates — silent exit-0 on a missing provider was a latent bug.

## Test plan

- [x] `:argus-cli:test` passes (incl. new `ProvidersTest`)
- [x] Full `./gradlew build` (excluding `integrationTest`) passes
- [x] Smoke: `argus gc 999999` exits 1 with stderr message
- [ ] Verify on user side that no downstream script depended on the old exit-0 behaviour