### PR TITLE
feat(profile): forward remaining 7 asprof flags

### DIFF
--- a/argus-cli/src/main/java/io/argus/cli/command/ProfileCommand.java
+++ b/argus-cli/src/main/java/io/argus/cli/command/ProfileCommand.java
@@ -856,6 +856,20 @@ public final class ProfileCommand implements Command {
                 subOptsBuilder.addInclude(arg.substring(10));
             } else if (arg.startsWith("--exclude=")) {
                 subOptsBuilder.addExclude(arg.substring(10));
+            } else if (arg.equals("--reverse")) {
+                subOptsBuilder.reverse(true);
+            } else if (arg.startsWith("--minwidth=")) {
+                subOptsBuilder.minwidth(arg.substring("--minwidth=".length()));
+            } else if (arg.equals("--sched")) {
+                subOptsBuilder.sched(true);
+            } else if (arg.startsWith("--clock=")) {
+                subOptsBuilder.clock(arg.substring("--clock=".length()));
+            } else if (arg.startsWith("--signal=")) {
+                subOptsBuilder.signal(arg.substring("--signal=".length()));
+            } else if (arg.startsWith("--proc=")) {
+                subOptsBuilder.procInterval(arg.substring("--proc=".length()));
+            } else if (arg.equals("--nofree")) {
+                subOptsBuilder.nofree(true);
             }
         }
 

--- a/argus-cli/src/main/java/io/argus/cli/command/ProfileCommand.java
+++ b/argus-cli/src/main/java/io/argus/cli/command/ProfileCommand.java
@@ -243,6 +243,20 @@ public final class ProfileCommand implements Command {
                 optsBuilder.addInclude(arg.substring(10));
             } else if (arg.startsWith("--exclude=")) {
                 optsBuilder.addExclude(arg.substring(10));
+            } else if (arg.equals("--reverse")) {
+                optsBuilder.reverse(true);
+            } else if (arg.startsWith("--minwidth=")) {
+                optsBuilder.minwidth(arg.substring("--minwidth=".length()));
+            } else if (arg.equals("--sched")) {
+                optsBuilder.sched(true);
+            } else if (arg.startsWith("--clock=")) {
+                optsBuilder.clock(arg.substring("--clock=".length()));
+            } else if (arg.startsWith("--signal=")) {
+                optsBuilder.signal(arg.substring("--signal=".length()));
+            } else if (arg.startsWith("--proc=")) {
+                optsBuilder.procInterval(arg.substring("--proc=".length()));
+            } else if (arg.equals("--nofree")) {
+                optsBuilder.nofree(true);
             }
         }
 

--- a/argus-cli/src/main/java/io/argus/cli/provider/jdk/AsProfOptions.java
+++ b/argus-cli/src/main/java/io/argus/cli/provider/jdk/AsProfOptions.java
@@ -52,6 +52,27 @@ public final class AsProfOptions {
      */
     public final String outputFormat;
 
+    /** Pass {@code --reverse} to asprof — generate a stack-reversed (icicle) flame graph. */
+    public final boolean reverse;
+
+    /** Minimum frame width percentage to render, e.g. {@code "0.5"} — or null. Maps to {@code --minwidth pct}. */
+    public final String minwidth;
+
+    /** Pass {@code --sched} to asprof — group threads by scheduling policy (Linux only). */
+    public final boolean sched;
+
+    /** Clock source for JFR timestamps: {@code tsc} or {@code monotonic} — or null. Maps to {@code --clock source}. */
+    public final String clock;
+
+    /** Alternative signal number for cpu/wall profiling — or null. Maps to {@code --signal num}. */
+    public final String signal;
+
+    /** Process sampling interval, e.g. {@code "60s"} — or null. Maps to {@code --proc interval}. */
+    public final String procInterval;
+
+    /** Pass {@code --nofree} to asprof — exclude free() events from native allocation profiling. */
+    public final boolean nofree;
+
     private AsProfOptions(Builder b) {
         this.interval     = b.interval;
         this.jstackdepth  = b.jstackdepth;
@@ -64,6 +85,13 @@ public final class AsProfOptions {
         this.include      = Collections.unmodifiableList(new ArrayList<>(b.include));
         this.exclude      = Collections.unmodifiableList(new ArrayList<>(b.exclude));
         this.outputFormat = b.outputFormat;
+        this.reverse      = b.reverse;
+        this.minwidth     = b.minwidth;
+        this.sched        = b.sched;
+        this.clock        = b.clock;
+        this.signal       = b.signal;
+        this.procInterval = b.procInterval;
+        this.nofree       = b.nofree;
     }
 
     /** Returns an instance with all fields at their "no override" defaults. */
@@ -87,18 +115,32 @@ public final class AsProfOptions {
         private final List<String> include = new ArrayList<>();
         private final List<String> exclude = new ArrayList<>();
         private String outputFormat;
+        private boolean reverse;
+        private String minwidth;
+        private boolean sched;
+        private String clock;
+        private String signal;
+        private String procInterval;
+        private boolean nofree;
 
-        public Builder interval(String v)     { this.interval = v;    return this; }
-        public Builder jstackdepth(int v)     { this.jstackdepth = v; return this; }
-        public Builder cstack(String v)       { this.cstack = v;      return this; }
-        public Builder perThread(boolean v)   { this.perThread = v;   return this; }
-        public Builder allUser(boolean v)     { this.allUser = v;     return this; }
-        public Builder allKernel(boolean v)   { this.allKernel = v;   return this; }
-        public Builder allocBytes(String v)   { this.allocBytes = v;  return this; }
-        public Builder live(boolean v)        { this.live = v;        return this; }
-        public Builder addInclude(String v)   { this.include.add(v);  return this; }
-        public Builder addExclude(String v)   { this.exclude.add(v);  return this; }
+        public Builder interval(String v)     { this.interval = v;     return this; }
+        public Builder jstackdepth(int v)     { this.jstackdepth = v;  return this; }
+        public Builder cstack(String v)       { this.cstack = v;       return this; }
+        public Builder perThread(boolean v)   { this.perThread = v;    return this; }
+        public Builder allUser(boolean v)     { this.allUser = v;      return this; }
+        public Builder allKernel(boolean v)   { this.allKernel = v;    return this; }
+        public Builder allocBytes(String v)   { this.allocBytes = v;   return this; }
+        public Builder live(boolean v)        { this.live = v;         return this; }
+        public Builder addInclude(String v)   { this.include.add(v);   return this; }
+        public Builder addExclude(String v)   { this.exclude.add(v);   return this; }
         public Builder outputFormat(String v) { this.outputFormat = v; return this; }
+        public Builder reverse(boolean v)     { this.reverse = v;      return this; }
+        public Builder minwidth(String v)     { this.minwidth = v;     return this; }
+        public Builder sched(boolean v)       { this.sched = v;        return this; }
+        public Builder clock(String v)        { this.clock = v;        return this; }
+        public Builder signal(String v)       { this.signal = v;       return this; }
+        public Builder procInterval(String v) { this.procInterval = v; return this; }
+        public Builder nofree(boolean v)      { this.nofree = v;       return this; }
 
         public AsProfOptions build() {
             return new AsProfOptions(this);

--- a/argus-cli/src/main/java/io/argus/cli/provider/jdk/AsProfProvider.java
+++ b/argus-cli/src/main/java/io/argus/cli/provider/jdk/AsProfProvider.java
@@ -450,6 +450,13 @@ public final class AsProfProvider implements ProfileProvider {
         if (opts.live)                { cmd.add("--live"); }
         for (String p : opts.include) { cmd.add("-I"); cmd.add(p); }
         for (String p : opts.exclude) { cmd.add("-X"); cmd.add(p); }
+        if (opts.reverse)             { cmd.add("--reverse"); }
+        if (opts.minwidth != null)    { cmd.add("--minwidth"); cmd.add(opts.minwidth); }
+        if (opts.sched)               { cmd.add("--sched"); }
+        if (opts.clock != null)       { cmd.add("--clock"); cmd.add(opts.clock); }
+        if (opts.signal != null)      { cmd.add("--signal"); cmd.add(opts.signal); }
+        if (opts.procInterval != null){ cmd.add("--proc"); cmd.add(opts.procInterval); }
+        if (opts.nofree)              { cmd.add("--nofree"); }
     }
 
     /** Returns the output format string to pass to asprof for the one-shot profile() path. */

--- a/docs/commands/profiling-tracing.md
+++ b/docs/commands/profiling-tracing.md
@@ -100,6 +100,13 @@ Power-user flags forwarded directly to async-profiler. All optional; defaults pr
 | `--live` | `--live` | Only count live allocations (only with `--type=alloc`) |
 | `--include=PATTERN` | `-I PATTERN` | Repeatable include filter |
 | `--exclude=PATTERN` | `-X PATTERN` | Repeatable exclude filter |
+| `--reverse` | `--reverse` | Stack-reversed (icicle) flame graph — surfaces hot leaf frames' callers |
+| `--minwidth=PCT` | `--minwidth pct` | Skip frames narrower than PCT% — noise reduction for large captures |
+| `--sched` | `--sched` | Group threads by scheduling policy (Linux only) |
+| `--clock=tsc\|monotonic` | `--clock source` | Clock source for JFR timestamps — use `monotonic` for container correctness |
+| `--signal=N` | `--signal num` | Alternative signal number for cpu/wall profiling — resolves signal conflicts |
+| `--proc=N` | `--proc interval` | Process sampling interval (e.g. `30s`) — how often asprof probes for thread list changes |
+| `--nofree` | `--nofree` | Exclude free() events from `nativemem` profiling — focus on allocation hotspots |
 
 ```bash
 # Native stacks for JNI debugging:


### PR DESCRIPTION
## Summary
Completes async-profiler 4.4 flag passthrough so `argus profile` wraps the **full** asprof surface, in line with the project philosophy of being the unified JVM diagnostic CLI.

Adds 7 new flags on top of PR #174:

| Argus flag | Asprof flag | Purpose |
|---|---|---|
| `--reverse` | `--reverse` | Stack-reversed (icicle) flame graph |
| `--minwidth=PCT` | `--minwidth pct` | Skip frames narrower than PCT% |
| `--sched` | `--sched` | Group threads by scheduling policy (Linux only) |
| `--clock=tsc\|monotonic` | `--clock source` | JFR timestamp clock source (container correctness) |
| `--signal=N` | `--signal num` | Alternative signal for cpu/wall profiling |
| `--proc=N` | `--proc interval` | Process sampling interval |
| `--nofree` | `--nofree` | Exclude `free()` from `nativemem` profiling |

Cosmetic flags (`--simple`, `--norm`, `--sig`, `--ann`, `--lib`, `--dot`, `--title`, `--total`, `--inverted`) remain unforwarded — they affect display only, not diagnostic data. If desired, easy to add in a follow-up.

## Test plan
- [x] `./gradlew :argus-cli:compileJava :argus-cli:test` — exit 0
- [x] Live capture: `argus profile <pid> --reverse --minwidth=2.0` → normal asprof output, both flags accepted.
- [x] Live capture: `argus profile <pid> --clock=monotonic` → normal asprof output.
- [x] Live capture: `argus profile <pid> --nofree --sched` → normal asprof output.
- [x] Live capture: `argus profile <pid> --signal=42 --proc=10s` → asprof responds with `[ERROR] Process sampling is not supported on the platform` (macOS) — confirming `--proc` reached the asprof argv.

## Stacks with PR #174
This PR is based on **master**, not on #174. The two PRs touch the same 4 files but at distinct anchor points (different table rows in docs, separate builder methods, separate buildExtraArgs lines). They will conflict only trivially on the docs table; the resolution is "keep both blocks". Either merge order works.

## Out of scope
Cosmetic flags above; `--inverted` (pairs with `--reverse`, can be added with `--reverse` if a real user asks); `--all` (shorthand for cpu+wall+alloc+live; conflicts with `-e` and Argus already supports `--type=` with PMU/method-trace events).