### PR TITLE
chore: sync async-profiler version + README command count

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Full reference: [docs/harness.md](docs/harness.md)
 
 ## Why Argus?
 
-- **66 diagnostic commands** — heap, GC, threads, profiling, flame graphs, NMT, class loaders, and more. No agent required.
+- **67 diagnostic commands** — heap, GC, threads, profiling, flame graphs, NMT, class loaders, and more. No agent required.
 - **Live JVM attach** — attaches externally via `jcmd`/JMX; target JVM needs no restart and no `-javaagent` flag.
 - **ZGC-aware** — `argus zgc` gives a HEALTHY/WARNING/UNHEALTHY verdict with allocation stall detection, cycle-overlap analysis, SoftMax breach detection, and diff-against-baseline in one command.
 - **Virtual thread support** — JFR-based pinning detection, carrier-thread distribution, and virtual thread monitoring on Java 21+.

--- a/install.sh
+++ b/install.sh
@@ -229,7 +229,7 @@ fi
 
 # --- Download async-profiler ---
 
-ASPROF_VERSION="3.0"
+ASPROF_VERSION="4.4"
 ASPROF_DIR="$INSTALL_DIR/lib/async-profiler"
 
 detect_asprof_platform() {


### PR DESCRIPTION
## Summary

Two drift surfaces surfaced by a container-based install verification (clean `eclipse-temurin:21-jdk`, install via the README quick-start one-liner, version + live diagnostic assertions):

- `install.sh` was pinned to `ASPROF_VERSION="3.0"`, while the runtime (`AsProfDownloader` / `AsProfCapabilities`) is hard-coded to `4.4`. Both write to `~/.argus/lib/async-profiler/`, so the install-time 3.0 binary was dead weight — runtime re-downloads 4.4 on first `argus profile`. Bumped install.sh to `4.4` to remove the duplication.
- `README.md:64` still said "66 diagnostic commands". Line 14 and `argus --help` both report 67. Synced line 64.

## Verification

Clean container reinstall with the patched `install.sh`:

```
$ docker run --rm --platform=linux/arm64 \
    -v ./install.sh:/install.sh:ro \
    eclipse-temurin:21-jdk \
    bash -c "apt-get update -qq && apt-get install -y -qq curl ca-certificates >/dev/null && bash /install.sh"
...
[INFO]  Downloading async-profiler 4.4 for linux-arm64...
[OK]    async-profiler 4.4 (linux-arm64)
  Argus installed successfully!
```

Live JVM diagnostics in the same container — `argus --version` = `1.4.0`, `argus ps/info/gc/threads/heap/histo/nmt/vmflag/sysprops <pid>` all return structured output, `argus doctor <pid>` exits 0 with the healthy panel.

## Test plan
- [x] `install.sh` succeeds in clean `eclipse-temurin:21-jdk` container
- [x] async-profiler 4.4 artifact resolves for linux-arm64 / linux-x64 / macos (`HTTP 302`)
- [x] `argus profile` runtime version (4.4) now matches install-time version
- [x] `README.md` internal consistency: both lines and `argus --help` say 67