### PR TITLE
fix(ci): pin setup-graalvm to v1.4.5 and switch to graalvm distribution

### DIFF
--- a/.github/workflows/native-image.yml
+++ b/.github/workflows/native-image.yml
@@ -20,10 +20,10 @@ jobs:
       contents: write
     steps:
       - uses: actions/checkout@v4
-      - uses: graalvm/setup-graalvm@v1
+      - uses: graalvm/setup-graalvm@v1.4.5
         with:
           java-version: '21'
-          distribution: 'graalvm-community'
+          distribution: 'graalvm'
       - name: Build fat JAR
         run: ./gradlew :argus-cli:fatJar
       - name: Build native image


### PR DESCRIPTION
## Summary
- Native image builds have been silently broken since **v1.3.0** (2026-05-08). The floating `graalvm/setup-graalvm@v1` tag resolved to **v1.5.3** (released 2026-05-06, two days before v1.3.0's release), which rejects `distribution: 'graalvm-community'` with `Unsupported distribution: graalce`.
- Result: `argus-linux-amd64` and `argus-macos-aarch64` assets have been missing from every release since v1.3.0. `install.sh` fail-soft falls back to the fat JAR, so end-users were unaffected — but the native distribution channel is dead.
- Pin to `v1.4.5` (2026-01-28, pre-regression) and switch to `distribution: 'graalvm'` (Oracle GraalVM, free under the GraalVM Free Terms and Conditions). Belt-and-suspenders fix.

## Test plan
- [ ] CI: `native-image.yml` workflow_dispatch on this branch — both `ubuntu-latest` and `macos-latest` jobs succeed and upload `argus-linux-amd64` / `argus-macos-aarch64` artifacts.
- [ ] After merge: re-run `native-image.yml` via workflow_dispatch against tag **v1.3.0** to backfill the missing release assets.
- [ ] Verify the next tagged release (1.4.0) produces native binaries.

## Evidence of the regression
- `release.yml` v1.3.0: success, assets = `argus-agent.jar`, `argus-cli-1.3.0-all.jar`, `argus-server.jar`, `checksums.txt` (no native binaries)
- `docker.yml` v1.3.0: success, GHCR images present
- `native-image.yml` v1.3.0: **failure** on both 2026-05-08 runs — root error `##[error]Unsupported distribution: graalce`