### PR TITLE
refactor(cli): consolidate JFR capture loop into JfrCaptureSession

### DIFF
--- a/argus-cli/src/main/java/io/argus/cli/command/GcProfileCommand.java
+++ b/argus-cli/src/main/java/io/argus/cli/command/GcProfileCommand.java
@@ -7,8 +7,9 @@ import io.argus.cli.profiler.AllocationProfiler.AllocatedType;
 import io.argus.cli.profiler.AllocationProfiler.AllocationByClass;
 import io.argus.cli.profiler.AllocationProfiler.AllocationProfile;
 import io.argus.cli.profiler.AllocationProfiler.AllocationSite;
+import io.argus.cli.jfr.JfrCaptureFailed;
+import io.argus.cli.jfr.JfrCaptureSession;
 import io.argus.cli.provider.ProviderRegistry;
-import io.argus.cli.provider.jdk.JcmdExecutor;
 import io.argus.cli.render.AnsiStyle;
 import io.argus.cli.render.RichRenderer;
 import io.argus.core.command.CommandGroup;
@@ -90,58 +91,16 @@ public final class GcProfileCommand implements Command {
         }
 
         boolean useColor = config.color();
-        Path tmpFile = null;
+        System.out.println("  Starting JFR recording on PID " + pid + " for " + durationSec + "s...");
 
-        try {
-            tmpFile = Files.createTempFile("argus-gcprofile-" + pid + "-", ".jfr");
-            String jfrPath = tmpFile.toAbsolutePath().toString();
+        try (JfrCaptureSession.Capture capture = JfrCaptureSession.capture(
+                pid, JFR_RECORDING_NAME, "profile", durationSec, "argus-gcprofile-")) {
 
-            // Step 1: Start JFR recording
-            System.out.println("  Starting JFR recording on PID " + pid + " for " + durationSec + "s...");
-            String startOut = JcmdExecutor.runJcmd(pid, "JFR.start",
-                    "name=" + JFR_RECORDING_NAME,
-                    "duration=" + durationSec + "s",
-                    "settings=profile");
-            if (startOut == null) {
-                System.err.println("Failed to start JFR recording. Ensure jcmd is available and the JVM is accessible.");
-                return;
-            }
-            if (startOut.contains("Could not") || startOut.contains("error") || startOut.contains("Error")) {
-                System.err.println("JFR.start failed: " + startOut.trim());
-                return;
-            }
-
-            // Step 2: Wait for recording duration
-            System.out.println("  Recording... (wait " + durationSec + "s)");
-            try {
-                Thread.sleep((long) durationSec * 1000);
-            } catch (InterruptedException e) {
-                Thread.currentThread().interrupt();
-                System.err.println("Interrupted while waiting for JFR recording.");
-                return;
-            }
-
-            // Step 3: Dump the recording
-            String dumpOut = JcmdExecutor.runJcmd(pid, "JFR.dump",
-                    "name=" + JFR_RECORDING_NAME,
-                    "filename=" + jfrPath);
-            if (dumpOut == null || dumpOut.contains("Could not") || dumpOut.contains("error")) {
-                System.err.println("JFR.dump failed: " + (dumpOut != null ? dumpOut.trim() : "no output"));
-                return;
-            }
-
-            // Step 4: Stop the recording
-            JcmdExecutor.runJcmd(pid, "JFR.stop", "name=" + JFR_RECORDING_NAME);
-
-            // Step 5: Parse and display
-            if (!Files.exists(tmpFile) || Files.size(tmpFile) == 0) {
-                System.err.println("JFR file is empty or was not created. The JVM may not support JFR recording.");
-                return;
-            }
+            Path jfrFile = capture.file();
 
             // Optional: write folded stacks for flamegraph.pl consumption.
             if (foldPath != null) {
-                Map<String, Long> folded = AllocationProfiler.analyzeFoldedStacks(tmpFile);
+                Map<String, Long> folded = AllocationProfiler.analyzeFoldedStacks(jfrFile);
                 writeFolded(Path.of(foldPath), folded);
                 System.out.println("  Folded stacks written: " + foldPath
                         + " (" + folded.size() + " stacks)");
@@ -150,14 +109,14 @@ public final class GcProfileCommand implements Command {
             }
 
             if ("class".equals(by)) {
-                AllocationByClass byClass = AllocationProfiler.analyzeByClass(tmpFile);
+                AllocationByClass byClass = AllocationProfiler.analyzeByClass(jfrFile);
                 if (json) {
                     printJsonByClass(byClass, pid, durationSec, top);
                 } else {
                     printRichByClass(byClass, pid, durationSec, top, useColor);
                 }
             } else {
-                AllocationProfile profile = AllocationProfiler.analyze(tmpFile);
+                AllocationProfile profile = AllocationProfiler.analyze(jfrFile);
                 if (json) {
                     printJson(profile, pid, durationSec, top);
                 } else {
@@ -165,14 +124,12 @@ public final class GcProfileCommand implements Command {
                 }
             }
 
+        } catch (JfrCaptureFailed e) {
+            System.err.println(e.getMessage());
         } catch (IOException e) {
             System.err.println("Failed to profile PID " + pid + ": " + e.getMessage());
             if (Boolean.getBoolean("argus.debug") || System.getenv("ARGUS_DEBUG") != null) {
                 e.printStackTrace();
-            }
-        } finally {
-            if (tmpFile != null) {
-                try { Files.deleteIfExists(tmpFile); } catch (IOException ignored) {}
             }
         }
     }

--- a/argus-cli/src/main/java/io/argus/cli/command/GcScoreCommand.java
+++ b/argus-cli/src/main/java/io/argus/cli/command/GcScoreCommand.java
@@ -10,8 +10,9 @@ import io.argus.cli.gcscore.AxisScore;
 import io.argus.cli.gcscore.GcScoreCalculator;
 import io.argus.cli.gcscore.GcScoreResult;
 import io.argus.cli.gcwhy.GcWhyJfrCollector;
+import io.argus.cli.jfr.JfrCaptureFailed;
+import io.argus.cli.jfr.JfrCaptureSession;
 import io.argus.cli.provider.ProviderRegistry;
-import io.argus.cli.provider.jdk.JcmdExecutor;
 import io.argus.cli.render.AnsiStyle;
 import io.argus.cli.render.RichRenderer;
 import io.argus.core.command.CommandGroup;
@@ -117,71 +118,25 @@ public final class GcScoreCommand implements Command {
     // ── Live JFR form ────────────────────────────────────────────────────────
 
     private void executeLive(long pid, int durationSec, boolean json, boolean useColor, Messages messages) {
-        Path tmpFile = null;
-        try {
-            tmpFile = Files.createTempFile("argus-gcscore-" + pid + "-", ".jfr");
-            String jfrPath = tmpFile.toAbsolutePath().toString();
+        System.out.println("  " + messages.get("gcscore.live.capturing",
+                String.valueOf(pid), String.valueOf(durationSec)));
 
-            System.out.println("  " + messages.get("gcscore.live.capturing",
-                    String.valueOf(pid), String.valueOf(durationSec)));
+        try (JfrCaptureSession.Capture capture = JfrCaptureSession.capture(
+                pid, JFR_RECORDING_NAME, "default", durationSec, "argus-gcscore-")) {
 
-            String startOut = JcmdExecutor.runJcmd(pid, "JFR.start",
-                    "name=" + JFR_RECORDING_NAME,
-                    "settings=default");
-            if (startOut == null) {
-                System.err.println("Failed to start JFR recording. Ensure jcmd is available and the JVM is accessible.");
-                return;
-            }
-            if (startOut.contains("Could not") || startOut.toLowerCase().contains("error")) {
-                System.err.println("JFR.start failed: " + startOut.trim());
-                return;
-            }
-
-            try {
-                Thread.sleep((long) durationSec * 1000);
-            } catch (InterruptedException e) {
-                Thread.currentThread().interrupt();
-                System.err.println("Interrupted while waiting for JFR recording.");
-                return;
-            }
-
-            String dumpOut = JcmdExecutor.runJcmd(pid, "JFR.dump",
-                    "name=" + JFR_RECORDING_NAME,
-                    "filename=" + jfrPath);
-            if (dumpOut == null || dumpOut.contains("Could not") || dumpOut.toLowerCase().contains("error")) {
-                System.err.println("JFR.dump failed: " + (dumpOut != null ? dumpOut.trim() : "no output"));
-                return;
-            }
-            JcmdExecutor.runJcmd(pid, "JFR.stop", "name=" + JFR_RECORDING_NAME);
-
-            if (!Files.exists(tmpFile) || Files.size(tmpFile) == 0) {
-                System.err.println("JFR file is empty or was not created. The JVM may not support JFR recording.");
-                return;
-            }
-
-            List<GcEvent> events;
-            try {
-                events = GcWhyJfrCollector.collect(tmpFile);
-            } catch (IOException e) {
-                System.err.println("Failed to parse JFR recording: " + e.getMessage());
-                return;
-            }
-
+            List<GcEvent> events = GcWhyJfrCollector.collect(capture.file());
             if (events.isEmpty()) {
                 System.err.println(messages.get("gcscore.no.events", String.valueOf(durationSec)));
                 return;
             }
-
             scoreAndRender(events, json, useColor, messages, "pid:" + pid);
 
+        } catch (JfrCaptureFailed e) {
+            System.err.println(e.getMessage());
         } catch (IOException e) {
             System.err.println("Failed to capture live GC data for PID " + pid + ": " + e.getMessage());
             if (Boolean.getBoolean("argus.debug") || System.getenv("ARGUS_DEBUG") != null) {
                 e.printStackTrace();
-            }
-        } finally {
-            if (tmpFile != null) {
-                try { Files.deleteIfExists(tmpFile); } catch (IOException ignored) {}
             }
         }
     }

--- a/argus-cli/src/main/java/io/argus/cli/command/GcWhyCommand.java
+++ b/argus-cli/src/main/java/io/argus/cli/command/GcWhyCommand.java
@@ -7,8 +7,9 @@ import io.argus.cli.gclog.GcLogParser;
 import io.argus.cli.gcwhy.GcWhyAnalyzer;
 import io.argus.cli.gcwhy.GcWhyJfrCollector;
 import io.argus.cli.gcwhy.GcWhyResult;
+import io.argus.cli.jfr.JfrCaptureFailed;
+import io.argus.cli.jfr.JfrCaptureSession;
 import io.argus.cli.provider.ProviderRegistry;
-import io.argus.cli.provider.jdk.JcmdExecutor;
 import io.argus.cli.render.AnsiStyle;
 import io.argus.cli.render.RichRenderer;
 import io.argus.core.command.CommandGroup;
@@ -122,76 +123,25 @@ public final class GcWhyCommand implements Command {
 
     private void executeLive(long pid, int durationSec, double windowSec,
                              boolean json, boolean useColor, Messages messages) {
-        Path tmpFile = null;
-        try {
-            tmpFile = Files.createTempFile("argus-gcwhy-" + pid + "-", ".jfr");
-            String jfrPath = tmpFile.toAbsolutePath().toString();
+        System.out.println("  " + messages.get("gcwhy.live.capturing",
+                String.valueOf(pid), String.valueOf(durationSec)));
 
-            System.out.println("  " + messages.get("gcwhy.live.capturing", String.valueOf(pid), String.valueOf(durationSec)));
+        try (JfrCaptureSession.Capture capture = JfrCaptureSession.capture(
+                pid, JFR_RECORDING_NAME, "default", durationSec, "argus-gcwhy-")) {
 
-            // Start JFR recording on the target JVM. Do NOT pass `duration=`: with that flag
-            // the JVM auto-stops + finalises the recording at the deadline, racing our explicit
-            // JFR.dump and yielding an empty file. We control timing by sleeping then stopping.
-            String startOut = JcmdExecutor.runJcmd(pid, "JFR.start",
-                    "name=" + JFR_RECORDING_NAME,
-                    "settings=default");
-            if (startOut == null) {
-                System.err.println("Failed to start JFR recording. Ensure jcmd is available and the JVM is accessible.");
-                return;
-            }
-            if (startOut.contains("Could not") || startOut.toLowerCase().contains("error")) {
-                System.err.println("JFR.start failed: " + startOut.trim());
-                return;
-            }
-
-            // Wait for the recording to complete.
-            try {
-                Thread.sleep((long) durationSec * 1000);
-            } catch (InterruptedException e) {
-                Thread.currentThread().interrupt();
-                System.err.println("Interrupted while waiting for JFR recording.");
-                return;
-            }
-
-            // Dump and stop.
-            String dumpOut = JcmdExecutor.runJcmd(pid, "JFR.dump",
-                    "name=" + JFR_RECORDING_NAME,
-                    "filename=" + jfrPath);
-            if (dumpOut == null || dumpOut.contains("Could not") || dumpOut.toLowerCase().contains("error")) {
-                System.err.println("JFR.dump failed: " + (dumpOut != null ? dumpOut.trim() : "no output"));
-                return;
-            }
-            JcmdExecutor.runJcmd(pid, "JFR.stop", "name=" + JFR_RECORDING_NAME);
-
-            if (!Files.exists(tmpFile) || Files.size(tmpFile) == 0) {
-                System.err.println("JFR file is empty or was not created. The JVM may not support JFR recording.");
-                return;
-            }
-
-            // Parse JFR into GcEvent list using the same window that applies to file form.
-            List<GcEvent> events;
-            try {
-                events = GcWhyJfrCollector.collect(tmpFile);
-            } catch (IOException e) {
-                System.err.println("Failed to parse JFR recording: " + e.getMessage());
-                return;
-            }
-
+            List<GcEvent> events = GcWhyJfrCollector.collect(capture.file());
             if (events.isEmpty()) {
                 System.err.println("No GC events captured in the " + durationSec + "s recording window.");
                 return;
             }
-
             renderResult(events, windowSec, json, useColor, messages);
 
+        } catch (JfrCaptureFailed e) {
+            System.err.println(e.getMessage());
         } catch (IOException e) {
             System.err.println("Failed to capture live GC data for PID " + pid + ": " + e.getMessage());
             if (Boolean.getBoolean("argus.debug") || System.getenv("ARGUS_DEBUG") != null) {
                 e.printStackTrace();
-            }
-        } finally {
-            if (tmpFile != null) {
-                try { Files.deleteIfExists(tmpFile); } catch (IOException ignored) {}
             }
         }
     }

--- a/argus-cli/src/main/java/io/argus/cli/command/ZgcCommand.java
+++ b/argus-cli/src/main/java/io/argus/cli/command/ZgcCommand.java
@@ -2,6 +2,8 @@ package io.argus.cli.command;
 
 import io.argus.cli.config.CliConfig;
 import io.argus.cli.config.Messages;
+import io.argus.cli.jfr.JfrCaptureFailed;
+import io.argus.cli.jfr.JfrCaptureSession;
 import io.argus.cli.provider.ProviderRegistry;
 import io.argus.cli.provider.jdk.JcmdExecutor;
 import io.argus.cli.render.AnsiStyle;
@@ -19,7 +21,6 @@ import javax.management.remote.JMXConnectorFactory;
 import javax.management.remote.JMXServiceURL;
 import javax.management.openmbean.CompositeData;
 import java.io.IOException;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Duration;
 import java.time.Instant;
@@ -175,75 +176,19 @@ public final class ZgcCommand implements Command {
         d.maxHeapBytes     = info.maxHeapBytes;
         d.softMaxHeapBytes = info.softMaxHeapBytes;
 
-        Path tmpFile = null;
-        try {
-            tmpFile = Files.createTempFile("argus-zgc-" + pid + "-", ".jfr");
-            String jfrPath = tmpFile.toAbsolutePath().toString();
+        System.out.println(messages.get("cli.zgc.capturing", String.valueOf(durationSec)));
 
-            System.out.println(messages.get("cli.zgc.capturing", String.valueOf(durationSec)));
+        try (JfrCaptureSession.Capture capture = JfrCaptureSession.capture(
+                pid, JFR_RECORDING_NAME, "profile", durationSec, "argus-zgc-")) {
 
-            // Stop any existing recording with the same name to avoid conflicts
-            stopExistingRecording(pid);
+            ZgcJfrCollector.collect(capture.file(), d);
 
-            String startOut = JcmdExecutor.runJcmd(pid, "JFR.start",
-                    "name=" + JFR_RECORDING_NAME,
-                    "settings=profile");
-            if (startOut == null
-                    || startOut.contains("Could not")
-                    || startOut.toLowerCase().contains("error")) {
-                // Retry once after stopping any existing recording
-                stopExistingRecording(pid);
-                startOut = JcmdExecutor.runJcmd(pid, "JFR.start",
-                        "name=" + JFR_RECORDING_NAME,
-                        "settings=profile");
-                if (startOut == null
-                        || startOut.contains("Could not")
-                        || startOut.toLowerCase().contains("error")) {
-                    System.err.println("JFR.start failed: "
-                            + (startOut != null ? startOut.trim() : "no output"));
-                    throw new CommandExitException(2);
-                }
-            }
-
-            try {
-                Thread.sleep((long) durationSec * 1000L);
-            } catch (InterruptedException e) {
-                Thread.currentThread().interrupt();
-                System.err.println("Interrupted while waiting for JFR recording.");
-                throw new CommandExitException(2);
-            }
-
-            String dumpOut = JcmdExecutor.runJcmd(pid, "JFR.dump",
-                    "name=" + JFR_RECORDING_NAME,
-                    "filename=" + jfrPath);
-            if (dumpOut == null
-                    || dumpOut.contains("Could not")
-                    || dumpOut.toLowerCase().contains("error")) {
-                System.err.println("JFR.dump failed: "
-                        + (dumpOut != null ? dumpOut.trim() : "no output"));
-                throw new CommandExitException(2);
-            }
-            JcmdExecutor.runJcmd(pid, "JFR.stop", "name=" + JFR_RECORDING_NAME);
-
-            if (!Files.exists(tmpFile) || Files.size(tmpFile) == 0) {
-                System.err.println("JFR file is empty. The JVM may not support JFR recording.");
-                throw new CommandExitException(2);
-            }
-
-            try {
-                ZgcJfrCollector.collect(tmpFile, d);
-            } catch (IOException e) {
-                System.err.println("Failed to parse JFR recording: " + e.getMessage());
-                throw new CommandExitException(2);
-            }
-
+        } catch (JfrCaptureFailed e) {
+            System.err.println(e.getMessage());
+            throw new CommandExitException(2);
         } catch (IOException e) {
             System.err.println("Failed to capture live ZGC data for PID " + pid + ": " + e.getMessage());
             throw new CommandExitException(2);
-        } finally {
-            if (tmpFile != null) {
-                try { Files.deleteIfExists(tmpFile); } catch (IOException ignored) {}
-            }
         }
 
         return d;

--- a/argus-cli/src/main/java/io/argus/cli/jfr/JfrCaptureFailed.java
+++ b/argus-cli/src/main/java/io/argus/cli/jfr/JfrCaptureFailed.java
@@ -1,0 +1,13 @@
+package io.argus.cli.jfr;
+
+/**
+ * Thrown by {@link JfrCaptureSession#capture} when a JFR recording cannot
+ * be started, dumped, or written. The message describes which stage failed;
+ * callers decide how to surface it (stderr message, exit code).
+ */
+public final class JfrCaptureFailed extends Exception {
+
+    public JfrCaptureFailed(String message) {
+        super(message);
+    }
+}

--- a/argus-cli/src/main/java/io/argus/cli/jfr/JfrCaptureSession.java
+++ b/argus-cli/src/main/java/io/argus/cli/jfr/JfrCaptureSession.java
@@ -1,0 +1,111 @@
+package io.argus.cli.jfr;
+
+import io.argus.cli.provider.jdk.JcmdExecutor;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+/**
+ * Runs the {@code JFR.start → sleep → JFR.dump → JFR.stop} sequence on a
+ * target JVM and writes the recording to a temp file owned by the returned
+ * {@link Capture}.
+ *
+ * <p>Closing the {@link Capture} (e.g. via try-with-resources) deletes the
+ * temp file. Failures at any stage surface as {@link JfrCaptureFailed} with a
+ * description of which step broke; callers translate that into their own
+ * exit-code or message convention.
+ *
+ * <p>The session deliberately does <em>not</em> pass {@code duration=} to
+ * {@code JFR.start}: with that flag the JVM auto-stops and finalises the
+ * recording at the deadline, racing the explicit {@code JFR.dump} and
+ * occasionally producing an empty file. Timing is controlled by sleeping
+ * inside this helper instead.
+ */
+public final class JfrCaptureSession {
+
+    private JfrCaptureSession() {}
+
+    /**
+     * Captures a JFR recording.
+     *
+     * @param pid           target JVM PID
+     * @param recordingName JFR recording name (e.g. {@code "argus-zgc"})
+     * @param settings      JFR settings template ({@code "default"} or {@code "profile"})
+     * @param durationSec   capture window in seconds
+     * @param tmpPrefix     temp-file name prefix (e.g. {@code "argus-zgc-"})
+     * @return a non-empty {@link Capture} wrapping the dumped recording
+     * @throws JfrCaptureFailed if start or dump fails, the wait is interrupted,
+     *                          or the recording file ends up missing/empty
+     * @throws IOException if temp-file creation fails
+     */
+    public static Capture capture(long pid, String recordingName, String settings,
+                                  int durationSec, String tmpPrefix)
+            throws JfrCaptureFailed, IOException {
+        Path tmpFile = Files.createTempFile(tmpPrefix + pid + "-", ".jfr");
+        boolean ok = false;
+        try {
+            // Stop any leftover recording with the same name from a prior run.
+            JcmdExecutor.runJcmd(pid, "JFR.stop", "name=" + recordingName);
+
+            String startOut = JcmdExecutor.runJcmd(pid, "JFR.start",
+                    "name=" + recordingName,
+                    "settings=" + settings);
+            if (failed(startOut)) {
+                throw new JfrCaptureFailed("JFR.start failed: " + describe(startOut));
+            }
+
+            try {
+                Thread.sleep((long) durationSec * 1000L);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new JfrCaptureFailed("Interrupted while waiting for JFR recording.");
+            }
+
+            String dumpOut = JcmdExecutor.runJcmd(pid, "JFR.dump",
+                    "name=" + recordingName,
+                    "filename=" + tmpFile.toAbsolutePath());
+            if (failed(dumpOut)) {
+                throw new JfrCaptureFailed("JFR.dump failed: " + describe(dumpOut));
+            }
+            JcmdExecutor.runJcmd(pid, "JFR.stop", "name=" + recordingName);
+
+            if (!Files.exists(tmpFile) || Files.size(tmpFile) == 0) {
+                throw new JfrCaptureFailed(
+                        "JFR file is empty or was not created. The JVM may not support JFR recording.");
+            }
+
+            ok = true;
+            return new Capture(tmpFile);
+        } finally {
+            if (!ok) {
+                try { Files.deleteIfExists(tmpFile); } catch (IOException ignored) {}
+            }
+        }
+    }
+
+    private static boolean failed(String out) {
+        return out == null
+                || out.contains("Could not")
+                || out.toLowerCase().contains("error");
+    }
+
+    private static String describe(String out) {
+        return out == null ? "no output" : out.trim();
+    }
+
+    /** A captured recording on disk; closing deletes the temp file. */
+    public static final class Capture implements Closeable {
+        private final Path file;
+
+        Capture(Path file) { this.file = file; }
+
+        public Path file() { return file; }
+
+        @Override
+        public void close() {
+            try { Files.deleteIfExists(file); } catch (IOException ignored) {}
+        }
+    }
+}

--- a/argus-cli/src/test/java/io/argus/cli/jfr/JfrCaptureSessionTest.java
+++ b/argus-cli/src/test/java/io/argus/cli/jfr/JfrCaptureSessionTest.java
@@ -1,0 +1,60 @@
+package io.argus.cli.jfr;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class JfrCaptureSessionTest {
+
+    /**
+     * Capturing from a non-existent PID must surface as {@link JfrCaptureFailed}
+     * (the JVM's jcmd will not be able to attach), not as a generic IOException
+     * or a partial recording. The temp file must be cleaned up.
+     */
+    @Test
+    void unreachablePidThrowsJfrCaptureFailed() throws IOException {
+        long bogusPid = 99_999_999L;
+        Path tempDirBefore = listTempJfrFiles();
+
+        JfrCaptureFailed ex = assertThrows(JfrCaptureFailed.class, () ->
+                JfrCaptureSession.capture(bogusPid, "argus-jfr-test", "default", 1, "argus-jfrtest-"));
+
+        assertNotNull(ex.getMessage(), "failed message should not be null");
+
+        Path tempDirAfter = listTempJfrFiles();
+        assertEquals(tempDirBefore, tempDirAfter,
+                "no leftover argus-jfrtest- temp files after a failed capture");
+    }
+
+    /**
+     * The {@link JfrCaptureSession.Capture} returned on success must implement
+     * AutoCloseable in a way that deletes its temp file.
+     */
+    @Test
+    void captureCloseDeletesTempFile() throws IOException {
+        Path tmp = Files.createTempFile("argus-jfrtest-close-", ".jfr");
+        Files.writeString(tmp, "fake recording");
+
+        try (JfrCaptureSession.Capture capture = new JfrCaptureSession.Capture(tmp)) {
+            assertTrue(Files.exists(capture.file()), "file present while capture is open");
+        }
+
+        assertFalse(Files.exists(tmp), "file deleted after close()");
+    }
+
+    /** Returns the count of leftover argus-jfrtest- temp files for leak checks. */
+    private static Path listTempJfrFiles() throws IOException {
+        Path tmpDir = Path.of(System.getProperty("java.io.tmpdir"));
+        long count;
+        try (var stream = Files.list(tmpDir)) {
+            count = stream.filter(p -> p.getFileName().toString().startsWith("argus-jfrtest-"))
+                    .count();
+        }
+        // Encode count as a sentinel path so assertEquals on Path values compares the count.
+        return Path.of(String.valueOf(count));
+    }
+}


### PR DESCRIPTION
## Summary

Four CLI commands — `gcwhy`, `gcscore`, `gcprofile`, `zgc` — each carried their own ~50-line copy of the same JFR capture lifecycle: tempfile → `JFR.start` → sleep → `JFR.dump` → `JFR.stop` → file-empty check → `finally delete tempfile`. Subtle drift had crept in:

- `gcprofile` passed `duration=` to `JFR.start`, which races the explicit dump and can yield an empty file. `gcwhy` already documented this pitfall but the others didn't avoid it.
- `zgc` had a unique pre-stop + retry-on-start-fail wrapper.

This PR moves the lifecycle behind `JfrCaptureSession`, returning an `AutoCloseable` `Capture` so try-with-resources handles tempfile cleanup. Failures surface as the new checked `JfrCaptureFailed`; callers translate that into their own exit-code convention (gcwhy/gcscore/gcprofile keep return-on-fail, zgc keeps `CommandExitException(2)`).

- New: `argus-cli/.../jfr/JfrCaptureSession.java` (~111 LOC) and `JfrCaptureFailed.java` (checked exception)
- 4 commands migrated; net **−47 lines** while adding test coverage
- Tests: `JfrCaptureSessionTest` covers the unreachable-pid failure path (no leftover temp files) and the `Capture#close` deletion contract

## Side effects

- `gcprofile` no longer passes `duration=` to `JFR.start`. This **fixes a latent race** where the JVM auto-stops the recording before the explicit dump.
- `zgc` drops its retry-once-on-start-fail loop. The helper does an unconditional pre-stop of any leftover recording with the same name, which is the case the retry was guarding against.

## Test plan

- [x] `:argus-cli:test` passes (incl. new `JfrCaptureSessionTest`)
- [x] Full `./gradlew build -x integrationTest` passes
- [ ] Smoke against a live JVM: `argus gcwhy <pid> --duration=10 --format=json` produces non-empty JSON
- [ ] Smoke: `argus zgc <pid> --duration=10` for a ZGC JVM still produces a verdict
- [ ] Smoke: `argus gcprofile <pid> --duration=10` produces an allocation profile