### PR TITLE
feat(doctor): close CodeCache + DirectBuffer detection gaps on JDK 16+

### DIFF
--- a/argus-cli/src/main/java/io/argus/cli/doctor/DoctorEngine.java
+++ b/argus-cli/src/main/java/io/argus/cli/doctor/DoctorEngine.java
@@ -23,6 +23,7 @@ public final class DoctorEngine {
             new HeapPressureRule(),
             new MetaspaceRule(),
             new DirectBufferRule(),
+            new CodeCacheRule(),
             new CpuUsageRule(),
             new ThreadContentionRule(),
             new FinalizerQueueRule(),

--- a/argus-cli/src/main/java/io/argus/cli/doctor/JvmSnapshot.java
+++ b/argus-cli/src/main/java/io/argus/cli/doctor/JvmSnapshot.java
@@ -58,6 +58,15 @@ public final class JvmSnapshot {
     // GC pause — populated from MXBean on local path; heuristic on remote path; 0 if unknown.
     private final long maxRecentPauseMs;
 
+    // CodeCache — populated from CompilerProvider; 0 if collection failed.
+    private final long codeCacheUsedKb;
+    private final long codeCacheSizeKb;
+
+    // NMT — committedKB per category from jcmd VM.native_memory summary; empty if NMT off
+    // or jcmd call failed. Category names are passed through from jcmd verbatim (e.g.
+    // "Other", "Internal", "Java Heap") so callers must match case-insensitively.
+    private final Map<String, Long> nmtCommittedKbByCategory;
+
     public JvmSnapshot(long heapUsed, long heapMax, long heapCommitted, long nonHeapUsed,
                        Map<String, PoolInfo> memoryPools,
                        List<GcInfo> collectors, long totalGcCount, long totalGcTimeMs, long uptimeMs,
@@ -88,6 +97,29 @@ public final class JvmSnapshot {
                        int pendingFinalization,
                        String vmName, String vmVersion, String gcAlgorithm, List<String> vmFlags,
                        long maxRecentPauseMs) {
+        this(heapUsed, heapMax, heapCommitted, nonHeapUsed, memoryPools,
+                collectors, totalGcCount, totalGcTimeMs, uptimeMs,
+                processCpuLoad, systemCpuLoad, availableProcessors,
+                threadCount, daemonThreadCount, peakThreadCount,
+                threadStates, deadlockedThreads, bufferPools,
+                loadedClassCount, totalLoadedClassCount, unloadedClassCount,
+                pendingFinalization, vmName, vmVersion, gcAlgorithm, vmFlags,
+                maxRecentPauseMs, 0L, 0L, Map.of());
+    }
+
+    public JvmSnapshot(long heapUsed, long heapMax, long heapCommitted, long nonHeapUsed,
+                       Map<String, PoolInfo> memoryPools,
+                       List<GcInfo> collectors, long totalGcCount, long totalGcTimeMs, long uptimeMs,
+                       double processCpuLoad, double systemCpuLoad, int availableProcessors,
+                       int threadCount, int daemonThreadCount, int peakThreadCount,
+                       Map<String, Integer> threadStates, int deadlockedThreads,
+                       List<BufferInfo> bufferPools,
+                       int loadedClassCount, long totalLoadedClassCount, long unloadedClassCount,
+                       int pendingFinalization,
+                       String vmName, String vmVersion, String gcAlgorithm, List<String> vmFlags,
+                       long maxRecentPauseMs,
+                       long codeCacheUsedKb, long codeCacheSizeKb,
+                       Map<String, Long> nmtCommittedKbByCategory) {
         this.heapUsed = heapUsed;
         this.heapMax = heapMax;
         this.heapCommitted = heapCommitted;
@@ -115,6 +147,9 @@ public final class JvmSnapshot {
         this.gcAlgorithm = gcAlgorithm;
         this.vmFlags = vmFlags;
         this.maxRecentPauseMs = maxRecentPauseMs;
+        this.codeCacheUsedKb = codeCacheUsedKb;
+        this.codeCacheSizeKb = codeCacheSizeKb;
+        this.nmtCommittedKbByCategory = nmtCommittedKbByCategory;
     }
 
     // Accessors
@@ -151,6 +186,12 @@ public final class JvmSnapshot {
     public List<String> vmFlags() { return vmFlags; }
     /** Most recent STW pause in ms. 0 means unknown (remote path or no GC yet). */
     public long maxRecentPauseMs() { return maxRecentPauseMs; }
+    /** Code cache used in KB. 0 means unknown (collector failed). */
+    public long codeCacheUsedKb() { return codeCacheUsedKb; }
+    /** Code cache total size in KB. 0 means unknown (collector failed). */
+    public long codeCacheSizeKb() { return codeCacheSizeKb; }
+    /** NMT committed KB per category (verbatim jcmd names). Empty when NMT is off or unreadable. */
+    public Map<String, Long> nmtCommittedKbByCategory() { return nmtCommittedKbByCategory; }
 
     public static final class PoolInfo {
         private final String name;

--- a/argus-cli/src/main/java/io/argus/cli/doctor/JvmSnapshotCollector.java
+++ b/argus-cli/src/main/java/io/argus/cli/doctor/JvmSnapshotCollector.java
@@ -1,8 +1,12 @@
 package io.argus.cli.doctor;
 
+import io.argus.cli.model.CompilerResult;
 import io.argus.cli.model.GcUtilResult;
+import io.argus.cli.model.NmtResult;
 import io.argus.cli.provider.jdk.JcmdExecutor;
+import io.argus.cli.provider.jdk.JdkCompilerProvider;
 import io.argus.cli.provider.jdk.JdkGcUtilProvider;
+import io.argus.cli.provider.jdk.JdkNmtProvider;
 
 import java.lang.management.*;
 import java.util.*;
@@ -98,6 +102,10 @@ public final class JvmSnapshotCollector {
                     buf.getName(), buf.getCount(), buf.getTotalCapacity(), buf.getMemoryUsed()));
         }
 
+        long pid = rt.getPid();
+        CodeCacheSnapshot cc = collectCodeCache(pid);
+        Map<String, Long> nmt = collectNmtCommittedKb(pid);
+
         return new JvmSnapshot(
                 heap.getUsed(), heap.getMax(), heap.getCommitted(),
                 mem.getNonHeapMemoryUsage().getUsed(),
@@ -111,7 +119,8 @@ public final class JvmSnapshotCollector {
                 mem.getObjectPendingFinalizationCount(),
                 rt.getVmName(), rt.getVmVersion(), gcAlgorithm,
                 List.copyOf(rt.getInputArguments()),
-                maxRecentPauseMs
+                maxRecentPauseMs,
+                cc.usedKb, cc.sizeKb, nmt
         );
     }
 
@@ -282,6 +291,9 @@ public final class JvmSnapshotCollector {
             }
         }
 
+        CodeCacheSnapshot cc = collectCodeCache(pid);
+        Map<String, Long> nmt = collectNmtCommittedKb(pid);
+
         return new JvmSnapshot(
                 heapUsed, heapMax, heapCommitted, nonHeapUsed,
                 Map.copyOf(pools),
@@ -293,8 +305,48 @@ public final class JvmSnapshotCollector {
                 0, 0, 0, 0,
                 vmName, vmVersion, gcAlgorithm,
                 List.copyOf(vmFlags),
-                maxRecentPauseMs
+                maxRecentPauseMs,
+                cc.usedKb, cc.sizeKb, nmt
         );
+    }
+
+    /** Best-effort code-cache totals; returns zeros on failure (doctor degrades gracefully). */
+    private static CodeCacheSnapshot collectCodeCache(long pid) {
+        try {
+            CompilerResult r = new JdkCompilerProvider().getCompilerInfo(pid);
+            return new CodeCacheSnapshot(r.codeCacheUsedKb(), r.codeCacheSizeKb());
+        } catch (RuntimeException e) {
+            warnings.get().add("Compiler.codecache failed: " + e.getMessage());
+            return new CodeCacheSnapshot(0L, 0L);
+        }
+    }
+
+    /**
+     * Best-effort NMT committed-KB per category. Returns empty map if NMT is not enabled
+     * or the call fails — rules that consume this must treat empty as "no signal".
+     */
+    private static Map<String, Long> collectNmtCommittedKb(long pid) {
+        try {
+            NmtResult r = new JdkNmtProvider().getNativeMemory(pid);
+            if (r.isNmtNotEnabled() || r.categories().isEmpty()) return Map.of();
+            Map<String, Long> out = new LinkedHashMap<>();
+            for (NmtResult.NmtCategory c : r.categories()) {
+                out.put(c.name(), c.committedKB());
+            }
+            return Map.copyOf(out);
+        } catch (RuntimeException e) {
+            warnings.get().add("VM.native_memory summary failed: " + e.getMessage());
+            return Map.of();
+        }
+    }
+
+    private static final class CodeCacheSnapshot {
+        final long usedKb;
+        final long sizeKb;
+        CodeCacheSnapshot(long usedKb, long sizeKb) {
+            this.usedKb = usedKb;
+            this.sizeKb = sizeKb;
+        }
     }
 
     /**

--- a/argus-cli/src/main/java/io/argus/cli/doctor/rules/CodeCacheRule.java
+++ b/argus-cli/src/main/java/io/argus/cli/doctor/rules/CodeCacheRule.java
@@ -1,0 +1,48 @@
+package io.argus.cli.doctor.rules;
+
+import io.argus.cli.doctor.*;
+
+import java.util.List;
+
+/**
+ * Detects JIT code-cache pressure. When the cache approaches its reserved
+ * size, HotSpot starts deoptimizing nmethods to free room, which manifests
+ * as sudden CPU spikes and lost throughput. Without this rule the symptom
+ * is easy to misdiagnose as application-level CPU contention.
+ */
+public final class CodeCacheRule implements HealthRule {
+
+    static final int WARN_PERCENT = 80;
+    static final int CRITICAL_PERCENT = 95;
+
+    @Override
+    public List<Finding> evaluate(JvmSnapshot s) {
+        long sizeKb = s.codeCacheSizeKb();
+        long usedKb = s.codeCacheUsedKb();
+        if (sizeKb <= 0) return List.of();
+
+        double pct = (double) usedKb / sizeKb * 100;
+        if (pct < WARN_PERCENT) return List.of();
+
+        Severity sev = pct >= CRITICAL_PERCENT ? Severity.CRITICAL : Severity.WARNING;
+        long suggestedMb = Math.max(sizeKb / 1024 * 2, 256);
+
+        var b = Finding.builder(sev, "Memory",
+                        String.format("CodeCache pressure: %.0f%% used (%dMB / %dMB)",
+                                pct, usedKb / 1024, sizeKb / 1024))
+                .detail("Code cache near exhaustion causes HotSpot to deoptimize compiled "
+                        + "methods, producing CPU spikes that look like application hot loops. "
+                        + "Increase the reserved size; ensure flushing is on so the JVM can "
+                        + "evict cold nmethods.")
+                .recommend("Run: argus compiler <pid> to track used / max / free over time")
+                .flag("-XX:ReservedCodeCacheSize=" + suggestedMb + "m");
+
+        boolean flushingDisabled = s.vmFlags().stream()
+                .anyMatch(f -> f.contains("-UseCodeCacheFlushing"));
+        if (flushingDisabled) {
+            b.flag("-XX:+UseCodeCacheFlushing");
+        }
+
+        return List.of(b.build());
+    }
+}

--- a/argus-cli/src/main/java/io/argus/cli/doctor/rules/DirectBufferRule.java
+++ b/argus-cli/src/main/java/io/argus/cli/doctor/rules/DirectBufferRule.java
@@ -3,12 +3,23 @@ package io.argus.cli.doctor.rules;
 import io.argus.cli.doctor.*;
 
 import java.util.List;
+import java.util.Map;
 
 /**
  * Detects NIO direct buffer pressure — common in Netty/NIO applications.
  * Direct buffers are allocated outside the heap and not tracked by GC.
+ *
+ * <p>Prefers JVM-reported buffer pools when present. On JDK 16+ the jcmd
+ * remote path cannot read buffer pools, so we fall back to NMT category
+ * totals (DirectByteBuffer allocations land under {@code Other} on JDK 17
+ * and {@code Other} or {@code Internal} on JDK 21+). The NMT fallback is
+ * coarser — it includes any unattributed native memory, not strictly
+ * NIO direct buffers — so the finding text says "via NMT" for honesty.
  */
 public final class DirectBufferRule implements HealthRule {
+
+    private static final long ABS_THRESHOLD_MB = 200;
+    private static final double HEAP_RATIO_PCT = 50.0;
 
     @Override
     public List<Finding> evaluate(JvmSnapshot s) {
@@ -16,23 +27,45 @@ public final class DirectBufferRule implements HealthRule {
             if (!buf.name().toLowerCase().contains("direct")) continue;
             if (buf.capacity() <= 0) continue;
 
-            // Check relative to heap (>50% of heap is concerning) and absolute (>200MB minimum)
             long mb = buf.used() / (1024 * 1024);
-            long heapMB = s.heapMax() > 0 ? s.heapMax() / (1024 * 1024) : 1;
-            double ratioToHeap = (double) mb / heapMB * 100;
-            if (mb < 200 && ratioToHeap < 50) return List.of();
-
-            Severity sev = (mb >= 800 || ratioToHeap >= 100) ? Severity.CRITICAL : Severity.WARNING;
-            return List.of(Finding.builder(sev, "Memory",
-                            String.format("Direct buffer pool: %dMB used (%d buffers)",
-                                    mb, buf.count()))
-                    .detail("Large direct buffer usage indicates potential buffer leaks in NIO/Netty. "
-                            + "Direct buffers are allocated outside the Java heap and not collected by GC.")
-                    .recommend("Run: argus buffers <pid> for detailed buffer pool breakdown")
-                    .recommend("Check for Netty ByteBuf leaks — enable -Dio.netty.leakDetection.level=paranoid")
-                    .flag("-XX:MaxDirectMemorySize=" + Math.max(mb * 2, 1024) + "m")
-                    .build());
+            Finding f = build(mb, buf.count(), s.heapMax(), false);
+            if (f != null) return List.of(f);
+            return List.of();
         }
-        return List.of();
+
+        // Fallback: bufferPools empty (JDK 16+ jcmd path). Read NMT instead.
+        long maxCategoryMb = 0;
+        for (Map.Entry<String, Long> e : s.nmtCommittedKbByCategory().entrySet()) {
+            String name = e.getKey().toLowerCase();
+            if (name.contains("other") || name.contains("internal")) {
+                maxCategoryMb = Math.max(maxCategoryMb, e.getValue() / 1024);
+            }
+        }
+        if (maxCategoryMb == 0) return List.of();
+        Finding f = build(maxCategoryMb, -1, s.heapMax(), true);
+        return f == null ? List.of() : List.of(f);
+    }
+
+    private static Finding build(long mb, long bufferCount, long heapMax, boolean viaNmt) {
+        long heapMB = heapMax > 0 ? heapMax / (1024 * 1024) : 1;
+        double ratioToHeap = (double) mb / heapMB * 100;
+        if (mb < ABS_THRESHOLD_MB && ratioToHeap < HEAP_RATIO_PCT) return null;
+
+        Severity sev = (mb >= 800 || ratioToHeap >= 100) ? Severity.CRITICAL : Severity.WARNING;
+        String title = bufferCount >= 0
+                ? String.format("Direct buffer pool: %dMB used (%d buffers)", mb, bufferCount)
+                : String.format("Native off-heap memory: %dMB committed (via NMT)", mb);
+        String detail = viaNmt
+                ? "JDK 16+ jcmd cannot read BufferPoolMXBean, so this is derived from NMT "
+                  + "categories (Other / Internal) where DirectByteBuffer allocations land. "
+                  + "It is an upper bound — non-NIO native allocations are included."
+                : "Large direct buffer usage indicates potential buffer leaks in NIO/Netty. "
+                  + "Direct buffers are allocated outside the Java heap and not collected by GC.";
+        return Finding.builder(sev, "Memory", title)
+                .detail(detail)
+                .recommend("Run: argus nmt <pid> --save / --diff to track growth over time")
+                .recommend("Check for Netty ByteBuf leaks — enable -Dio.netty.leakDetection.level=paranoid")
+                .flag("-XX:MaxDirectMemorySize=" + Math.max(mb * 2, 1024) + "m")
+                .build();
     }
 }

--- a/argus-cli/src/test/java/io/argus/cli/doctor/rules/CodeCacheRuleTest.java
+++ b/argus-cli/src/test/java/io/argus/cli/doctor/rules/CodeCacheRuleTest.java
@@ -1,0 +1,84 @@
+package io.argus.cli.doctor.rules;
+
+import io.argus.cli.doctor.Finding;
+import io.argus.cli.doctor.JvmSnapshot;
+import io.argus.cli.doctor.Severity;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class CodeCacheRuleTest {
+
+    private static final long MB = 1024L * 1024L;
+
+    @Test
+    void unknownCodeCacheSize_noFinding() {
+        assertTrue(new CodeCacheRule().evaluate(snapshot(0L, 0L, List.of())).isEmpty());
+    }
+
+    @Test
+    void halfFull_noFinding() {
+        assertTrue(new CodeCacheRule().evaluate(snapshot(120L * 1024, 240L * 1024, List.of())).isEmpty());
+    }
+
+    @Test
+    void atWarnThreshold_emitsWarning() {
+        List<Finding> findings = new CodeCacheRule()
+                .evaluate(snapshot(80L * 1024, 100L * 1024, List.of()));
+        assertEquals(1, findings.size());
+        assertEquals(Severity.WARNING, findings.get(0).severity());
+        assertTrue(findings.get(0).title().contains("CodeCache pressure"));
+    }
+
+    @Test
+    void atCriticalThreshold_emitsCritical() {
+        List<Finding> findings = new CodeCacheRule()
+                .evaluate(snapshot(96L * 1024, 100L * 1024, List.of()));
+        assertEquals(1, findings.size());
+        assertEquals(Severity.CRITICAL, findings.get(0).severity());
+    }
+
+    @Test
+    void recommendsDoublingReservedSize() {
+        Finding f = new CodeCacheRule()
+                .evaluate(snapshot(80L * 1024, 100L * 1024, List.of())).get(0);
+        assertTrue(f.suggestedFlags().stream().anyMatch(fl -> fl.equals("-XX:ReservedCodeCacheSize=256m")),
+                "Should suggest doubling current size (100MB -> 200MB), clamped to 256m floor; got: " + f.suggestedFlags());
+    }
+
+    @Test
+    void suggestsFlushingOnlyWhenDisabled() {
+        Finding withoutDisabledFlag = new CodeCacheRule()
+                .evaluate(snapshot(80L * 1024, 100L * 1024, List.of())).get(0);
+        assertFalse(withoutDisabledFlag.suggestedFlags().stream()
+                        .anyMatch(fl -> fl.contains("UseCodeCacheFlushing")),
+                "Should not nag about flushing when user hasn't disabled it");
+
+        Finding withDisabledFlag = new CodeCacheRule()
+                .evaluate(snapshot(80L * 1024, 100L * 1024, List.of("-XX:-UseCodeCacheFlushing"))).get(0);
+        assertTrue(withDisabledFlag.suggestedFlags().stream()
+                        .anyMatch(fl -> fl.equals("-XX:+UseCodeCacheFlushing")),
+                "Should recommend re-enabling flushing when user has disabled it");
+    }
+
+    private static JvmSnapshot snapshot(long codeCacheUsedKb, long codeCacheSizeKb, List<String> vmFlags) {
+        return new JvmSnapshot(
+                100 * MB, 512 * MB, 512 * MB, 0,
+                Map.of(), List.of(),
+                1L, 100L, 120_000L,
+                0.1, 0.2, 4,
+                10, 5, 10,
+                Map.of("RUNNABLE", 10), 0,
+                List.of(),
+                1000, 1000, 0,
+                0,
+                "OpenJDK 64-Bit Server VM", "21.0.1", "G1",
+                vmFlags,
+                0L,
+                codeCacheUsedKb, codeCacheSizeKb, Map.of()
+        );
+    }
+}

--- a/argus-cli/src/test/java/io/argus/cli/doctor/rules/DirectBufferRuleTest.java
+++ b/argus-cli/src/test/java/io/argus/cli/doctor/rules/DirectBufferRuleTest.java
@@ -1,0 +1,114 @@
+package io.argus.cli.doctor.rules;
+
+import io.argus.cli.doctor.Finding;
+import io.argus.cli.doctor.JvmSnapshot;
+import io.argus.cli.doctor.Severity;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class DirectBufferRuleTest {
+
+    private static final long MB = 1024L * 1024L;
+
+    @Test
+    void emptyBufferPools_noNmt_noFinding() {
+        assertTrue(new DirectBufferRule().evaluate(snapshot(List.of(), Map.of())).isEmpty());
+    }
+
+    @Test
+    void smallDirectPool_noFinding() {
+        JvmSnapshot s = snapshot(
+                List.of(new JvmSnapshot.BufferInfo("direct", 100, 50 * MB, 50 * MB)),
+                Map.of());
+        assertTrue(new DirectBufferRule().evaluate(s).isEmpty());
+    }
+
+    @Test
+    void largeDirectPool_emitsWarning() {
+        JvmSnapshot s = snapshot(
+                List.of(new JvmSnapshot.BufferInfo("direct", 100, 400 * MB, 400 * MB)),
+                Map.of());
+        List<Finding> findings = new DirectBufferRule().evaluate(s);
+        assertEquals(1, findings.size());
+        assertEquals(Severity.WARNING, findings.get(0).severity());
+        assertTrue(findings.get(0).title().contains("400MB"));
+    }
+
+    @Test
+    void hugeDirectPool_emitsCritical() {
+        JvmSnapshot s = snapshot(
+                List.of(new JvmSnapshot.BufferInfo("direct", 100, 900 * MB, 900 * MB)),
+                Map.of());
+        Finding f = new DirectBufferRule().evaluate(s).get(0);
+        assertEquals(Severity.CRITICAL, f.severity());
+    }
+
+    // --- NMT fallback (JDK 16+ jcmd path) ---
+
+    @Test
+    void nmtFallback_otherCategory_emitsWarning() {
+        // 400 MiB committed under "Other" — typical for DirectByteBuffer on JDK 17
+        JvmSnapshot s = snapshot(List.of(), Map.of("Other", 400L * 1024));
+        List<Finding> findings = new DirectBufferRule().evaluate(s);
+        assertEquals(1, findings.size());
+        Finding f = findings.get(0);
+        assertEquals(Severity.WARNING, f.severity());
+        assertTrue(f.title().contains("via NMT"),
+                "NMT-derived finding should label itself: " + f.title());
+        assertTrue(f.detail().toLowerCase().contains("nmt"));
+    }
+
+    @Test
+    void nmtFallback_internalCategory_emitsCritical() {
+        JvmSnapshot s = snapshot(List.of(), Map.of("Internal", 900L * 1024));
+        Finding f = new DirectBufferRule().evaluate(s).get(0);
+        assertEquals(Severity.CRITICAL, f.severity());
+    }
+
+    @Test
+    void nmtFallback_smallCategory_noFinding() {
+        JvmSnapshot s = snapshot(List.of(), Map.of("Other", 50L * 1024));
+        assertTrue(new DirectBufferRule().evaluate(s).isEmpty());
+    }
+
+    @Test
+    void nmtFallback_ignoresUnrelatedCategories() {
+        JvmSnapshot s = snapshot(List.of(),
+                Map.of("Java Heap", 800L * 1024, "Thread", 500L * 1024));
+        assertTrue(new DirectBufferRule().evaluate(s).isEmpty(),
+                "Java Heap / Thread are not direct-buffer territory");
+    }
+
+    @Test
+    void bufferPoolsTakePrecedenceOverNmt() {
+        // Both present but bufferPools small → no finding (NMT path not consulted)
+        JvmSnapshot s = snapshot(
+                List.of(new JvmSnapshot.BufferInfo("direct", 10, 10 * MB, 10 * MB)),
+                Map.of("Other", 900L * 1024));
+        assertTrue(new DirectBufferRule().evaluate(s).isEmpty(),
+                "Reported pool dominates; fallback should not double-flag");
+    }
+
+    private static JvmSnapshot snapshot(List<JvmSnapshot.BufferInfo> bufferPools,
+                                        Map<String, Long> nmtCommittedKbByCategory) {
+        return new JvmSnapshot(
+                100 * MB, 512 * MB, 512 * MB, 0,
+                Map.of(), List.of(),
+                1L, 100L, 120_000L,
+                0.1, 0.2, 4,
+                10, 5, 10,
+                Map.of("RUNNABLE", 10), 0,
+                bufferPools,
+                1000, 1000, 0,
+                0,
+                "OpenJDK 64-Bit Server VM", "21.0.1", "G1",
+                List.of(),
+                0L,
+                0L, 0L, nmtCommittedKbByCategory
+        );
+    }
+}


### PR DESCRIPTION
## Summary

A live `/verify` pass surfaced two cases where `argus doctor` printed "✔ All checks passed" while the JVM was unhealthy:

- **CodeCache pressure** is never flagged. With `-XX:ReservedCodeCacheSize=10m -XX:-UseCodeCacheFlushing`, code cache fills to 99.8% ("Compiler has been disabled" in JVM stderr) and doctor stays silent.
- **`DirectBufferRule`** iterates `JvmSnapshot.bufferPools()` — but on JDK 16+ the jcmd path returns empty (`argus buffers <pid>` already says "JDK 16 이상에서는 jcmd를 통해 버퍼 풀 정보를 가져올 수 없습니다"). A 400 MiB DirectByteBuffer leak that NMT shows as `Other 400M committed (100%)` slips past doctor entirely.

This PR:
- Plumbs code-cache totals + NMT category committed-KB into `JvmSnapshot` via the existing `JdkCompilerProvider` / `JdkNmtProvider`.
- Adds `CodeCacheRule`: WARNING ≥80%, CRITICAL ≥95%. Suggests doubling `-XX:ReservedCodeCacheSize` (256m floor) and `+UseCodeCacheFlushing` only when the user has disabled it.
- Extends `DirectBufferRule` to consult NMT `Other` / `Internal` categories when `bufferPools()` is empty. Finding text labels itself "via NMT" — it's an upper bound, since non-NIO native allocations share those categories.

`JvmSnapshot`'s existing two constructors are preserved by delegating to a new 30-param canonical, so no test fixtures need positional updates.

## Live verification

```
$ argus doctor 61780    # CodeCacheBurn2: -XX:ReservedCodeCacheSize=10m -XX:-UseCodeCacheFlushing
🟡 WARNING: CodeCache pressure: 94% used (9MB / 10MB)
   Suggested:  -XX:ReservedCodeCacheSize=256m
               -XX:+UseCodeCacheFlushing

$ argus doctor 61966    # DirectLeak: 200 × 2 MiB DirectByteBuffer, -XX:NativeMemoryTracking=summary
🔴 CRITICAL: Native off-heap memory: 400MB committed (via NMT)
   Suggested:  -XX:MaxDirectMemorySize=1024m
```

## Test plan

- [x] 13 new unit tests across `CodeCacheRuleTest` + `DirectBufferRuleTest`
- [x] `./gradlew :argus-cli:test` — green
- [x] `./gradlew :argus-cli:fatJar` — builds clean
- [x] Live doctor run against `CodeCacheBurn2` reproducer → CodeCacheRule fires
- [x] Live doctor run against `DirectLeak` reproducer on JDK 17 (no agent) → DirectBufferRule fires via NMT path
- [x] Existing `MaxPauseRuleTest`, `ZgcCycleOverlapRuleTest`, `ZgcSoftMaxBreachRuleTest`, `HarnessSessionTest`, `HeapGrowthLeakRuleTest`, `CompareCommandTest`, `DoctorEngineTest` unchanged and still green (positional constructors back-compat preserved)