### PR TITLE
refactor(profile): extract shared AsprofFlagParser

### DIFF
--- a/argus-cli/src/main/java/io/argus/cli/command/AsprofFlagParser.java
+++ b/argus-cli/src/main/java/io/argus/cli/command/AsprofFlagParser.java
@@ -1,0 +1,80 @@
+package io.argus.cli.command;
+
+import io.argus.cli.config.Messages;
+import io.argus.cli.provider.jdk.AsProfOptions;
+
+/**
+ * Shared parser for asprof passthrough flags used by both the one-shot
+ * profile command and the session subcommands (start/stop/dump/status).
+ *
+ * <p>The caller dispatches each CLI argument here first; on {@link Result#NOT_HANDLED}
+ * the caller falls through to its parser-specific flags. On {@link Result#ERROR} the
+ * helper has already printed a localized error and the caller should return.
+ */
+public final class AsprofFlagParser {
+
+    public enum Result { NOT_HANDLED, HANDLED, ERROR }
+
+    private AsprofFlagParser() {}
+
+    public static Result handle(String arg, AsProfOptions.Builder b, Messages messages) {
+        // boolean flags
+        if (arg.equals("--threads"))   { b.perThread(true);  return Result.HANDLED; }
+        if (arg.equals("--alluser"))   { b.allUser(true);    return Result.HANDLED; }
+        if (arg.equals("--allkernel")) { b.allKernel(true);  return Result.HANDLED; }
+        if (arg.equals("--live"))      { b.live(true);       return Result.HANDLED; }
+        if (arg.equals("--reverse"))   { b.reverse(true);    return Result.HANDLED; }
+        if (arg.equals("--sched"))     { b.sched(true);      return Result.HANDLED; }
+        if (arg.equals("--nofree"))    { b.nofree(true);     return Result.HANDLED; }
+        if (arg.equals("--ttsp"))      { b.ttsp(true);       return Result.HANDLED; }
+
+        // key=value with validation
+        if (arg.startsWith("--interval=")) {
+            String v = arg.substring("--interval=".length());
+            String err = ProfileCommand.validateInterval(v, messages);
+            if (err != null) { System.err.println(err); return Result.ERROR; }
+            b.interval(v); return Result.HANDLED;
+        }
+        if (arg.startsWith("--jstackdepth=")) {
+            int depth = ProfileCommand.parseClampedInt(arg.substring("--jstackdepth=".length()), 1, 2048, 64);
+            b.jstackdepth(depth); return Result.HANDLED;
+        }
+        if (arg.startsWith("--cstack=")) {
+            String v = arg.substring("--cstack=".length());
+            String err = ProfileCommand.validateCstack(v, messages);
+            if (err != null) { System.err.println(err); return Result.ERROR; }
+            b.cstack(v); return Result.HANDLED;
+        }
+        if (arg.startsWith("--clock=")) {
+            String v = arg.substring("--clock=".length());
+            String err = ProfileCommand.validateClock(v, messages);
+            if (err != null) { System.err.println(err); return Result.ERROR; }
+            b.clock(v); return Result.HANDLED;
+        }
+        if (arg.startsWith("--proc=")) {
+            String v = arg.substring("--proc=".length());
+            String err = ProfileCommand.validateInterval(v, messages);
+            if (err != null) { System.err.println(err); return Result.ERROR; }
+            b.procInterval(v); return Result.HANDLED;
+        }
+        if (arg.startsWith("--begin=")) {
+            String v = arg.substring("--begin=".length());
+            if (v.isEmpty()) { System.err.println(messages.get("error.profile.adv.begin.empty")); return Result.ERROR; }
+            b.beginFunction(v); return Result.HANDLED;
+        }
+        if (arg.startsWith("--end=")) {
+            String v = arg.substring("--end=".length());
+            if (v.isEmpty()) { System.err.println(messages.get("error.profile.adv.end.empty")); return Result.ERROR; }
+            b.endFunction(v); return Result.HANDLED;
+        }
+
+        // key=value raw passthrough
+        if (arg.startsWith("--alloc="))    { b.allocBytes(arg.substring("--alloc=".length()));   return Result.HANDLED; }
+        if (arg.startsWith("--include="))  { b.addInclude(arg.substring("--include=".length())); return Result.HANDLED; }
+        if (arg.startsWith("--exclude="))  { b.addExclude(arg.substring("--exclude=".length())); return Result.HANDLED; }
+        if (arg.startsWith("--minwidth=")) { b.minwidth(arg.substring("--minwidth=".length()));  return Result.HANDLED; }
+        if (arg.startsWith("--signal="))   { b.signal(arg.substring("--signal=".length()));      return Result.HANDLED; }
+
+        return Result.NOT_HANDLED;
+    }
+}

--- a/argus-cli/src/main/java/io/argus/cli/command/ProfileCommand.java
+++ b/argus-cli/src/main/java/io/argus/cli/command/ProfileCommand.java
@@ -216,63 +216,10 @@ public final class ProfileCommand implements Command {
                 diffWith = Path.of(diffVal);
             } else if (arg.startsWith("--output-format=")) {
                 outputFormat = arg.substring(16).toLowerCase();
-            } else if (arg.startsWith("--interval=")) {
-                String v = arg.substring(11);
-                String err = validateInterval(v, messages);
-                if (err != null) { System.err.println(err); return; }
-                optsBuilder.interval(v);
-            } else if (arg.startsWith("--jstackdepth=")) {
-                int depth = parseClampedInt(arg.substring(14), 1, 2048, 64);
-                optsBuilder.jstackdepth(depth);
-            } else if (arg.startsWith("--cstack=")) {
-                String v = arg.substring(9);
-                String err = validateCstack(v, messages);
-                if (err != null) { System.err.println(err); return; }
-                optsBuilder.cstack(v);
-            } else if (arg.equals("--threads")) {
-                optsBuilder.perThread(true);
-            } else if (arg.equals("--alluser")) {
-                optsBuilder.allUser(true);
-            } else if (arg.equals("--allkernel")) {
-                optsBuilder.allKernel(true);
-            } else if (arg.startsWith("--alloc=")) {
-                optsBuilder.allocBytes(arg.substring(8));
-            } else if (arg.equals("--live")) {
-                optsBuilder.live(true);
-            } else if (arg.startsWith("--include=")) {
-                optsBuilder.addInclude(arg.substring(10));
-            } else if (arg.startsWith("--exclude=")) {
-                optsBuilder.addExclude(arg.substring(10));
-            } else if (arg.equals("--reverse")) {
-                optsBuilder.reverse(true);
-            } else if (arg.startsWith("--minwidth=")) {
-                optsBuilder.minwidth(arg.substring("--minwidth=".length()));
-            } else if (arg.equals("--sched")) {
-                optsBuilder.sched(true);
-            } else if (arg.startsWith("--clock=")) {
-                String v = arg.substring("--clock=".length());
-                String err = validateClock(v, messages);
-                if (err != null) { System.err.println(err); return; }
-                optsBuilder.clock(v);
-            } else if (arg.startsWith("--signal=")) {
-                optsBuilder.signal(arg.substring("--signal=".length()));
-            } else if (arg.startsWith("--proc=")) {
-                String v = arg.substring("--proc=".length());
-                String err = validateInterval(v, messages);
-                if (err != null) { System.err.println(err); return; }
-                optsBuilder.procInterval(v);
-            } else if (arg.equals("--nofree")) {
-                optsBuilder.nofree(true);
-            } else if (arg.equals("--ttsp")) {
-                optsBuilder.ttsp(true);
-            } else if (arg.startsWith("--begin=")) {
-                String v = arg.substring("--begin=".length());
-                if (v.isEmpty()) { System.err.println(messages.get("error.profile.adv.begin.empty")); return; }
-                optsBuilder.beginFunction(v);
-            } else if (arg.startsWith("--end=")) {
-                String v = arg.substring("--end=".length());
-                if (v.isEmpty()) { System.err.println(messages.get("error.profile.adv.end.empty")); return; }
-                optsBuilder.endFunction(v);
+            } else {
+                AsprofFlagParser.Result r = AsprofFlagParser.handle(arg, optsBuilder, messages);
+                if (r == AsprofFlagParser.Result.ERROR) return;
+                // unrecognised args silently skipped (matches pre-extraction behaviour)
             }
         }
 
@@ -855,62 +802,10 @@ public final class ProfileCommand implements Command {
                 flame = true;
             } else if (arg.startsWith("--source=")) {
                 sourceOverride = arg.substring(9);
-            } else if (arg.startsWith("--interval=")) {
-                String v = arg.substring(11);
-                String err = validateInterval(v, messages);
-                if (err != null) { System.err.println(err); return; }
-                subOptsBuilder.interval(v);
-            } else if (arg.startsWith("--jstackdepth=")) {
-                subOptsBuilder.jstackdepth(parseClampedInt(arg.substring(14), 1, 2048, 64));
-            } else if (arg.startsWith("--cstack=")) {
-                String v = arg.substring(9);
-                String err = validateCstack(v, messages);
-                if (err != null) { System.err.println(err); return; }
-                subOptsBuilder.cstack(v);
-            } else if (arg.equals("--threads")) {
-                subOptsBuilder.perThread(true);
-            } else if (arg.equals("--alluser")) {
-                subOptsBuilder.allUser(true);
-            } else if (arg.equals("--allkernel")) {
-                subOptsBuilder.allKernel(true);
-            } else if (arg.startsWith("--alloc=")) {
-                subOptsBuilder.allocBytes(arg.substring(8));
-            } else if (arg.equals("--live")) {
-                subOptsBuilder.live(true);
-            } else if (arg.startsWith("--include=")) {
-                subOptsBuilder.addInclude(arg.substring(10));
-            } else if (arg.startsWith("--exclude=")) {
-                subOptsBuilder.addExclude(arg.substring(10));
-            } else if (arg.equals("--reverse")) {
-                subOptsBuilder.reverse(true);
-            } else if (arg.startsWith("--minwidth=")) {
-                subOptsBuilder.minwidth(arg.substring("--minwidth=".length()));
-            } else if (arg.equals("--sched")) {
-                subOptsBuilder.sched(true);
-            } else if (arg.startsWith("--clock=")) {
-                String v = arg.substring("--clock=".length());
-                String err = validateClock(v, messages);
-                if (err != null) { System.err.println(err); return; }
-                subOptsBuilder.clock(v);
-            } else if (arg.startsWith("--signal=")) {
-                subOptsBuilder.signal(arg.substring("--signal=".length()));
-            } else if (arg.startsWith("--proc=")) {
-                String v = arg.substring("--proc=".length());
-                String err = validateInterval(v, messages);
-                if (err != null) { System.err.println(err); return; }
-                subOptsBuilder.procInterval(v);
-            } else if (arg.equals("--nofree")) {
-                subOptsBuilder.nofree(true);
-            } else if (arg.equals("--ttsp")) {
-                subOptsBuilder.ttsp(true);
-            } else if (arg.startsWith("--begin=")) {
-                String v = arg.substring("--begin=".length());
-                if (v.isEmpty()) { System.err.println(messages.get("error.profile.adv.begin.empty")); return; }
-                subOptsBuilder.beginFunction(v);
-            } else if (arg.startsWith("--end=")) {
-                String v = arg.substring("--end=".length());
-                if (v.isEmpty()) { System.err.println(messages.get("error.profile.adv.end.empty")); return; }
-                subOptsBuilder.endFunction(v);
+            } else {
+                AsprofFlagParser.Result r = AsprofFlagParser.handle(arg, subOptsBuilder, messages);
+                if (r == AsprofFlagParser.Result.ERROR) return;
+                // unrecognised args silently skipped (matches pre-extraction behaviour)
             }
         }
 
@@ -1442,8 +1337,8 @@ public final class ProfileCommand implements Command {
         return type.matches("[a-zA-Z_$][a-zA-Z0-9_$.\\-]*");
     }
 
-    /** Returns null if valid, else an i18n error string. */
-    private static String validateInterval(String v, Messages messages) {
+    /** Returns null if valid, else an i18n error string. Package-private for {@link AsprofFlagParser}. */
+    static String validateInterval(String v, Messages messages) {
         if (v == null || v.isEmpty()) return messages.get("error.profile.adv.interval.invalid", v);
         if (!v.endsWith("ms") && !v.endsWith("us") && !v.endsWith("ns") && !v.endsWith("s")) {
             return messages.get("error.profile.adv.interval.invalid", v);
@@ -1459,23 +1354,24 @@ public final class ProfileCommand implements Command {
         return null;
     }
 
-    /** Returns null if valid, else an i18n error string. */
-    private static String validateCstack(String v, Messages messages) {
+    /** Returns null if valid, else an i18n error string. Package-private for {@link AsprofFlagParser}. */
+    static String validateCstack(String v, Messages messages) {
         if ("fp".equals(v) || "dwarf".equals(v) || "lbr".equals(v) || "vm".equals(v) || "no".equals(v)) {
             return null;
         }
         return messages.get("error.profile.adv.cstack.invalid", v);
     }
 
-    /** Returns null if valid, else an i18n error string. Accepts the asprof clock-source enum. */
-    private static String validateClock(String v, Messages messages) {
+    /** Returns null if valid, else an i18n error string. Package-private for {@link AsprofFlagParser}. */
+    static String validateClock(String v, Messages messages) {
         if ("tsc".equals(v) || "monotonic".equals(v)) {
             return null;
         }
         return messages.get("error.profile.adv.clock.invalid", v);
     }
 
-    private static int parseClampedInt(String s, int min, int max, int fallback) {
+    /** Package-private for {@link AsprofFlagParser}. */
+    static int parseClampedInt(String s, int min, int max, int fallback) {
         try {
             return Math.min(max, Math.max(min, Integer.parseInt(s)));
         } catch (NumberFormatException e) {


### PR DESCRIPTION
## Summary

Closes #179.

`ProfileCommand` carried **two identical ~50-line if/else chains** for asprof passthrough flag parsing — one for the one-shot path and one for the session subcommands (`profile start|stop|dump|status`). Every new asprof flag added in PRs #174 and #175 had to be replicated in both places, and the absence of that abstraction was the P1 finding of the #175 review.

This PR introduces `AsprofFlagParser` — a single source of truth keyed by `(arg, AsProfOptions.Builder, Messages) -> Result`. Both parsers replace their 19-flag if/else chain with a single `handle()` call. The non-asprof flags (`--type`, `--duration`, `--save`, `--diff`, `--source`, `--file`, `--top`, `--flame`, `--format=json`, `--output-format=`, `--output=`) stay parser-specific.

`validateInterval`, `validateCstack`, `parseClampedInt` were widened from `private` to package-private so the new helper can reuse them.

## Diff

| File | Change |
|---|---|
| `argus-cli/src/main/java/io/argus/cli/command/AsprofFlagParser.java` | +73 (new) |
| `argus-cli/src/main/java/io/argus/cli/command/ProfileCommand.java` | -107 / +12 net (parser blocks collapsed; validator visibility widened) |

## Test plan

- [x] `./gradlew :argus-cli:compileJava :argus-cli:test` — BUILD SUCCESSFUL.
- [x] Live smoke: `argus profile <pid> --cstack=bogus` still errors with the localized message via the helper.
- [x] Live smoke: `argus profile <pid> --begin=` still errors with the empty-value message via the helper.
- [x] Live smoke: `argus profile <pid> --duration=1 --type=cpu` still profiles normally (no asprof flag, helper returns NOT_HANDLED, falls through).
- [ ] CI green.

## Stacking

Touches the same files (`ProfileCommand.java`) as PR #176/#177/#178. Trivial merge conflicts expected; first to merge sets the anchor, subsequent rebases keep both blocks intact.