### PR TITLE
chore(release): auto-bump Homebrew Formula on tag push + fix license/desc drift

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,3 +65,52 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: gh workflow run native-image.yml --ref ${{ github.ref_name }}
+
+      - name: Update Homebrew Formula on master
+        env:
+          VERSION: ${{ steps.version.outputs.VERSION }}
+        run: |
+          set -euo pipefail
+          JAR="argus-cli-${VERSION}-all.jar"
+          SHA=$(sha256sum "$JAR" | awk '{print $1}')
+          echo "Computed sha256: $SHA"
+
+          git fetch origin master
+          git checkout master
+
+          # Patch version, url, sha256, and the libexec rename line. Anchored to the
+          # `^  version` / `url "...releases/download/...`/ `sha256 "..."` lines so we
+          # don't accidentally rewrite unrelated occurrences.
+          python3 - "$VERSION" "$SHA" <<'PY'
+          import re, sys, pathlib
+          version, sha = sys.argv[1], sys.argv[2]
+          p = pathlib.Path("Formula/argus.rb")
+          src = p.read_text()
+          # Homebrew derives version from the URL — no separate version line.
+          src = re.sub(
+              r'releases/download/v\d+\.\d+\.\d+/argus-cli-\d+\.\d+\.\d+-all\.jar',
+              f'releases/download/v{version}/argus-cli-{version}-all.jar',
+              src,
+          )
+          src = re.sub(r'sha256 "[a-f0-9]{64}"', f'sha256 "{sha}"', src, count=1)
+          src = re.sub(
+              r'argus-cli-\d+\.\d+\.\d+-all\.jar',
+              f'argus-cli-{version}-all.jar',
+              src,
+          )
+          p.write_text(src)
+          PY
+
+          if git diff --quiet Formula/argus.rb; then
+            echo "Formula already at ${VERSION} — nothing to commit."
+            exit 0
+          fi
+
+          git config user.name  "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add Formula/argus.rb
+          git commit -s -m "chore(formula): bump to ${VERSION}
+
+          Auto-bumped by release.yml after publishing v${VERSION} artifacts.
+          sha256 computed against argus-cli-${VERSION}-all.jar from the release build."
+          git push origin master

--- a/Formula/argus.rb
+++ b/Formula/argus.rb
@@ -1,9 +1,9 @@
 class Argus < Formula
-  desc "JVM diagnostic toolkit — 66 commands, health diagnosis, GC analysis, profiling, interactive TUI"
+  desc "JVM Monitoring Orchestration Tools — diagnostic CLI, dashboard, TUI, and rule-based doctor"
   homepage "https://github.com/rlaope/Argus"
   url "https://github.com/rlaope/Argus/releases/download/v1.3.0/argus-cli-1.3.0-all.jar"
   sha256 "f2e3ce15bf8f95a8c0e4d0d5da26c6d5ae8321295de41af1758e8516c8627a4e"
-  license "Apache-2.0"
+  license "MIT"
 
   depends_on "openjdk@21"
 


### PR DESCRIPTION
## Summary

Removes the manual post-release Formula update step. After `release.yml` uploads the v${VERSION} artifacts, it now computes the sha256 of `argus-cli-${VERSION}-all.jar` and patches `Formula/argus.rb` (URL, sha256, `libexec.install` rename) via a small Python regex, then commits to master as `github-actions[bot]`.

Drives the "no manual follow-up" promise: tag push → release.yml builds + publishes + dispatches native-image + auto-bumps Formula. End.

## While here — drift fixes in Formula/argus.rb

- `license "Apache-2.0"` → `license "MIT"` (the repo's actual LICENSE file is MIT)
- `desc "JVM diagnostic toolkit — 66 commands, …"` → `desc "JVM Monitoring Orchestration Tools — diagnostic CLI, dashboard, TUI, and rule-based doctor"` — command count would rot every release.

## Verification

- [x] Python regex dry-run against current `Formula/argus.rb` → URL, sha256, and `libexec.install` lines all match and rewrite cleanly. No unintended hits.
- [x] YAML heredoc indentation: `run: \|` strips the common leading whitespace, so the closing `PY` terminator lands at column 0 in the executed script.
- [x] Permissions: `release.yml` already has `contents: write` → push to master from the workflow token works.
- [x] No new dependencies — `python3` is on `ubuntu-latest` by default.