### PR TITLE
chore(ci): pin graalvm/setup-graalvm to 1.4.x via Dependabot ignore

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,10 @@ updates:
       prefix: "chore(ci)"
     labels:
       - "dependencies"
+    # graalvm/setup-graalvm@1.5.x removed the `distribution: graalvm-community`
+    # input that native-image.yml depends on. The 1.4.x line is the last
+    # version compatible with our workflow. Re-enable only when native-image.yml
+    # has been migrated to the new input shape and tested end-to-end on a tag.
+    ignore:
+      - dependency-name: "graalvm/setup-graalvm"
+        update-types: ["version-update:semver-major", "version-update:semver-minor"]


### PR DESCRIPTION
## Summary

Stops Dependabot from re-proposing `graalvm/setup-graalvm@1.5.x` bumps that break `native-image.yml`.

`graalvm/setup-graalvm@1.5.0` removed the `distribution: graalvm-community` input the workflow depends on. PR #173 pinned to `1.4.5` to fix the v1.3.0 regression where an earlier auto-bump to `1.5.3` had silently broken native-image builds. Today's #195 was the same bump trying to come back through.

Ignores `version-update:semver-major` and `version-update:semver-minor` for this action only. Patch bumps within `1.4.x` stay eligible.

Re-enable only after `native-image.yml` is migrated to the new input shape and verified end-to-end against a real tag push.

## Test plan

- [x] `.github/dependabot.yml` parses (YAML lint clean — config is the only change)
- [x] Ignore rule scope is action-specific; no other Dependabot updates affected
- [x] #195 closed with explanation linking back to this PR