### PR TITLE
chore(release): cut v1.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,25 @@ All notable changes to Argus are documented here. Format follows [Keep a Changel
 
 ## [Unreleased]
 
+## [1.4.0] - 2026-05-13
+
 ### Added
 - `argus harness <pid>` — continuous JVM monitoring + optimization + troubleshooting. Samples on a fixed interval, runs the existing 12 doctor health rules plus four new trend rules (heap-leak regression, GC overhead trend, thread growth, GC pause regression) and produces a single severity-ranked session report with JVM-flag suggestions. Observation-only — no JVM mutation. Supports `--profile=quick|deep`, `--interval=<dur>`, `--duration=<dur>`, `--out=<file>`, and `--format=json`. Dedupes findings by category+title across the session and reports per-rule hit counts so a leak rule that fires 600 times shows up once with "(fired 600 ticks)".
 - `.claude-plugin/marketplace.json` + `.claude-plugin/skills/argus-jvm-harness/SKILL.md` — Argus is now installable as a Claude Code plugin via `/plugin marketplace add https://github.com/rlaope/Argus` then `/plugin install argus-jvm-harness`. The skill wraps the CLI; if `argus` isn't on PATH it bootstraps via `install.sh` first.
 - `docs/harness.md` — full reference for the harness, trend rules, output formats, and recommended usage patterns.
+- **`argus profile` — 10 new async-profiler passthrough flags**: `--ttsp` (time-to-safepoint profiling), `--begin=<func>` / `--end=<func>` (profile boundary triggers), `--reverse` (call-tree direction), `--minwidth=<pct>` (collapse narrow frames), `--sched` (Linux scheduler events), `--clock=tsc|monotonic` (closed-enum validated), `--signal=<n>`, `--proc=<duration>` (per-process sampling interval), `--nofree` (suppress free events). `--cstack`, `--interval`, and `--clock` all parse-validate at the CLI boundary; `--sched` is Linux-gated and `--nofree` warns when the event isn't `nativemem`.
+- **`argus doctor` — CodeCache pressure rule + DirectBuffer rule that works on JDK 16+**: `CodeCacheRule` flags WARNING at ≥80% used and CRITICAL at ≥95%, recommending `-XX:ReservedCodeCacheSize=<2×current>` (256m floor) and re-enabling `+UseCodeCacheFlushing` only when the user has disabled it. `DirectBufferRule` reads the JVM-reported buffer pools first, then consults NMT `Other` / `Internal` category committed bytes when buffer pools are empty (the case on JDK 16+ jcmd-only path). Finding text says "via NMT" so operators know the source. `JvmSnapshot` now carries `codeCacheUsedKb` / `codeCacheSizeKb` / `nmtCommittedKbByCategory`, populated once per doctor run via `JdkCompilerProvider` and `JdkNmtProvider`.
+- **`argus compiler` — runtime deoptimization count**: reads `sun.ci.totalInvalidates` from `jcmd PerfCounter.print` and renders `Deoptimizations: N` under the existing code-cache block. JSON output gains `"deoptCount": N`. Stable across HotSpot JDK 8+.
+- `install.sh` / `install.ps1` `--run` flag — `install.sh ... --run <subcommand>` (and `install.ps1 ... -Run <subcommand>`) installs and immediately execs into the freshly-installed `argus` in one shot.
 
 ### Changed
-- `argusVersion` bumped to `1.4.0-SNAPSHOT` while harness work lands; the next tagged release will be `1.4.0`.
+- All GitHub Actions in `.github/workflows/*.yml` are now pinned by commit SHA (`uses: <owner>/<repo>@<sha> # <tag>`) for supply-chain hardening.
+- `setup-graalvm` pinned to `1.4.5` and Dependabot configured to ignore major/minor bumps for this action — `1.5.x` removed the `distribution: graalvm-community` input that `native-image.yml` depends on, so unattended bumps would break native-image builds. Patch bumps remain eligible. Lift only after `native-image.yml` is migrated to the new input shape and verified end-to-end on a tag.
+- `argus-cli` commands now self-register via `ServiceLoader` rather than a hand-maintained list. Adding a new command is one file plus a `META-INF/services` line; the CLI dispatcher does not need to be touched.
+- `JfrCaptureSession` consolidates the JFR start → stream → stop loop that was previously duplicated across `flame`, `gcprofile`, `profile`, and `slowlog`.
+
+### Fixed
+- `argus top` wiring: `ArgusTop` (a dead alternate command class) removed; `TopCommand` is now the single entry point for the `top` subcommand.
 
 ## [1.3.0] - 2026-05-08
 

--- a/charts/argus/Chart.yaml
+++ b/charts/argus/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: argus
 description: Argus JVM Observability — Prometheus metrics, Grafana dashboards, and alerting for JVM applications
 type: application
-version: 1.3.0
-appVersion: "1.3.0"
+version: 1.4.0
+appVersion: "1.4.0"
 kubeVersion: ">=1.23.0-0"
 home: https://github.com/rlaope/Argus
 sources:

--- a/charts/argus/README.md
+++ b/charts/argus/README.md
@@ -63,13 +63,13 @@ env:
 <dependency>
   <groupId>io.github.rlaope</groupId>
   <artifactId>argus-spring-boot-starter</artifactId>
-  <version>1.3.0</version>
+  <version>1.4.0</version>
 </dependency>
 ```
 
 ```groovy
 // Gradle
-implementation 'io.github.rlaope:argus-spring-boot-starter:1.3.0'
+implementation 'io.github.rlaope:argus-spring-boot-starter:1.4.0'
 ```
 
 ### Step 3 — Expose the metrics port

--- a/deploy/sdkman/README.md
+++ b/deploy/sdkman/README.md
@@ -13,7 +13,7 @@ This directory contains the candidate definition for submitting Argus to the [SD
 Once the candidate is registered, publish each release via the SDKMAN Vendor API:
 
 ```bash
-VERSION="1.3.0"
+VERSION="1.4.0"
 CONSUMER_KEY="<your-key>"
 CONSUMER_SECRET="<your-secret>"
 
@@ -59,7 +59,7 @@ sdk install argus
 Or a specific version:
 
 ```bash
-sdk install argus 1.3.0
+sdk install argus 1.4.0
 ```
 
 ## Notes

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -43,15 +43,15 @@ argus report 12345
 
 ```bash
 # Install a specific version
-curl -fsSL https://raw.githubusercontent.com/rlaope/argus/master/install.sh | bash -s -- v1.3.0
+curl -fsSL https://raw.githubusercontent.com/rlaope/argus/master/install.sh | bash -s -- v1.4.0
 ```
 
 ### Option 2: Manual Download
 
 ```bash
 # Download JARs from GitHub Releases
-curl -LO https://github.com/rlaope/argus/releases/latest/download/argus-agent-1.3.0.jar
-curl -LO https://github.com/rlaope/argus/releases/latest/download/argus-cli-1.3.0-all.jar
+curl -LO https://github.com/rlaope/argus/releases/latest/download/argus-agent-1.4.0.jar
+curl -LO https://github.com/rlaope/argus/releases/latest/download/argus-cli-1.4.0-all.jar
 ```
 
 ### Option 3: Build from Source
@@ -63,8 +63,8 @@ cd argus
 ./gradlew :argus-cli:fatJar
 
 # JARs:
-# argus-agent/build/libs/argus-agent-1.3.0.jar
-# argus-cli/build/libs/argus-cli-1.3.0-all.jar
+# argus-agent/build/libs/argus-agent-1.4.0.jar
+# argus-cli/build/libs/argus-cli-1.4.0-all.jar
 ```
 
 ## Quick Start with Sample Project
@@ -119,7 +119,7 @@ argus info <pid>               # JVM information
 argus top
 
 # Or run directly
-java -jar argus-cli/build/libs/argus-cli-1.3.0-all.jar --help
+java -jar argus-cli/build/libs/argus-cli-1.4.0-all.jar --help
 ```
 
 The CLI auto-detects the best data source: Argus agent (HTTP) when available, JDK tools (`jcmd`) as fallback. Use `--source=agent|jdk` to override.

--- a/docs/kubernetes.md
+++ b/docs/kubernetes.md
@@ -68,7 +68,7 @@ Use an init container to inject the agent JAR via a shared volume. This avoids m
 ```yaml
 initContainers:
   - name: argus-init
-    image: ghcr.io/rlaope/argus:1.3.0
+    image: ghcr.io/rlaope/argus:1.4.0
     command: ["cp", "/opt/argus/argus-cli.jar", "/argus-volume/argus-cli.jar"]
     volumeMounts:
       - name: argus-volume
@@ -98,13 +98,13 @@ Add the Argus Spring Boot starter to `pom.xml` or `build.gradle`. No `-javaagent
 <dependency>
   <groupId>io.argus</groupId>
   <artifactId>argus-spring-boot-starter</artifactId>
-  <version>1.3.0</version>
+  <version>1.4.0</version>
 </dependency>
 ```
 
 **Gradle:**
 ```groovy
-implementation 'io.argus:argus-spring-boot-starter:1.3.0'
+implementation 'io.argus:argus-spring-boot-starter:1.4.0'
 ```
 
 The `/prometheus` and `/argus` endpoints are auto-registered alongside your application's existing endpoints.
@@ -279,7 +279,7 @@ spec:
               mountPath: /argus
       initContainers:
         - name: argus-init
-          image: ghcr.io/rlaope/argus:1.3.0
+          image: ghcr.io/rlaope/argus:1.4.0
           command: ["cp", "/opt/argus/argus-cli.jar", "/argus-volume/argus-cli.jar"]
           volumeMounts:
             - name: argus-volume

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -119,7 +119,7 @@ All settings are passed as `-D` system properties:
 Add `argus-spring-boot-starter` to your Spring Boot 3.2+ application for zero-config JVM monitoring:
 
 ```kotlin
-implementation("io.argus:argus-spring-boot-starter:1.3.0")
+implementation("io.argus:argus-spring-boot-starter:1.4.0")
 ```
 
 Configure via `application.yml`:

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
-argusVersion=1.4.0-SNAPSHOT
+argusVersion=1.4.0
 nettyVersion=4.1.115.Final
 junitVersion=5.11.4

--- a/install.ps1
+++ b/install.ps1
@@ -11,7 +11,7 @@
     irm https://raw.githubusercontent.com/rlaope/argus/master/install.ps1 | iex
 
 .EXAMPLE
-    .\install.ps1 -Version v1.3.0
+    .\install.ps1 -Version v1.4.0
 #>
 
 param(
@@ -58,8 +58,8 @@ if ($Version -eq "latest") {
         $Release = Invoke-RestMethod "https://api.github.com/repos/$Repo/releases/latest" -UseBasicParsing
         $Version = $Release.tag_name
     } catch {
-        Write-Warn "Could not resolve latest release. Using 'v1.3.0' as fallback."
-        $Version = "v1.3.0"
+        Write-Warn "Could not resolve latest release. Using 'v1.4.0' as fallback."
+        $Version = "v1.4.0"
     }
 }
 

--- a/install.sh
+++ b/install.sh
@@ -127,8 +127,8 @@ if [ "$VERSION" = "latest" ]; then
         | grep '"tag_name"' | head -1 | sed 's/.*"tag_name"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/')
 
     if [ -z "$VERSION" ]; then
-        warn "Could not resolve latest release. Using 'v1.3.0' as fallback."
-        VERSION="v1.3.0"
+        warn "Could not resolve latest release. Using 'v1.4.0' as fallback."
+        VERSION="v1.4.0"
     fi
 fi
 

--- a/site/index.html
+++ b/site/index.html
@@ -633,7 +633,7 @@
                         <span class="badge green">Java 21+ Full Features</span>
                         <span class="badge">67 Commands</span>
                         <span class="badge">Zero Dependencies</span>
-                        <span class="badge green">v1.3.0</span>
+                        <span class="badge green">v1.4.0</span>
                     </div>
                 </div>
 
@@ -967,7 +967,7 @@ $ argus zgc 12345 --watch=10 --interval=60</code></pre>
                 <h3>Setup</h3>
 
                 <pre><code>// build.gradle.kts
-implementation("io.argus:argus-spring-boot-starter:1.3.0")</code></pre>
+implementation("io.argus:argus-spring-boot-starter:1.4.0")</code></pre>
 
                 <p>When your Spring Boot application starts, Argus will:</p>
                 <ul>


### PR DESCRIPTION
## Summary

Version sync for the v1.4.0 release. After this PR merges, master is tagged `v1.4.0` and `release.yml` publishes the artifacts.

**Bumps:**
- `gradle.properties`: `argusVersion 1.4.0-SNAPSHOT → 1.4.0`
- Helm chart: `version` + `appVersion` `1.3.0 → 1.4.0`
- `install.sh` / `install.ps1`: fallback `v1.3.0 → v1.4.0`
- `docs/getting-started.md`, `docs/kubernetes.md`, `docs/usage.md`, `site/index.html`, `charts/argus/README.md`, `deploy/sdkman/README.md`: all version refs `1.3.0 → 1.4.0`
- `CHANGELOG.md`: promote `[Unreleased]` → `[1.4.0] - 2026-05-13`

**v1.4.0 headline changes (per CHANGELOG):**
- `argus harness <pid>` — continuous JVM trend-aware health watch (doctor + 4 trend rules)
- `argus profile` — 10 new async-profiler passthrough flags (`--ttsp`, `--begin/--end`, `--reverse`, `--minwidth`, `--sched`, `--clock`, `--signal`, `--proc`, `--nofree`)
- `argus doctor` — `CodeCacheRule` (80%/95% threshold) + `DirectBufferRule` NMT path for JDK 16+
- `argus compiler` — runtime deoptimization count (`sun.ci.totalInvalidates`) in TUI and JSON
- All GitHub Actions pinned by SHA; Dependabot ignores `graalvm/setup-graalvm` major/minor to keep `native-image.yml` working
- `ServiceLoader`-based command registration; `JfrCaptureSession` consolidates JFR capture loop
- Claude Code plugin entry (`/plugin install argus-jvm-harness`)
- `install.sh --run` / `install.ps1 -Run` chains install → exec in one shot

## Intentionally NOT included

- **`Formula/argus.rb`** stays at `1.3.0`. The Homebrew `sha256` must be computed against the actual `argus-cli-1.4.0-all.jar` artifact, which doesn't exist until `release.yml` publishes after the tag push. Follow-up commit will update `version` + `url` + `sha256` once the artifact is on the release.

## Test plan

- [x] `./gradlew :argus-cli:test` — green
- [x] `./gradlew :argus-cli:fatJar` builds `argus-cli-1.4.0-all.jar`
- [x] `java -jar .../argus-cli-1.4.0-all.jar --version` prints `argus 1.4.0`
- [x] No stray `v?1\.3\.0` left in tracked files outside `CHANGELOG.md` (historical sections) and `Formula/argus.rb` (sha256 dependency)

## Post-merge

```
git checkout master && git pull
git tag -a v1.4.0 -m "Argus 1.4.0"
git push origin v1.4.0   # triggers release.yml
```