### PR TITLE
refactor(cli): JmxAttachment seam + JvmSnapshotCollector regex hoist

### DIFF
--- a/argus-cli/src/main/java/io/argus/cli/command/MBeanCommand.java
+++ b/argus-cli/src/main/java/io/argus/cli/command/MBeanCommand.java
@@ -2,6 +2,8 @@ package io.argus.cli.command;
 
 import io.argus.cli.config.CliConfig;
 import io.argus.cli.config.Messages;
+import io.argus.cli.jmx.JmxAttachment;
+import io.argus.cli.jmx.JmxAttachmentException;
 import io.argus.cli.provider.ProviderRegistry;
 import io.argus.cli.render.AnsiStyle;
 import io.argus.cli.render.RichRenderer;
@@ -13,9 +15,6 @@ import javax.management.MBeanServerConnection;
 import javax.management.ObjectName;
 import javax.management.openmbean.CompositeData;
 import javax.management.openmbean.TabularData;
-import javax.management.remote.JMXConnector;
-import javax.management.remote.JMXConnectorFactory;
-import javax.management.remote.JMXServiceURL;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
@@ -72,22 +71,26 @@ public final class MBeanCommand implements Command {
             else if (arg.equals("--format=json")) json = true;
         }
 
-        String connectorAddr = getConnectorAddress(pid);
-        if (connectorAddr == null) {
+        final boolean jsonOut = json;
+        final boolean colorOut = useColor;
+        final boolean listAllFinal = listAll;
+        final String mbeanNameFinal = mbeanName;
+        final String attrNameFinal = attrName;
+        final String domainFinal = domain;
+
+        try {
+            JmxAttachment.withConnection(pid, mbs -> {
+                if (mbeanNameFinal != null) {
+                    showMBeanAttributes(mbs, mbeanNameFinal, attrNameFinal, colorOut, jsonOut);
+                } else if (listAllFinal || domainFinal != null) {
+                    listMBeans(mbs, domainFinal, colorOut, jsonOut);
+                } else {
+                    listDomains(mbs, colorOut, jsonOut);
+                }
+                return null;
+            });
+        } catch (JmxAttachmentException e) {
             System.err.println("Cannot connect to JVM " + pid + " via JMX. Try: argus jmx " + pid + " start-local");
-            return;
-        }
-
-        try (JMXConnector connector = JMXConnectorFactory.connect(new JMXServiceURL(connectorAddr))) {
-            MBeanServerConnection mbs = connector.getMBeanServerConnection();
-
-            if (mbeanName != null) {
-                showMBeanAttributes(mbs, mbeanName, attrName, useColor, json);
-            } else if (listAll || domain != null) {
-                listMBeans(mbs, domain, useColor, json);
-            } else {
-                listDomains(mbs, useColor, json);
-            }
         } catch (Exception e) {
             System.err.println("JMX connection error: " + e.getMessage());
         }
@@ -291,29 +294,6 @@ public final class MBeanCommand implements Command {
         }
         sb.append("}}");
         System.out.println(sb);
-    }
-
-    /**
-     * Obtains the JMX connector address for a local JVM by PID using the Attach API.
-     */
-    private String getConnectorAddress(long pid) {
-        try {
-            var vm = com.sun.tools.attach.VirtualMachine.attach(String.valueOf(pid));
-            try {
-                String addr = vm.getAgentProperties().getProperty("com.sun.management.jmxremote.localConnectorAddress");
-                if (addr == null) {
-                    // Start the local management agent
-                    vm.startLocalManagementAgent();
-                    addr = vm.getAgentProperties().getProperty("com.sun.management.jmxremote.localConnectorAddress");
-                }
-                return addr;
-            } finally {
-                vm.detach();
-            }
-        } catch (Exception e) {
-            System.err.println("Cannot attach to PID " + pid + ": " + e.getMessage());
-            return null;
-        }
     }
 
     private static final class AttrEntry {

--- a/argus-cli/src/main/java/io/argus/cli/command/SpringCommand.java
+++ b/argus-cli/src/main/java/io/argus/cli/command/SpringCommand.java
@@ -2,6 +2,8 @@ package io.argus.cli.command;
 
 import io.argus.cli.config.CliConfig;
 import io.argus.cli.config.Messages;
+import io.argus.cli.jmx.JmxAttachment;
+import io.argus.cli.jmx.JmxAttachmentException;
 import io.argus.cli.provider.ProviderRegistry;
 import io.argus.cli.provider.jdk.JcmdExecutor;
 import io.argus.cli.render.AnsiStyle;
@@ -11,9 +13,6 @@ import io.argus.core.command.CommandGroup;
 import javax.management.MBeanServerConnection;
 import javax.management.ObjectName;
 import javax.management.openmbean.CompositeData;
-import javax.management.remote.JMXConnector;
-import javax.management.remote.JMXConnectorFactory;
-import javax.management.remote.JMXServiceURL;
 import java.util.Set;
 
 /**
@@ -60,22 +59,22 @@ public final class SpringCommand implements Command {
             return;
         }
 
-        String connectorAddr = getConnectorAddress(pid);
-        if (connectorAddr == null) {
+        final boolean showBeansFinal = showBeans;
+        final boolean showDatasourceFinal = showDatasource;
+
+        try {
+            JmxAttachment.withConnection(pid, mbs -> {
+                if (showBeansFinal) {
+                    renderBeans(mbs, pid, appName, useColor, messages);
+                } else if (showDatasourceFinal) {
+                    renderDatasource(mbs, pid, appName, useColor, messages);
+                } else {
+                    renderOverview(mbs, pid, appName, useColor, messages);
+                }
+                return null;
+            });
+        } catch (JmxAttachmentException e) {
             System.err.println(messages.get("error.spring.jmx.unavailable", pid));
-            return;
-        }
-
-        try (JMXConnector connector = JMXConnectorFactory.connect(new JMXServiceURL(connectorAddr))) {
-            MBeanServerConnection mbs = connector.getMBeanServerConnection();
-
-            if (showBeans) {
-                renderBeans(mbs, pid, appName, useColor, messages);
-            } else if (showDatasource) {
-                renderDatasource(mbs, pid, appName, useColor, messages);
-            } else {
-                renderOverview(mbs, pid, appName, useColor, messages);
-            }
         } catch (Exception e) {
             System.err.println(messages.get("error.spring.jmx.error", e.getMessage()));
         }
@@ -403,30 +402,6 @@ public final class SpringCommand implements Command {
             return 0;
         } catch (Exception ignored) {
             return 0;
-        }
-    }
-
-    // -------------------------------------------------------------------------
-    // JMX attach
-    // -------------------------------------------------------------------------
-
-    private String getConnectorAddress(long pid) {
-        try {
-            var vm = com.sun.tools.attach.VirtualMachine.attach(String.valueOf(pid));
-            try {
-                String addr = vm.getAgentProperties().getProperty(
-                        "com.sun.management.jmxremote.localConnectorAddress");
-                if (addr == null) {
-                    vm.startLocalManagementAgent();
-                    addr = vm.getAgentProperties().getProperty(
-                            "com.sun.management.jmxremote.localConnectorAddress");
-                }
-                return addr;
-            } finally {
-                vm.detach();
-            }
-        } catch (Exception e) {
-            return null;
         }
     }
 

--- a/argus-cli/src/main/java/io/argus/cli/command/ThreadsCommand.java
+++ b/argus-cli/src/main/java/io/argus/cli/command/ThreadsCommand.java
@@ -2,6 +2,8 @@ package io.argus.cli.command;
 
 import io.argus.cli.config.CliConfig;
 import io.argus.cli.config.Messages;
+import io.argus.cli.jmx.JmxAttachment;
+import io.argus.cli.jmx.JmxAttachmentException;
 import io.argus.cli.model.ThreadResult;
 import io.argus.cli.provider.ProviderRegistry;
 import io.argus.cli.provider.ThreadProvider;
@@ -10,9 +12,6 @@ import io.argus.cli.render.RichRenderer;
 import io.argus.core.command.CommandGroup;
 
 import javax.management.MBeanServerConnection;
-import javax.management.remote.JMXConnector;
-import javax.management.remote.JMXConnectorFactory;
-import javax.management.remote.JMXServiceURL;
 import java.lang.management.ManagementFactory;
 import java.lang.management.ThreadInfo;
 import java.lang.management.ThreadMXBean;
@@ -183,15 +182,23 @@ public final class ThreadsCommand implements Command {
      * Shows top-N threads ranked by CPU usage. Samples ThreadMXBean twice with 1s interval.
      */
     private void showCpuRanking(long pid, int topN, boolean c, boolean json) {
-        String connAddr = getConnectorAddress(pid);
-        if (connAddr == null) {
+        try {
+            JmxAttachment.withConnection(pid, mbs -> {
+                showCpuRankingWithConnection(pid, topN, c, json, mbs);
+                return null;
+            });
+        } catch (JmxAttachmentException e) {
             System.err.println("Cannot attach to PID " + pid + " via JMX. Ensure same user and Java 9+.");
-            return;
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        } catch (Exception e) {
+            System.err.println("Error reading thread CPU: " + e.getMessage());
         }
+    }
 
-        try (JMXConnector connector = JMXConnectorFactory.connect(new JMXServiceURL(connAddr))) {
-            MBeanServerConnection mbs = connector.getMBeanServerConnection();
-            ThreadMXBean tmx = ManagementFactory.newPlatformMXBeanProxy(
+    private void showCpuRankingWithConnection(long pid, int topN, boolean c, boolean json,
+                                               MBeanServerConnection mbs) throws Exception {
+        ThreadMXBean tmx = ManagementFactory.newPlatformMXBeanProxy(
                     mbs, ManagementFactory.THREAD_MXBEAN_NAME, ThreadMXBean.class);
 
             if (!tmx.isThreadCpuTimeSupported() || !tmx.isThreadCpuTimeEnabled()) {
@@ -294,32 +301,6 @@ public final class ThreadsCommand implements Command {
                             + "  |  Showing top " + show
                             + AnsiStyle.style(c, AnsiStyle.RESET), WIDTH));
             System.out.println(RichRenderer.boxFooter(c, null, WIDTH));
-
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-        } catch (Exception e) {
-            System.err.println("Error reading thread CPU: " + e.getMessage());
-        }
-    }
-
-    private String getConnectorAddress(long pid) {
-        try {
-            var vm = com.sun.tools.attach.VirtualMachine.attach(String.valueOf(pid));
-            try {
-                String addr = vm.getAgentProperties().getProperty(
-                        "com.sun.management.jmxremote.localConnectorAddress");
-                if (addr == null) {
-                    vm.startLocalManagementAgent();
-                    addr = vm.getAgentProperties().getProperty(
-                            "com.sun.management.jmxremote.localConnectorAddress");
-                }
-                return addr;
-            } finally {
-                vm.detach();
-            }
-        } catch (Exception e) {
-            return null;
-        }
     }
 
     private void printCpuJson(List<ThreadCpuEntry> entries, int show, long totalDelta) {

--- a/argus-cli/src/main/java/io/argus/cli/command/ZgcCommand.java
+++ b/argus-cli/src/main/java/io/argus/cli/command/ZgcCommand.java
@@ -4,6 +4,8 @@ import io.argus.cli.config.CliConfig;
 import io.argus.cli.config.Messages;
 import io.argus.cli.jfr.JfrCaptureFailed;
 import io.argus.cli.jfr.JfrCaptureSession;
+import io.argus.cli.jmx.JmxAttachment;
+import io.argus.cli.jmx.JmxAttachmentException;
 import io.argus.cli.provider.ProviderRegistry;
 import io.argus.cli.provider.jdk.JcmdExecutor;
 import io.argus.cli.render.AnsiStyle;
@@ -16,10 +18,10 @@ import io.argus.core.command.CommandGroup;
 
 import javax.management.MBeanServerConnection;
 import javax.management.ObjectName;
+import javax.management.openmbean.CompositeData;
 import javax.management.remote.JMXConnector;
 import javax.management.remote.JMXConnectorFactory;
 import javax.management.remote.JMXServiceURL;
-import javax.management.openmbean.CompositeData;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.time.Duration;
@@ -443,27 +445,13 @@ public final class ZgcCommand implements Command {
 
         String connectorAddr;
         try {
-            var vm = com.sun.tools.attach.VirtualMachine.attach(String.valueOf(pid));
-            try {
-                connectorAddr = vm.getAgentProperties()
-                        .getProperty("com.sun.management.jmxremote.localConnectorAddress");
-                if (connectorAddr == null) {
-                    vm.startLocalManagementAgent();
-                    connectorAddr = vm.getAgentProperties()
-                            .getProperty("com.sun.management.jmxremote.localConnectorAddress");
-                }
-            } finally {
-                vm.detach();
-            }
-        } catch (Exception e) {
+            connectorAddr = JmxAttachment.resolveConnectorAddress(pid);
+        } catch (JmxAttachmentException e) {
             return new TargetInfo(false, false, "", "", 0, -1);
         }
 
-        if (connectorAddr == null) {
-            return new TargetInfo(false, false, "", "", 0, -1);
-        }
-
-        try (JMXConnector connector = JMXConnectorFactory.connect(new JMXServiceURL(connectorAddr))) {
+        try (JMXConnector connector =
+                JMXConnectorFactory.connect(new JMXServiceURL(connectorAddr))) {
             MBeanServerConnection mbs = connector.getMBeanServerConnection();
 
             Set<ObjectName> gcs = mbs.queryNames(

--- a/argus-cli/src/main/java/io/argus/cli/doctor/JvmSnapshotCollector.java
+++ b/argus-cli/src/main/java/io/argus/cli/doctor/JvmSnapshotCollector.java
@@ -21,6 +21,9 @@ public final class JvmSnapshotCollector {
 
     private static final ThreadLocal<List<String>> warnings = ThreadLocal.withInitial(ArrayList::new);
 
+    private static final Pattern JCMD_HEAP_TOTAL_USED_KB = Pattern.compile("total\\s+(\\d+)K.*used\\s+(\\d+)K");
+    private static final Pattern JCMD_HEAP_POOL_PARSE = Pattern.compile("(\\w[\\w\\s-]*)\\s+(?:total\\s+)?(\\d+)K.*used\\s+(\\d+)K");
+
     /**
      * Collect snapshot — routes to local or remote based on PID.
      */
@@ -458,9 +461,8 @@ public final class JvmSnapshotCollector {
     private static HeapTotals parseHeapTotals(String output) {
         if (output == null) return null;
         // e.g.: "garbage-first heap   total 524288K, used 65536K [0x..., 0x..., 0x...)"
-        Pattern total = Pattern.compile("total\\s+(\\d+)K.*used\\s+(\\d+)K");
         for (String line : output.split("\n")) {
-            Matcher m = total.matcher(line.trim());
+            Matcher m = JCMD_HEAP_TOTAL_USED_KB.matcher(line.trim());
             if (m.find()) {
                 return new HeapTotals(Long.parseLong(m.group(1)) * 1024L,
                         Long.parseLong(m.group(2)) * 1024L);
@@ -471,9 +473,8 @@ public final class JvmSnapshotCollector {
 
     private static void parseHeapInfo(String output, Map<String, JvmSnapshot.PoolInfo> pools) {
         if (output == null) return;
-        Pattern sizePattern = Pattern.compile("(\\w[\\w\\s-]*)\\s+(?:total\\s+)?(\\d+)K.*used\\s+(\\d+)K");
         for (String line : output.split("\n")) {
-            Matcher m = sizePattern.matcher(line.trim());
+            Matcher m = JCMD_HEAP_POOL_PARSE.matcher(line.trim());
             if (m.find()) {
                 String name = m.group(1).trim();
                 long totalKB = Long.parseLong(m.group(2));

--- a/argus-cli/src/main/java/io/argus/cli/jmx/JmxAttachment.java
+++ b/argus-cli/src/main/java/io/argus/cli/jmx/JmxAttachment.java
@@ -1,0 +1,101 @@
+package io.argus.cli.jmx;
+
+import javax.management.MBeanServerConnection;
+import javax.management.remote.JMXConnector;
+import javax.management.remote.JMXConnectorFactory;
+import javax.management.remote.JMXServiceURL;
+
+/**
+ * Centralises the JVM-attach + JMX-connect boilerplate used by MBeanCommand,
+ * SpringCommand, ThreadsCommand, and ZgcCommand.
+ *
+ * <p>The typical attach sequence is:
+ * <ol>
+ *   <li>{@code VirtualMachine.attach(pid)}</li>
+ *   <li>Read {@code com.sun.management.jmxremote.localConnectorAddress} from agent properties.</li>
+ *   <li>If absent, call {@code vm.startLocalManagementAgent()} and re-read.</li>
+ *   <li>{@code JMXConnectorFactory.connect(new JMXServiceURL(addr))}</li>
+ *   <li>Use {@code MBeanServerConnection}.</li>
+ *   <li>Close connector + detach VM in finally.</li>
+ * </ol>
+ *
+ * <p>All methods throw {@link JmxAttachmentException} on failure so callers can
+ * choose between a fatal exit or a graceful fallback.
+ */
+public final class JmxAttachment {
+
+    private static final String LOCAL_CONNECTOR_ADDRESS =
+            "com.sun.management.jmxremote.localConnectorAddress";
+
+    private JmxAttachment() {}
+
+    /**
+     * Functional interface for code that uses an {@link MBeanServerConnection}.
+     *
+     * @param <T> return type
+     */
+    @FunctionalInterface
+    public interface ConnectionUser<T> {
+        T use(MBeanServerConnection conn) throws Exception;
+    }
+
+    /**
+     * Attaches to the JVM identified by {@code pid}, starts the local management
+     * agent if it is not already running, opens a JMX connector, runs {@code fn},
+     * and cleans everything up — even if {@code fn} throws.
+     *
+     * @param pid the target process id
+     * @param fn  the work to perform against the live {@link MBeanServerConnection}
+     * @return whatever {@code fn} returns
+     * @throws JmxAttachmentException if the attach or JMX connect step fails
+     * @throws Exception              if {@code fn} itself throws
+     */
+    public static <T> T withConnection(long pid, ConnectionUser<T> fn)
+            throws JmxAttachmentException, Exception {
+        String addr = resolveConnectorAddress(pid);
+        try (JMXConnector connector = JMXConnectorFactory.connect(new JMXServiceURL(addr))) {
+            return fn.use(connector.getMBeanServerConnection());
+        }
+    }
+
+    /**
+     * Attaches to the JVM identified by {@code pid} and resolves the JMX service URL
+     * string, starting the local management agent if it is not already active.
+     *
+     * <p>The VM is always detached before this method returns.
+     *
+     * @param pid the target process id
+     * @return the non-null JMX connector address string
+     * @throws JmxAttachmentException if attach fails or the address cannot be resolved
+     */
+    public static String resolveConnectorAddress(long pid) throws JmxAttachmentException {
+        com.sun.tools.attach.VirtualMachine vm;
+        try {
+            vm = com.sun.tools.attach.VirtualMachine.attach(String.valueOf(pid));
+        } catch (Exception e) {
+            throw new JmxAttachmentException(
+                    "Cannot attach to PID " + pid + ": " + e.getMessage(), e);
+        }
+
+        try {
+            String addr = vm.getAgentProperties().getProperty(LOCAL_CONNECTOR_ADDRESS);
+            if (addr == null) {
+                vm.startLocalManagementAgent();
+                addr = vm.getAgentProperties().getProperty(LOCAL_CONNECTOR_ADDRESS);
+            }
+            if (addr == null) {
+                throw new JmxAttachmentException(
+                        "Cannot resolve JMX connector address for PID " + pid
+                        + " — management agent may not have started");
+            }
+            return addr;
+        } catch (JmxAttachmentException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new JmxAttachmentException(
+                    "Failed to start management agent for PID " + pid + ": " + e.getMessage(), e);
+        } finally {
+            try { vm.detach(); } catch (Exception ignored) {}
+        }
+    }
+}

--- a/argus-cli/src/main/java/io/argus/cli/jmx/JmxAttachmentException.java
+++ b/argus-cli/src/main/java/io/argus/cli/jmx/JmxAttachmentException.java
@@ -1,0 +1,21 @@
+package io.argus.cli.jmx;
+
+/**
+ * Signals that attaching to a JVM process or resolving its JMX connector address failed.
+ *
+ * <p>This is a checked exception so callers are forced to decide whether the failure
+ * is fatal (throw {@link io.argus.cli.command.CommandExitException}) or recoverable
+ * (return a fallback value). All four callers that use {@link JmxAttachment} treat
+ * attach failure as "print a message and stop the current operation", which maps
+ * naturally to checked-exception handling.
+ */
+public final class JmxAttachmentException extends Exception {
+
+    public JmxAttachmentException(String message) {
+        super(message);
+    }
+
+    public JmxAttachmentException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}


### PR DESCRIPTION
## Summary

Architecture deepening pass — two surgical refactors validated by the deletion test.

- **JmxAttachment seam** (`io.argus.cli.jmx`) — `MBeanCommand`, `SpringCommand`, `ThreadsCommand`, and `ZgcCommand` each carried the same `VirtualMachine.attach` + JMX connector boilerplate. Extracted to `JmxAttachment.withConnection(pid, fn)` (and `resolveConnectorAddress(pid)` for the one call site whose JMX read spans multiple lambdas). Net **−85 lines** across the four commands. Checked `JmxAttachmentException` so callers must explicitly decide between print-and-return vs. throw-CommandExit.
- **`JvmSnapshotCollector` regex hoist** — two `Pattern.compile(...)` calls inside `parseHeapTotals()` / `parseHeapInfo()` moved to `private static final` (`JCMD_HEAP_TOTAL_USED_KB`, `JCMD_HEAP_POOL_PARSE`). Hot path — every `argus doctor` run and snapshot consumer hits it.

### Things intentionally NOT extracted

A shared `JcmdOutput` parser for `JdkNmtProvider` and `JdkHeapProvider` was considered and rejected under the deletion test: NMT parses `reserved=X, committed=Y` with units **inside** the captured value, Heap parses `reserved N` with the unit locked **inside** the regex. A shared helper would have forced callers into adapter glue rather than removing complexity.

## Test plan

- [x] \`./gradlew :argus-cli:compileJava\` — green
- [x] \`./gradlew :argus-cli:test\` — green
- [ ] Smoke: \`argus mbean <pid>\`, \`argus spring <pid>\`, \`argus threads --cpu <pid>\`, \`argus zgc <pid>\` against a live JVM (reviewer)
- [ ] Verify i18n keys and error messages unchanged across the 4 migrated commands

## Behavior preserved

- All 4 commands keep identical i18n keys, error messages, and exit codes
- \`ThreadsCommand\` keeps the outer-level \`InterruptedException\` re-interrupt
- \`ZgcCommand\` keeps its single-connection multi-MBean read pattern (uses \`resolveConnectorAddress\` rather than \`withConnection\` to avoid effectively-final lambda capture on aggregated locals)