### PR TITLE
test(profile): add unit tests for AsProfOptions builder and buildExtraArgs

### DIFF
--- a/argus-cli/src/main/java/io/argus/cli/provider/jdk/AsProfProvider.java
+++ b/argus-cli/src/main/java/io/argus/cli/provider/jdk/AsProfProvider.java
@@ -438,7 +438,8 @@ public final class AsProfProvider implements ProfileProvider {
      * Appends extra asprof arguments derived from {@link AsProfOptions} to the command list.
      * Handles null opts gracefully (no-op).
      */
-    private static void buildExtraArgs(List<String> cmd, AsProfOptions opts) {
+    /** Package-private so {@link AsProfProviderArgvTest} can exercise the asprof argv production directly. */
+    static void buildExtraArgs(List<String> cmd, AsProfOptions opts) {
         if (opts == null) return;
         if (opts.interval != null)    { cmd.add("-i"); cmd.add(opts.interval); }
         if (opts.jstackdepth != null) { cmd.add("-j"); cmd.add(String.valueOf(opts.jstackdepth)); }

--- a/argus-cli/src/test/java/io/argus/cli/provider/jdk/AsProfOptionsTest.java
+++ b/argus-cli/src/test/java/io/argus/cli/provider/jdk/AsProfOptionsTest.java
@@ -1,0 +1,127 @@
+package io.argus.cli.provider.jdk;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class AsProfOptionsTest {
+
+    @Test
+    void defaults_areNoOverride() {
+        AsProfOptions o = AsProfOptions.defaults();
+        assertNull(o.interval);
+        assertNull(o.jstackdepth);
+        assertNull(o.cstack);
+        assertNull(o.allocBytes);
+        assertNull(o.outputFormat);
+        assertNull(o.minwidth);
+        assertNull(o.clock);
+        assertNull(o.signal);
+        assertNull(o.procInterval);
+        assertNull(o.beginFunction);
+        assertNull(o.endFunction);
+
+        assertFalse(o.perThread);
+        assertFalse(o.allUser);
+        assertFalse(o.allKernel);
+        assertFalse(o.live);
+        assertFalse(o.reverse);
+        assertFalse(o.sched);
+        assertFalse(o.nofree);
+        assertFalse(o.ttsp);
+
+        assertTrue(o.include.isEmpty());
+        assertTrue(o.exclude.isEmpty());
+    }
+
+    @Test
+    void builderSetters_landOnFields() {
+        AsProfOptions o = AsProfOptions.builder()
+                .interval("1ms")
+                .jstackdepth(64)
+                .cstack("dwarf")
+                .perThread(true)
+                .allUser(true)
+                .allocBytes("512k")
+                .live(true)
+                .outputFormat("jfr")
+                .reverse(true)
+                .minwidth("0.5")
+                .sched(true)
+                .clock("monotonic")
+                .signal("42")
+                .procInterval("30s")
+                .nofree(true)
+                .ttsp(true)
+                .beginFunction("com.example.MyClass.handle")
+                .endFunction("com.example.MyClass.done")
+                .build();
+
+        assertEquals("1ms", o.interval);
+        assertEquals(64, o.jstackdepth);
+        assertEquals("dwarf", o.cstack);
+        assertTrue(o.perThread);
+        assertTrue(o.allUser);
+        assertEquals("512k", o.allocBytes);
+        assertTrue(o.live);
+        assertEquals("jfr", o.outputFormat);
+        assertTrue(o.reverse);
+        assertEquals("0.5", o.minwidth);
+        assertTrue(o.sched);
+        assertEquals("monotonic", o.clock);
+        assertEquals("42", o.signal);
+        assertEquals("30s", o.procInterval);
+        assertTrue(o.nofree);
+        assertTrue(o.ttsp);
+        assertEquals("com.example.MyClass.handle", o.beginFunction);
+        assertEquals("com.example.MyClass.done", o.endFunction);
+    }
+
+    @Test
+    void allKernel_isMutuallyExclusiveFlagFromAllUser_butBothSettableViaBuilder() {
+        AsProfOptions o = AsProfOptions.builder().allKernel(true).build();
+        assertTrue(o.allKernel);
+        assertFalse(o.allUser);
+    }
+
+    @Test
+    void addInclude_accumulatesMultipleEntries() {
+        AsProfOptions o = AsProfOptions.builder()
+                .addInclude("com.example.*")
+                .addInclude("org.foo.*")
+                .build();
+        assertEquals(2, o.include.size());
+        assertEquals("com.example.*", o.include.get(0));
+        assertEquals("org.foo.*", o.include.get(1));
+    }
+
+    @Test
+    void addExclude_accumulatesMultipleEntries() {
+        AsProfOptions o = AsProfOptions.builder()
+                .addExclude("java.*")
+                .addExclude("jdk.*")
+                .addExclude("sun.*")
+                .build();
+        assertEquals(3, o.exclude.size());
+    }
+
+    @Test
+    void includeList_isUnmodifiable() {
+        AsProfOptions o = AsProfOptions.builder().addInclude("com.x.*").build();
+        assertThrows(UnsupportedOperationException.class, () -> o.include.add("late"));
+    }
+
+    @Test
+    void excludeList_isUnmodifiable() {
+        AsProfOptions o = AsProfOptions.builder().addExclude("java.*").build();
+        assertThrows(UnsupportedOperationException.class, () -> o.exclude.add("late"));
+    }
+
+    @Test
+    void builderSnapshot_isIndependentOfPostBuildBuilderMutation() {
+        AsProfOptions.Builder b = AsProfOptions.builder().interval("1ms");
+        AsProfOptions snapshot = b.build();
+        b.interval("999ms");
+        assertEquals("1ms", snapshot.interval);
+    }
+}

--- a/argus-cli/src/test/java/io/argus/cli/provider/jdk/AsProfProviderArgvTest.java
+++ b/argus-cli/src/test/java/io/argus/cli/provider/jdk/AsProfProviderArgvTest.java
@@ -1,0 +1,204 @@
+package io.argus.cli.provider.jdk;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class AsProfProviderArgvTest {
+
+    private static List<String> argv(AsProfOptions opts) {
+        List<String> cmd = new ArrayList<>();
+        AsProfProvider.buildExtraArgs(cmd, opts);
+        return cmd;
+    }
+
+    @Test
+    void nullOpts_emitsNothing() {
+        List<String> cmd = new ArrayList<>();
+        AsProfProvider.buildExtraArgs(cmd, null);
+        assertTrue(cmd.isEmpty());
+    }
+
+    @Test
+    void defaults_emitsNothing() {
+        assertTrue(argv(AsProfOptions.defaults()).isEmpty());
+    }
+
+    @Test
+    void interval_emitsShortFlagPair() {
+        assertEquals(Arrays.asList("-i", "1ms"),
+                argv(AsProfOptions.builder().interval("1ms").build()));
+    }
+
+    @Test
+    void jstackdepth_emitsShortFlagPair() {
+        assertEquals(Arrays.asList("-j", "64"),
+                argv(AsProfOptions.builder().jstackdepth(64).build()));
+    }
+
+    @Test
+    void cstack_emitsLongFlagPair() {
+        assertEquals(Arrays.asList("--cstack", "dwarf"),
+                argv(AsProfOptions.builder().cstack("dwarf").build()));
+    }
+
+    @Test
+    void perThread_emitsLoneShortFlag() {
+        assertEquals(List.of("-t"),
+                argv(AsProfOptions.builder().perThread(true).build()));
+    }
+
+    @Test
+    void allUser_emitsLoneLongFlag() {
+        assertEquals(List.of("--alluser"),
+                argv(AsProfOptions.builder().allUser(true).build()));
+    }
+
+    @Test
+    void allKernel_emitsLoneLongFlag() {
+        assertEquals(List.of("--allkernel"),
+                argv(AsProfOptions.builder().allKernel(true).build()));
+    }
+
+    @Test
+    void allocBytes_emitsLongFlagPair() {
+        assertEquals(Arrays.asList("--alloc", "512k"),
+                argv(AsProfOptions.builder().allocBytes("512k").build()));
+    }
+
+    @Test
+    void live_emitsLoneLongFlag() {
+        assertEquals(List.of("--live"),
+                argv(AsProfOptions.builder().live(true).build()));
+    }
+
+    @Test
+    void include_emitsRepeatedShortFlagPair() {
+        assertEquals(Arrays.asList("-I", "com.example.*", "-I", "org.foo.*"),
+                argv(AsProfOptions.builder()
+                        .addInclude("com.example.*")
+                        .addInclude("org.foo.*")
+                        .build()));
+    }
+
+    @Test
+    void exclude_emitsRepeatedShortFlagPair() {
+        assertEquals(Arrays.asList("-X", "java.*", "-X", "jdk.*"),
+                argv(AsProfOptions.builder()
+                        .addExclude("java.*")
+                        .addExclude("jdk.*")
+                        .build()));
+    }
+
+    @Test
+    void reverse_emitsLoneLongFlag() {
+        assertEquals(List.of("--reverse"),
+                argv(AsProfOptions.builder().reverse(true).build()));
+    }
+
+    @Test
+    void minwidth_emitsLongFlagPair() {
+        assertEquals(Arrays.asList("--minwidth", "0.5"),
+                argv(AsProfOptions.builder().minwidth("0.5").build()));
+    }
+
+    @Test
+    void sched_emitsLoneLongFlag() {
+        assertEquals(List.of("--sched"),
+                argv(AsProfOptions.builder().sched(true).build()));
+    }
+
+    @Test
+    void clock_emitsLongFlagPair() {
+        assertEquals(Arrays.asList("--clock", "monotonic"),
+                argv(AsProfOptions.builder().clock("monotonic").build()));
+    }
+
+    @Test
+    void signal_emitsLongFlagPair() {
+        assertEquals(Arrays.asList("--signal", "42"),
+                argv(AsProfOptions.builder().signal("42").build()));
+    }
+
+    @Test
+    void procInterval_emitsLongFlagPair() {
+        assertEquals(Arrays.asList("--proc", "30s"),
+                argv(AsProfOptions.builder().procInterval("30s").build()));
+    }
+
+    @Test
+    void nofree_emitsLoneLongFlag() {
+        assertEquals(List.of("--nofree"),
+                argv(AsProfOptions.builder().nofree(true).build()));
+    }
+
+    @Test
+    void ttsp_emitsLoneLongFlag() {
+        assertEquals(List.of("--ttsp"),
+                argv(AsProfOptions.builder().ttsp(true).build()));
+    }
+
+    @Test
+    void beginFunction_emitsLongFlagPair() {
+        assertEquals(Arrays.asList("--begin", "com.example.MyClass.handle"),
+                argv(AsProfOptions.builder().beginFunction("com.example.MyClass.handle").build()));
+    }
+
+    @Test
+    void endFunction_emitsLongFlagPair() {
+        assertEquals(Arrays.asList("--end", "com.example.MyClass.done"),
+                argv(AsProfOptions.builder().endFunction("com.example.MyClass.done").build()));
+    }
+
+    @Test
+    void allFlagsSet_emitsFullArgvInDeclarationOrder() {
+        AsProfOptions opts = AsProfOptions.builder()
+                .interval("1ms")
+                .jstackdepth(64)
+                .cstack("dwarf")
+                .perThread(true)
+                .allUser(true)
+                .allocBytes("512k")
+                .live(true)
+                .addInclude("com.example.*")
+                .addExclude("java.*")
+                .reverse(true)
+                .minwidth("0.5")
+                .sched(true)
+                .clock("monotonic")
+                .signal("42")
+                .procInterval("30s")
+                .nofree(true)
+                .ttsp(true)
+                .beginFunction("com.example.MyClass.handle")
+                .endFunction("com.example.MyClass.done")
+                .build();
+
+        List<String> expected = Arrays.asList(
+                "-i", "1ms",
+                "-j", "64",
+                "--cstack", "dwarf",
+                "-t",
+                "--alluser",
+                "--alloc", "512k",
+                "--live",
+                "-I", "com.example.*",
+                "-X", "java.*",
+                "--reverse",
+                "--minwidth", "0.5",
+                "--sched",
+                "--clock", "monotonic",
+                "--signal", "42",
+                "--proc", "30s",
+                "--nofree",
+                "--ttsp",
+                "--begin", "com.example.MyClass.handle",
+                "--end", "com.example.MyClass.done");
+
+        assertEquals(expected, argv(opts));
+    }
+}


### PR DESCRIPTION
## Summary

Closes #180.

`AsProfOptions` and `AsProfProvider.buildExtraArgs` had **zero unit tests** despite carrying the parsing of 19 asprof passthrough flags. Any silent regression in argv key emission would have shipped — there was no test to catch it.

This PR adds two test classes under `argus-cli/src/test/java/io/argus/cli/provider/jdk/`:

### `AsProfOptionsTest`
- `defaults()` returns the no-override instance (all booleans false, all reference fields null, lists empty).
- Each Builder setter lands on the corresponding `AsProfOptions` field.
- `addInclude` / `addExclude` accumulate multiple entries in order.
- `include` and `exclude` lists are unmodifiable (`UnsupportedOperationException` on `add`).
- Post-build snapshot is independent of subsequent Builder mutation.

### `AsProfProviderArgvTest`
- Null opts and default opts emit nothing.
- Each of the 19 asprof flags emits its exact argv form in isolation (`-i`, `-j`, `--cstack`, `-t`, `--alluser`, `--allkernel`, `--alloc`, `--live`, `-I`, `-X`, `--reverse`, `--minwidth`, `--sched`, `--clock`, `--signal`, `--proc`, `--nofree`, `--ttsp`, `--begin`, `--end`).
- All-flags-set case asserts the full argv in declaration order — locks the emission sequence against accidental reordering.

To enable the argv test, `AsProfProvider.buildExtraArgs` was widened from `private` to package-private. Both the source change and a Javadoc note for the package-private visibility ship in this PR.

## Test plan

- [x] `./gradlew :argus-cli:test --tests AsProfOptionsTest --tests AsProfProviderArgvTest` — passes.
- [x] `./gradlew :argus-cli:test` (full suite) — passes.
- [x] No production code behavior changed beyond the one visibility widening.