### PR TITLE
chore(skills): docs-sync — internal command-count consistency check

### DIFF
--- a/.claude/skills/docs-sync/SKILL.md
+++ b/.claude/skills/docs-sync/SKILL.md
@@ -81,8 +81,33 @@ grep -rEn 'v?[0-9]+\.[0-9]+\.[0-9]+' README.md docs/ site/index.html \
   | grep -v -E '(java|jdk|jvm|netty|micrometer|junit|spring|node|graalvm|grafana|prometheus|3\.[0-9]|11\+|17\+|21\+)' \
   | head -50
 
-# Command-count drift
+# Command-count drift (per-file listing)
 grep -rnE '[0-9]{2}\+? ?(commands|Commands)' README.md docs/ site/index.html
+
+# Command-count internal consistency (catches the trap where the SAME README
+# says "67 commands" on line 14 and "66 diagnostic commands" on line 64 — listing
+# alone doesn't fail; collapse all occurrences plus the runtime help banner to a
+# unique-value set and fail if there's more than one).
+COUNT_OCCURRENCES=$(grep -rhEo '[0-9]{2,3} (diagnostic )?commands?' \
+    README.md docs/ site/index.html 2>/dev/null \
+  | sed -E 's/ diagnostic / /' \
+  | awk '{print $1}' \
+  | sort -u)
+HELP_COUNT=""
+if command -v argus &>/dev/null; then
+  HELP_COUNT=$(argus --help 2>&1 | sed -E "s/\x1b\[[0-9;]*m//g" \
+    | grep -oE '[0-9]{2,3} commands' | head -1 | awk '{print $1}')
+fi
+echo "docs occurrences: $(echo "$COUNT_OCCURRENCES" | tr '\n' ' ')"
+echo "argus --help    : ${HELP_COUNT:-(argus not on PATH)}"
+echo "truth (source)  : $CMD_COUNT"
+ALL=$(printf '%s\n%s\n%s\n' "$COUNT_OCCURRENCES" "$HELP_COUNT" "$CMD_COUNT" \
+  | grep -E '^[0-9]+$' | sort -u)
+if [ "$(echo "$ALL" | wc -l | tr -d ' ')" -gt 1 ]; then
+  echo "DRIFT — multiple command counts in circulation: $(echo "$ALL" | tr '\n' ' ')"
+else
+  echo "OK — single command count everywhere: $ALL"
+fi
 
 # i18n parity
 diff <(cat /tmp/keys_en.txt) <(cat /tmp/keys_ko.txt)


### PR DESCRIPTION
## Summary

Closes a gap in the `docs-sync` skill that allowed `README.md:14` ("67 commands") and `README.md:64` ("66 diagnostic commands") to disagree inside the same file for an entire release cycle — surfaced only when a container-based verify pass ran `argus --help` and compared its 67 against the README prose.

The original step 2 in `.claude/skills/docs-sync/SKILL.md` did:

```bash
# Command-count drift
grep -rnE '[0-9]{2}\+? ?(commands|Commands)' README.md docs/ site/index.html
```

This **lists** every occurrence per-file but never **collapses** them. If the same file mentions two different counts, the operator gets two lines and has to spot the disagreement by eye. That's exactly what slipped through.

## What changes

Add a second pass after the listing grep that:

- regex-extracts every `N (diagnostic )?commands?` occurrence across `README.md`, `docs/`, `site/index.html`
- pulls the runtime banner from `argus --help` (ANSI-stripped) as another truth witness — this is what users actually see
- merges those with the source-of-truth `$CMD_COUNT` from step 1 (counted from `*Command.java`)
- `sort -u` and fails `DRIFT` when more than one unique value remains, passes `OK` on exactly one

## Verification

Ran the new pass against the current master tree:

```
docs occurrences: 65 66 67
argus --help    : (argus not on PATH)
truth (source)  : 67
DRIFT — multiple command counts in circulation: 65 66 67
```

In addition to catching the known 66/67 drift, the new check surfaced a **third stale value of "65 diagnostic commands"** living in `site/index.html` lines 642 and 1066 that nobody had flagged. Not fixed in this PR (this PR only hardens the skill); fixing the three site/index.html + README.md lines is a separate `docs-sync` run.

## Test plan
- [x] Block detects the 66/67 README drift that motivated this change
- [x] Block surfaces additional stale values nobody caught before (`65` in `site/index.html`)
- [x] Block degrades gracefully when `argus` is not on PATH (truth + docs occurrences still enough)