### PR TITLE
feat(profile): validate --clock=tsc|monotonic as a closed enum

### DIFF
--- a/argus-cli/src/main/java/io/argus/cli/command/ProfileCommand.java
+++ b/argus-cli/src/main/java/io/argus/cli/command/ProfileCommand.java
@@ -250,7 +250,10 @@ public final class ProfileCommand implements Command {
             } else if (arg.equals("--sched")) {
                 optsBuilder.sched(true);
             } else if (arg.startsWith("--clock=")) {
-                optsBuilder.clock(arg.substring("--clock=".length()));
+                String v = arg.substring("--clock=".length());
+                String err = validateClock(v, messages);
+                if (err != null) { System.err.println(err); return; }
+                optsBuilder.clock(v);
             } else if (arg.startsWith("--signal=")) {
                 optsBuilder.signal(arg.substring("--signal=".length()));
             } else if (arg.startsWith("--proc=")) {
@@ -873,7 +876,10 @@ public final class ProfileCommand implements Command {
             } else if (arg.equals("--sched")) {
                 subOptsBuilder.sched(true);
             } else if (arg.startsWith("--clock=")) {
-                subOptsBuilder.clock(arg.substring("--clock=".length()));
+                String v = arg.substring("--clock=".length());
+                String err = validateClock(v, messages);
+                if (err != null) { System.err.println(err); return; }
+                subOptsBuilder.clock(v);
             } else if (arg.startsWith("--signal=")) {
                 subOptsBuilder.signal(arg.substring("--signal=".length()));
             } else if (arg.startsWith("--proc=")) {
@@ -1435,6 +1441,14 @@ public final class ProfileCommand implements Command {
             return null;
         }
         return messages.get("error.profile.adv.cstack.invalid", v);
+    }
+
+    /** Returns null if valid, else an i18n error string. Accepts the asprof clock-source enum. */
+    private static String validateClock(String v, Messages messages) {
+        if ("tsc".equals(v) || "monotonic".equals(v)) {
+            return null;
+        }
+        return messages.get("error.profile.adv.clock.invalid", v);
     }
 
     private static int parseClampedInt(String s, int min, int max, int fallback) {

--- a/argus-cli/src/main/resources/messages_en.properties
+++ b/argus-cli/src/main/resources/messages_en.properties
@@ -404,6 +404,7 @@ cmd.profile.adv.begin.desc=Start profiling when FUNC is first executed (trigger-
 cmd.profile.adv.end.desc=Stop profiling when FUNC is executed (paired with --begin for entry/exit windowing)
 error.profile.adv.interval.invalid=Invalid --interval value '%s'. Use a positive integer with ms, us, or ns suffix (e.g. 1ms)
 error.profile.adv.cstack.invalid=Invalid --cstack value '%s'. Allowed: fp, dwarf, lbr, vm, no
+error.profile.adv.clock.invalid=Invalid --clock value '%s'. Allowed: tsc, monotonic
 error.profile.adv.alluser.allkernel.exclusive=--alluser and --allkernel are mutually exclusive
 error.profile.adv.begin.empty=--begin requires a function name, e.g. --begin=com.example.MyClass.handle
 error.profile.adv.end.empty=--end requires a function name, e.g. --end=com.example.MyClass.handle

--- a/argus-cli/src/main/resources/messages_ja.properties
+++ b/argus-cli/src/main/resources/messages_ja.properties
@@ -389,6 +389,7 @@ cmd.profile.adv.begin.desc=FUNC が初めて実行されたときにプロファ
 cmd.profile.adv.end.desc=FUNC が実行されたときにプロファイリング停止 (--begin と組み合わせて入出ウィンドウ捕捉)
 error.profile.adv.interval.invalid=--interval の値 '%s' が無効です。ms、us、ns サフィックスで正の整数を指定してください (例: 1ms)
 error.profile.adv.cstack.invalid=--cstack の値 '%s' が無効です。使用可能: fp, dwarf, lbr, vm, no
+error.profile.adv.clock.invalid=--clock の値 '%s' が無効です。使用可能: tsc, monotonic
 error.profile.adv.alluser.allkernel.exclusive=--alluserと--allkernelは同時に指定できません
 error.profile.adv.begin.empty=--begin には関数名が必要です。例: --begin=com.example.MyClass.handle
 error.profile.adv.end.empty=--end には関数名が必要です。例: --end=com.example.MyClass.handle

--- a/argus-cli/src/main/resources/messages_ko.properties
+++ b/argus-cli/src/main/resources/messages_ko.properties
@@ -389,6 +389,7 @@ cmd.profile.adv.begin.desc=FUNC가 처음 실행될 때 프로파일링 시작 (
 cmd.profile.adv.end.desc=FUNC가 실행될 때 프로파일링 중단 (--begin과 짝지어 진입/종료 구간 캡쳐)
 error.profile.adv.interval.invalid=잘못된 --interval 값 '%s'. ms, us, ns 접미사와 함께 양의 정수를 사용하세요 (예: 1ms)
 error.profile.adv.cstack.invalid=잘못된 --cstack 값 '%s'. 허용값: fp, dwarf, lbr, vm, no
+error.profile.adv.clock.invalid=잘못된 --clock 값 '%s'. 허용값: tsc, monotonic
 error.profile.adv.alluser.allkernel.exclusive=--alluser와 --allkernel은 상호 배타적입니다
 error.profile.adv.begin.empty=--begin에 함수 이름이 필요합니다. 예: --begin=com.example.MyClass.handle
 error.profile.adv.end.empty=--end에 함수 이름이 필요합니다. 예: --end=com.example.MyClass.handle

--- a/argus-cli/src/main/resources/messages_zh.properties
+++ b/argus-cli/src/main/resources/messages_zh.properties
@@ -390,6 +390,7 @@ cmd.profile.adv.begin.desc=当 FUNC 首次执行时开始采样 (基于触发的
 cmd.profile.adv.end.desc=当 FUNC 执行时停止采样 (与 --begin 配对以捕获入口/出口窗口)
 error.profile.adv.interval.invalid=--interval 值 '%s' 无效。请使用带 ms、us 或 ns 后缀的正整数 (例如 1ms)
 error.profile.adv.cstack.invalid=--cstack 值 '%s' 无效。允许值: fp, dwarf, lbr, vm, no
+error.profile.adv.clock.invalid=--clock 值 '%s' 无效。允许值: tsc, monotonic
 error.profile.adv.alluser.allkernel.exclusive=--alluser 和 --allkernel 互斥，不能同时使用
 error.profile.adv.begin.empty=--begin 需要函数名，例如: --begin=com.example.MyClass.handle
 error.profile.adv.end.empty=--end 需要函数名，例如: --end=com.example.MyClass.handle


### PR DESCRIPTION
## Summary

Closes #176.

`--clock=<source>` (added in PR #175) previously forwarded the value raw — invalid sources surfaced as cryptic asprof errors mid-run. This PR mirrors the existing `validateCstack` pattern: a small `validateClock` helper enforces the closed enum (`tsc`, `monotonic`) at parse time and emits a localized error.

Adds `error.profile.adv.clock.invalid` to en / ko / ja / zh in parity.

## Test plan

- [x] `./gradlew :argus-cli:compileJava :argus-cli:test` — BUILD SUCCESSFUL.
- [x] Live: `argus profile <pid> --clock=bogus --duration=1` → `Invalid --clock value 'bogus'. Allowed: tsc, monotonic` and exits before asprof is invoked.
- [x] Live: `argus profile <pid> --clock=monotonic --duration=1` → passes validation and reaches asprof normally.
- [x] Locale parity: `grep -c 'error.profile.adv.clock.invalid' messages_*.properties` → 1/1/1/1.
- [ ] CI green.

## Stacking

Touches `ProfileCommand.java` and the 4 locale files — same surface as PRs #177 / #178 / #179 / #180. Trivial merge conflicts expected; first to merge sets the anchor.