### PR TITLE
refactor(cli): collapse ProviderRegistry's 31 typed finders into one generic find()

### DIFF
--- a/argus-cli/src/main/java/io/argus/cli/command/BuffersCommand.java
+++ b/argus-cli/src/main/java/io/argus/cli/command/BuffersCommand.java
@@ -48,7 +48,7 @@ public final class BuffersCommand implements Command {
         }
 
         String source = sourceOverride != null ? sourceOverride : config.defaultSource();
-        BuffersProvider provider = Providers.require(registry.findBuffersProvider(pid, sourceOverride), pid, messages);
+        BuffersProvider provider = Providers.require(registry.find(BuffersProvider.class, pid, sourceOverride), pid, messages);
 
         BuffersResult result = provider.getBuffers(pid);
 

--- a/argus-cli/src/main/java/io/argus/cli/command/ClassLoaderCommand.java
+++ b/argus-cli/src/main/java/io/argus/cli/command/ClassLoaderCommand.java
@@ -46,7 +46,7 @@ public final class ClassLoaderCommand implements Command {
         }
 
         String source = sourceOverride != null ? sourceOverride : config.defaultSource();
-        ClassLoaderProvider provider = Providers.require(registry.findClassLoaderProvider(pid, sourceOverride), pid, messages);
+        ClassLoaderProvider provider = Providers.require(registry.find(ClassLoaderProvider.class, pid, sourceOverride), pid, messages);
 
         ClassLoaderResult result = provider.getClassLoaders(pid);
 

--- a/argus-cli/src/main/java/io/argus/cli/command/ClassStatCommand.java
+++ b/argus-cli/src/main/java/io/argus/cli/command/ClassStatCommand.java
@@ -39,7 +39,7 @@ public final class ClassStatCommand implements Command {
         }
 
         String source = sourceOverride != null ? sourceOverride : config.defaultSource();
-        ClassStatProvider provider = Providers.require(registry.findClassStatProvider(pid, sourceOverride), pid, messages);
+        ClassStatProvider provider = Providers.require(registry.find(ClassStatProvider.class, pid, sourceOverride), pid, messages);
 
         ClassStatResult result = provider.getClassStats(pid);
 

--- a/argus-cli/src/main/java/io/argus/cli/command/CompareCommand.java
+++ b/argus-cli/src/main/java/io/argus/cli/command/CompareCommand.java
@@ -6,6 +6,7 @@ import io.argus.cli.doctor.JvmSnapshot;
 import io.argus.cli.doctor.JvmSnapshotCollector;
 import io.argus.cli.model.NmtBaseline;
 import io.argus.cli.model.NmtResult;
+import io.argus.cli.provider.NmtProvider;
 import io.argus.cli.provider.ProviderRegistry;
 import io.argus.cli.render.AnsiStyle;
 import io.argus.cli.render.RichRenderer;
@@ -326,7 +327,7 @@ public final class CompareCommand implements Command {
 
     /** Collect NMT from live JVM; returns null if no NMT provider available. */
     private static NmtResult collectNmt(long pid, ProviderRegistry registry) {
-        var provider = registry.findNmtProvider(pid, null);
+        var provider = registry.find(NmtProvider.class, pid, null);
         if (provider == null) return null;
         try {
             return provider.getNativeMemory(pid);

--- a/argus-cli/src/main/java/io/argus/cli/command/CompilerCommand.java
+++ b/argus-cli/src/main/java/io/argus/cli/command/CompilerCommand.java
@@ -40,7 +40,7 @@ public final class CompilerCommand implements Command {
         }
 
         String source = sourceOverride != null ? sourceOverride : config.defaultSource();
-        CompilerProvider provider = Providers.require(registry.findCompilerProvider(pid, sourceOverride), pid, messages);
+        CompilerProvider provider = Providers.require(registry.find(CompilerProvider.class, pid, sourceOverride), pid, messages);
 
         CompilerResult result = provider.getCompilerInfo(pid);
 

--- a/argus-cli/src/main/java/io/argus/cli/command/DeadlockCommand.java
+++ b/argus-cli/src/main/java/io/argus/cli/command/DeadlockCommand.java
@@ -46,7 +46,7 @@ public final class DeadlockCommand implements Command {
         }
 
         String source = sourceOverride != null ? sourceOverride : config.defaultSource();
-        DeadlockProvider provider = Providers.require(registry.findDeadlockProvider(pid, sourceOverride), pid, messages);
+        DeadlockProvider provider = Providers.require(registry.find(DeadlockProvider.class, pid, sourceOverride), pid, messages);
 
         DeadlockResult result = provider.detectDeadlocks(pid);
 

--- a/argus-cli/src/main/java/io/argus/cli/command/DiffCommand.java
+++ b/argus-cli/src/main/java/io/argus/cli/command/DiffCommand.java
@@ -70,7 +70,7 @@ public final class DiffCommand implements Command {
         }
 
         String source = sourceOverride != null ? sourceOverride : config.defaultSource();
-        HistoProvider provider = Providers.require(registry.findHistoProvider(pid, sourceOverride), pid, messages);
+        HistoProvider provider = Providers.require(registry.find(HistoProvider.class, pid, sourceOverride), pid, messages);
 
         System.out.println("Taking first snapshot... waiting " + intervalSeconds + "s for second snapshot");
 

--- a/argus-cli/src/main/java/io/argus/cli/command/DoctorCommand.java
+++ b/argus-cli/src/main/java/io/argus/cli/command/DoctorCommand.java
@@ -95,7 +95,7 @@ public final class DoctorCommand implements Command {
         } else if (profileLive) {
             final long targetPid = pid > 0 ? pid : ProcessHandle.current().pid();
             try {
-                ProfileProvider pp = registry.findProfileProvider(targetPid, null);
+                ProfileProvider pp = registry.find(ProfileProvider.class, targetPid, null);
                 if (pp == null) {
                     profileError = "No profile provider available for pid " + targetPid;
                 } else {

--- a/argus-cli/src/main/java/io/argus/cli/command/DynLibsCommand.java
+++ b/argus-cli/src/main/java/io/argus/cli/command/DynLibsCommand.java
@@ -41,7 +41,7 @@ public final class DynLibsCommand implements Command {
         }
 
         String source = sourceOverride != null ? sourceOverride : config.defaultSource();
-        DynLibsProvider provider = Providers.require(registry.findDynLibsProvider(pid, sourceOverride), pid, messages);
+        DynLibsProvider provider = Providers.require(registry.find(DynLibsProvider.class, pid, sourceOverride), pid, messages);
 
         DynLibsResult result = provider.getDynLibs(pid);
 

--- a/argus-cli/src/main/java/io/argus/cli/command/EnvCommand.java
+++ b/argus-cli/src/main/java/io/argus/cli/command/EnvCommand.java
@@ -39,7 +39,7 @@ public final class EnvCommand implements Command {
         }
 
         String source = sourceOverride != null ? sourceOverride : config.defaultSource();
-        EnvProvider provider = Providers.require(registry.findEnvProvider(pid, sourceOverride), pid, messages);
+        EnvProvider provider = Providers.require(registry.find(EnvProvider.class, pid, sourceOverride), pid, messages);
 
         EnvResult result = provider.getEnv(pid);
 

--- a/argus-cli/src/main/java/io/argus/cli/command/FinalizerCommand.java
+++ b/argus-cli/src/main/java/io/argus/cli/command/FinalizerCommand.java
@@ -39,7 +39,7 @@ public final class FinalizerCommand implements Command {
         }
 
         String source = sourceOverride != null ? sourceOverride : config.defaultSource();
-        FinalizerProvider provider = Providers.require(registry.findFinalizerProvider(pid, sourceOverride), pid, messages);
+        FinalizerProvider provider = Providers.require(registry.find(FinalizerProvider.class, pid, sourceOverride), pid, messages);
 
         FinalizerResult result = provider.getFinalizerInfo(pid);
 

--- a/argus-cli/src/main/java/io/argus/cli/command/FlameCommand.java
+++ b/argus-cli/src/main/java/io/argus/cli/command/FlameCommand.java
@@ -125,7 +125,7 @@ public final class FlameCommand implements Command {
                     + "/argus-flame-" + pid + formatToExtension(resolvedFmt);
         }
 
-        ProfileProvider provider = registry.findProfileProvider(pid, null);
+        ProfileProvider provider = registry.find(ProfileProvider.class, pid, null);
         if (provider == null) {
             System.err.println(messages.get("error.profile.adv.no.provider"));
             return;

--- a/argus-cli/src/main/java/io/argus/cli/command/GcCauseCommand.java
+++ b/argus-cli/src/main/java/io/argus/cli/command/GcCauseCommand.java
@@ -40,7 +40,7 @@ public final class GcCauseCommand implements Command {
         }
 
         String source = sourceOverride != null ? sourceOverride : config.defaultSource();
-        GcCauseProvider provider = Providers.require(registry.findGcCauseProvider(pid, sourceOverride), pid, messages);
+        GcCauseProvider provider = Providers.require(registry.find(GcCauseProvider.class, pid, sourceOverride), pid, messages);
 
         GcCauseResult result = provider.getGcCause(pid);
 

--- a/argus-cli/src/main/java/io/argus/cli/command/GcCommand.java
+++ b/argus-cli/src/main/java/io/argus/cli/command/GcCommand.java
@@ -46,7 +46,7 @@ public final class GcCommand implements Command {
         }
 
         String source = sourceOverride != null ? sourceOverride : config.defaultSource();
-        GcProvider provider = Providers.require(registry.findGcProvider(pid, sourceOverride), pid, messages);
+        GcProvider provider = Providers.require(registry.find(GcProvider.class, pid, sourceOverride), pid, messages);
 
         GcResult result = provider.getGcInfo(pid);
 

--- a/argus-cli/src/main/java/io/argus/cli/command/GcNewCommand.java
+++ b/argus-cli/src/main/java/io/argus/cli/command/GcNewCommand.java
@@ -48,7 +48,7 @@ public final class GcNewCommand implements Command {
         }
 
         String source = sourceOverride != null ? sourceOverride : config.defaultSource();
-        GcNewProvider provider = Providers.require(registry.findGcNewProvider(pid, sourceOverride), pid, messages);
+        GcNewProvider provider = Providers.require(registry.find(GcNewProvider.class, pid, sourceOverride), pid, messages);
 
         GcNewResult result = provider.getGcNew(pid);
 
@@ -109,7 +109,7 @@ public final class GcNewCommand implements Command {
                             + AnsiStyle.style(useColor, AnsiStyle.RESET), WIDTH));
             System.out.println(RichRenderer.emptyLine(WIDTH));
 
-            GcAgeProvider ageProvider = registry.findGcAgeProvider(pid, sourceOverride);
+            GcAgeProvider ageProvider = registry.find(GcAgeProvider.class, pid, sourceOverride);
             if (ageProvider == null) {
                 System.out.println(RichRenderer.boxLine(
                         "  " + messages.get("gcnew.age.unavailable"), WIDTH));

--- a/argus-cli/src/main/java/io/argus/cli/command/GcUtilCommand.java
+++ b/argus-cli/src/main/java/io/argus/cli/command/GcUtilCommand.java
@@ -54,7 +54,7 @@ public final class GcUtilCommand implements Command {
         }
 
         String source = sourceOverride != null ? sourceOverride : config.defaultSource();
-        GcUtilProvider provider = Providers.require(registry.findGcUtilProvider(pid, sourceOverride), pid, messages);
+        GcUtilProvider provider = Providers.require(registry.find(GcUtilProvider.class, pid, sourceOverride), pid, messages);
 
         if (watchInterval > 0) {
             runWatchMode(pid, provider, source, useColor, watchInterval, messages);

--- a/argus-cli/src/main/java/io/argus/cli/command/HeapCommand.java
+++ b/argus-cli/src/main/java/io/argus/cli/command/HeapCommand.java
@@ -51,7 +51,7 @@ public final class HeapCommand implements Command {
         }
 
         String source = sourceOverride != null ? sourceOverride : config.defaultSource();
-        HeapProvider provider = Providers.require(registry.findHeapProvider(pid, sourceOverride), pid, messages);
+        HeapProvider provider = Providers.require(registry.find(HeapProvider.class, pid, sourceOverride), pid, messages);
 
         HeapResult result = provider.getHeapInfo(pid);
 
@@ -62,7 +62,7 @@ public final class HeapCommand implements Command {
 
         // Optionally fetch GC data for enriched output
         GcResult gcResult = null;
-        GcProvider gcProvider = registry.findGcProvider(pid, sourceOverride);
+        GcProvider gcProvider = registry.find(GcProvider.class, pid, sourceOverride);
         if (gcProvider != null) {
             try { gcResult = gcProvider.getGcInfo(pid); } catch (Exception ignored) {}
         }

--- a/argus-cli/src/main/java/io/argus/cli/command/HeapDumpCommand.java
+++ b/argus-cli/src/main/java/io/argus/cli/command/HeapDumpCommand.java
@@ -114,7 +114,7 @@ public final class HeapDumpCommand implements Command {
             }
         }
 
-        HeapDumpProvider provider = Providers.require(registry.findHeapDumpProvider(pid, sourceOverride), pid, messages);
+        HeapDumpProvider provider = Providers.require(registry.find(HeapDumpProvider.class, pid, sourceOverride), pid, messages);
 
         HeapDumpResult result = provider.heapDump(pid, filePath, liveOnly);
 

--- a/argus-cli/src/main/java/io/argus/cli/command/HistoCommand.java
+++ b/argus-cli/src/main/java/io/argus/cli/command/HistoCommand.java
@@ -51,7 +51,7 @@ public final class HistoCommand implements Command {
         }
 
         String source = sourceOverride != null ? sourceOverride : config.defaultSource();
-        HistoProvider provider = Providers.require(registry.findHistoProvider(pid, sourceOverride), pid, messages);
+        HistoProvider provider = Providers.require(registry.find(HistoProvider.class, pid, sourceOverride), pid, messages);
 
         HistoResult result = provider.getHistogram(pid, topN);
 

--- a/argus-cli/src/main/java/io/argus/cli/command/InfoCommand.java
+++ b/argus-cli/src/main/java/io/argus/cli/command/InfoCommand.java
@@ -47,7 +47,7 @@ public final class InfoCommand implements Command {
             }
         }
 
-        InfoProvider provider = Providers.require(registry.findInfoProvider(pid, sourceOverride), pid, messages);
+        InfoProvider provider = Providers.require(registry.find(InfoProvider.class, pid, sourceOverride), pid, messages);
 
         InfoResult result = provider.getVmInfo(pid);
 

--- a/argus-cli/src/main/java/io/argus/cli/command/JfrCommand.java
+++ b/argus-cli/src/main/java/io/argus/cli/command/JfrCommand.java
@@ -63,7 +63,7 @@ public final class JfrCommand implements Command {
             }
         }
 
-        JfrProvider provider = Providers.require(registry.findJfrProvider(pid, sourceOverride), pid, messages);
+        JfrProvider provider = Providers.require(registry.find(JfrProvider.class, pid, sourceOverride), pid, messages);
 
         JfrResult result;
         switch (subcommand) {

--- a/argus-cli/src/main/java/io/argus/cli/command/LoggerCommand.java
+++ b/argus-cli/src/main/java/io/argus/cli/command/LoggerCommand.java
@@ -61,7 +61,7 @@ public final class LoggerCommand implements Command {
             }
         }
 
-        LoggerProvider provider = Providers.require(registry.findLoggerProvider(pid, sourceOverride), pid, messages);
+        LoggerProvider provider = Providers.require(registry.find(LoggerProvider.class, pid, sourceOverride), pid, messages);
 
         // Set mode: change log level
         if (loggerName != null && level != null) {

--- a/argus-cli/src/main/java/io/argus/cli/command/MetaspaceCommand.java
+++ b/argus-cli/src/main/java/io/argus/cli/command/MetaspaceCommand.java
@@ -40,7 +40,7 @@ public final class MetaspaceCommand implements Command {
         }
 
         String source = sourceOverride != null ? sourceOverride : config.defaultSource();
-        MetaspaceProvider provider = Providers.require(registry.findMetaspaceProvider(pid, sourceOverride), pid, messages);
+        MetaspaceProvider provider = Providers.require(registry.find(MetaspaceProvider.class, pid, sourceOverride), pid, messages);
 
         MetaspaceResult result = provider.getMetaspaceInfo(pid);
 

--- a/argus-cli/src/main/java/io/argus/cli/command/NmtCommand.java
+++ b/argus-cli/src/main/java/io/argus/cli/command/NmtCommand.java
@@ -71,7 +71,7 @@ public final class NmtCommand implements Command {
             }
         }
 
-        NmtProvider provider = Providers.require(registry.findNmtProvider(pid, sourceOverride), pid, messages);
+        NmtProvider provider = Providers.require(registry.find(NmtProvider.class, pid, sourceOverride), pid, messages);
 
         // Watch mode — live delta loop, short-circuits everything else
         if (watchInterval > 0) {

--- a/argus-cli/src/main/java/io/argus/cli/command/PoolCommand.java
+++ b/argus-cli/src/main/java/io/argus/cli/command/PoolCommand.java
@@ -46,7 +46,7 @@ public final class PoolCommand implements Command {
         }
 
         String source = sourceOverride != null ? sourceOverride : config.defaultSource();
-        PoolProvider provider = Providers.require(registry.findPoolProvider(pid, sourceOverride), pid, messages);
+        PoolProvider provider = Providers.require(registry.find(PoolProvider.class, pid, sourceOverride), pid, messages);
 
         PoolResult result = provider.getPoolInfo(pid);
 

--- a/argus-cli/src/main/java/io/argus/cli/command/ProfileCommand.java
+++ b/argus-cli/src/main/java/io/argus/cli/command/ProfileCommand.java
@@ -245,7 +245,7 @@ public final class ProfileCommand implements Command {
             return;
         }
 
-        ProfileProvider provider = Providers.require(registry.findProfileProvider(pid, sourceOverride), pid, messages);
+        ProfileProvider provider = Providers.require(registry.find(ProfileProvider.class, pid, sourceOverride), pid, messages);
 
         boolean useColor = config.color();
 
@@ -376,7 +376,7 @@ public final class ProfileCommand implements Command {
             }
         }
 
-        ProfileProvider provider = Providers.require(registry.findProfileProvider(pid, sourceOverride), pid, messages);
+        ProfileProvider provider = Providers.require(registry.find(ProfileProvider.class, pid, sourceOverride), pid, messages);
 
         // Create output dir if needed
         final String snapDir = outputDir;
@@ -654,7 +654,7 @@ public final class ProfileCommand implements Command {
             futures.add(pool.submit(new Callable<PidOutcome>() {
                 @Override
                 public PidOutcome call() {
-                    ProfileProvider prov = registry.findProfileProvider(fp, finalSource);
+                    ProfileProvider prov = registry.find(ProfileProvider.class, fp, finalSource);
                     if (prov == null) {
                         return new PidOutcome(fp,
                                 ProfileResult.error(messages.get("error.provider.none", fp)), null);
@@ -829,7 +829,7 @@ public final class ProfileCommand implements Command {
             return;
         }
 
-        ProfileProvider provider = Providers.require(registry.findProfileProvider(pid, sourceOverride), pid, messages);
+        ProfileProvider provider = Providers.require(registry.find(ProfileProvider.class, pid, sourceOverride), pid, messages);
 
         ProfileResult result;
         switch (subcommand) {

--- a/argus-cli/src/main/java/io/argus/cli/command/PsCommand.java
+++ b/argus-cli/src/main/java/io/argus/cli/command/PsCommand.java
@@ -34,7 +34,7 @@ public final class PsCommand implements Command {
         boolean useColor = config.color();
         boolean json = "json".equals(config.format()) || hasFlag(args, "--format=json");
 
-        ProcessProvider provider = registry.findProcessProvider();
+        ProcessProvider provider = registry.find(ProcessProvider.class);
         if (provider == null) {
             System.err.println(messages.get("error.provider.none", "ps"));
             return;

--- a/argus-cli/src/main/java/io/argus/cli/command/ReportCommand.java
+++ b/argus-cli/src/main/java/io/argus/cli/command/ReportCommand.java
@@ -71,32 +71,32 @@ public final class ReportCommand implements Command {
         ThreadResult threadResult = null;
         HistoResult histoResult = null;
 
-        InfoProvider infoProvider = registry.findInfoProvider(pid, sourceOverride);
+        InfoProvider infoProvider = registry.find(InfoProvider.class, pid, sourceOverride);
         if (infoProvider != null) {
             try { infoResult = infoProvider.getVmInfo(pid); } catch (Exception ignored) {}
         }
 
-        HeapProvider heapProvider = registry.findHeapProvider(pid, sourceOverride);
+        HeapProvider heapProvider = registry.find(HeapProvider.class, pid, sourceOverride);
         if (heapProvider != null) {
             try { heapResult = heapProvider.getHeapInfo(pid); } catch (Exception ignored) {}
         }
 
-        GcProvider gcProvider = registry.findGcProvider(pid, sourceOverride);
+        GcProvider gcProvider = registry.find(GcProvider.class, pid, sourceOverride);
         if (gcProvider != null) {
             try { gcResult = gcProvider.getGcInfo(pid); } catch (Exception ignored) {}
         }
 
-        GcUtilProvider gcUtilProvider = registry.findGcUtilProvider(pid, sourceOverride);
+        GcUtilProvider gcUtilProvider = registry.find(GcUtilProvider.class, pid, sourceOverride);
         if (gcUtilProvider != null) {
             try { gcUtilResult = gcUtilProvider.getGcUtil(pid); } catch (Exception ignored) {}
         }
 
-        ThreadProvider threadProvider = registry.findThreadProvider(pid, sourceOverride);
+        ThreadProvider threadProvider = registry.find(ThreadProvider.class, pid, sourceOverride);
         if (threadProvider != null) {
             try { threadResult = threadProvider.getThreadDump(pid); } catch (Exception ignored) {}
         }
 
-        HistoProvider histoProvider = registry.findHistoProvider(pid, sourceOverride);
+        HistoProvider histoProvider = registry.find(HistoProvider.class, pid, sourceOverride);
         if (histoProvider != null) {
             try { histoResult = histoProvider.getHistogram(pid, HISTO_TOP); } catch (Exception ignored) {}
         }

--- a/argus-cli/src/main/java/io/argus/cli/command/SearchClassCommand.java
+++ b/argus-cli/src/main/java/io/argus/cli/command/SearchClassCommand.java
@@ -63,7 +63,7 @@ public final class SearchClassCommand implements Command {
             }
         }
 
-        SearchClassProvider provider = Providers.require(registry.findSearchClassProvider(pid, sourceOverride), pid, messages);
+        SearchClassProvider provider = Providers.require(registry.find(SearchClassProvider.class, pid, sourceOverride), pid, messages);
 
         SearchClassResult result = provider.searchClasses(pid, pattern);
 

--- a/argus-cli/src/main/java/io/argus/cli/command/StringTableCommand.java
+++ b/argus-cli/src/main/java/io/argus/cli/command/StringTableCommand.java
@@ -39,7 +39,7 @@ public final class StringTableCommand implements Command {
         }
 
         String source = sourceOverride != null ? sourceOverride : config.defaultSource();
-        StringTableProvider provider = Providers.require(registry.findStringTableProvider(pid, sourceOverride), pid, messages);
+        StringTableProvider provider = Providers.require(registry.find(StringTableProvider.class, pid, sourceOverride), pid, messages);
 
         StringTableResult result = provider.getStringTableInfo(pid);
 

--- a/argus-cli/src/main/java/io/argus/cli/command/SuggestCommand.java
+++ b/argus-cli/src/main/java/io/argus/cli/command/SuggestCommand.java
@@ -98,7 +98,7 @@ public final class SuggestCommand implements Command {
                 if (profileSnapshotPath != null) {
                     snapshot = ProfileSnapshot.load(Path.of(profileSnapshotPath));
                 } else {
-                    ProfileProvider provider = registry.findProfileProvider(pid, null);
+                    ProfileProvider provider = registry.find(ProfileProvider.class, pid, null);
                     if (provider == null) {
                         profileWarning = messages.get("suggest.profile.no.snapshot");
                         snapshot = null;

--- a/argus-cli/src/main/java/io/argus/cli/command/SymbolTableCommand.java
+++ b/argus-cli/src/main/java/io/argus/cli/command/SymbolTableCommand.java
@@ -39,7 +39,7 @@ public final class SymbolTableCommand implements Command {
         }
 
         String source = sourceOverride != null ? sourceOverride : config.defaultSource();
-        SymbolTableProvider provider = Providers.require(registry.findSymbolTableProvider(pid, sourceOverride), pid, messages);
+        SymbolTableProvider provider = Providers.require(registry.find(SymbolTableProvider.class, pid, sourceOverride), pid, messages);
 
         SymbolTableResult result = provider.getSymbolTableInfo(pid);
 

--- a/argus-cli/src/main/java/io/argus/cli/command/SysPropsCommand.java
+++ b/argus-cli/src/main/java/io/argus/cli/command/SysPropsCommand.java
@@ -51,7 +51,7 @@ public final class SysPropsCommand implements Command {
             }
         }
 
-        SysPropsProvider provider = Providers.require(registry.findSysPropsProvider(pid, sourceOverride), pid, messages);
+        SysPropsProvider provider = Providers.require(registry.find(SysPropsProvider.class, pid, sourceOverride), pid, messages);
 
         SysPropsResult result = provider.getSystemProperties(pid);
 

--- a/argus-cli/src/main/java/io/argus/cli/command/ThreadDumpCommand.java
+++ b/argus-cli/src/main/java/io/argus/cli/command/ThreadDumpCommand.java
@@ -59,7 +59,7 @@ public final class ThreadDumpCommand implements Command {
         }
 
         String source = sourceOverride != null ? sourceOverride : config.defaultSource();
-        ThreadDumpProvider provider = Providers.require(registry.findThreadDumpProvider(pid, sourceOverride), pid, messages);
+        ThreadDumpProvider provider = Providers.require(registry.find(ThreadDumpProvider.class, pid, sourceOverride), pid, messages);
 
         ThreadDumpResult result = provider.dumpThreads(pid);
 

--- a/argus-cli/src/main/java/io/argus/cli/command/ThreadsCommand.java
+++ b/argus-cli/src/main/java/io/argus/cli/command/ThreadsCommand.java
@@ -83,7 +83,7 @@ public final class ThreadsCommand implements Command {
         }
 
         String source = sourceOverride != null ? sourceOverride : config.defaultSource();
-        ThreadProvider provider = Providers.require(registry.findThreadProvider(pid, sourceOverride), pid, messages);
+        ThreadProvider provider = Providers.require(registry.find(ThreadProvider.class, pid, sourceOverride), pid, messages);
 
         ThreadResult result = provider.getThreadDump(pid);
 

--- a/argus-cli/src/main/java/io/argus/cli/command/VmFlagCommand.java
+++ b/argus-cli/src/main/java/io/argus/cli/command/VmFlagCommand.java
@@ -59,7 +59,7 @@ public final class VmFlagCommand implements Command {
             }
         }
 
-        VmFlagProvider provider = Providers.require(registry.findVmFlagProvider(pid, sourceOverride), pid, messages);
+        VmFlagProvider provider = Providers.require(registry.find(VmFlagProvider.class, pid, sourceOverride), pid, messages);
 
         if (setExpr != null) {
             executeSet(pid, setExpr, provider, useColor, messages);

--- a/argus-cli/src/main/java/io/argus/cli/provider/ProviderRegistry.java
+++ b/argus-cli/src/main/java/io/argus/cli/provider/ProviderRegistry.java
@@ -4,17 +4,17 @@ import io.argus.cli.provider.agent.AgentClient;
 import io.argus.cli.provider.agent.AgentGcProvider;
 import io.argus.cli.provider.agent.AgentHeapProvider;
 import io.argus.cli.provider.agent.AgentThreadProvider;
+import io.argus.cli.provider.jdk.AsProfProvider;
 import io.argus.cli.provider.jdk.JdkBuffersProvider;
+import io.argus.cli.provider.jdk.JdkClassLoaderProvider;
 import io.argus.cli.provider.jdk.JdkClassStatProvider;
-import io.argus.cli.provider.jdk.JdkLoggerProvider;
-import io.argus.cli.provider.jdk.JdkSearchClassProvider;
 import io.argus.cli.provider.jdk.JdkCompilerProvider;
 import io.argus.cli.provider.jdk.JdkDeadlockProvider;
 import io.argus.cli.provider.jdk.JdkDynLibsProvider;
 import io.argus.cli.provider.jdk.JdkEnvProvider;
 import io.argus.cli.provider.jdk.JdkFinalizerProvider;
-import io.argus.cli.provider.jdk.JdkGcCauseProvider;
 import io.argus.cli.provider.jdk.JdkGcAgeProvider;
+import io.argus.cli.provider.jdk.JdkGcCauseProvider;
 import io.argus.cli.provider.jdk.JdkGcNewProvider;
 import io.argus.cli.provider.jdk.JdkGcProvider;
 import io.argus.cli.provider.jdk.JdkGcUtilProvider;
@@ -22,23 +22,25 @@ import io.argus.cli.provider.jdk.JdkHeapDumpProvider;
 import io.argus.cli.provider.jdk.JdkHeapProvider;
 import io.argus.cli.provider.jdk.JdkHistoProvider;
 import io.argus.cli.provider.jdk.JdkInfoProvider;
-import io.argus.cli.provider.jdk.JdkClassLoaderProvider;
-import io.argus.cli.provider.jdk.AsProfProvider;
 import io.argus.cli.provider.jdk.JdkJfrProvider;
+import io.argus.cli.provider.jdk.JdkLoggerProvider;
 import io.argus.cli.provider.jdk.JdkMetaspaceProvider;
 import io.argus.cli.provider.jdk.JdkNmtProvider;
 import io.argus.cli.provider.jdk.JdkPoolProvider;
 import io.argus.cli.provider.jdk.JdkProcessProvider;
+import io.argus.cli.provider.jdk.JdkSearchClassProvider;
 import io.argus.cli.provider.jdk.JdkStringTableProvider;
 import io.argus.cli.provider.jdk.JdkSymbolTableProvider;
-import io.argus.cli.provider.jdk.JdkThreadDumpProvider;
 import io.argus.cli.provider.jdk.JdkSysPropsProvider;
+import io.argus.cli.provider.jdk.JdkThreadDumpProvider;
 import io.argus.cli.provider.jdk.JdkThreadProvider;
 import io.argus.cli.provider.jdk.JdkVmFlagProvider;
 
 import java.util.ArrayList;
 import java.util.Comparator;
+import java.util.IdentityHashMap;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Central registry that holds all diagnostic providers and selects the best available
@@ -54,37 +56,8 @@ import java.util.List;
  */
 public final class ProviderRegistry {
 
-    private final List<HistoProvider> histoProviders = new ArrayList<>();
-    private final List<ThreadProvider> threadProviders = new ArrayList<>();
-    private final List<GcProvider> gcProviders = new ArrayList<>();
-    private final List<HeapProvider> heapProviders = new ArrayList<>();
-    private final List<InfoProvider> infoProviders = new ArrayList<>();
-    private final List<ProcessProvider> processProviders = new ArrayList<>();
-    private final List<GcUtilProvider> gcUtilProviders = new ArrayList<>();
-    private final List<SysPropsProvider> sysPropsProviders = new ArrayList<>();
-    private final List<VmFlagProvider> vmFlagProviders = new ArrayList<>();
-    private final List<NmtProvider> nmtProviders = new ArrayList<>();
-    private final List<ClassLoaderProvider> classLoaderProviders = new ArrayList<>();
-    private final List<JfrProvider> jfrProviders = new ArrayList<>();
-    private final List<ProfileProvider> profileProviders = new ArrayList<>();
-    private final List<HeapDumpProvider> heapDumpProviders = new ArrayList<>();
-    private final List<DeadlockProvider> deadlockProviders = new ArrayList<>();
-    private final List<EnvProvider> envProviders = new ArrayList<>();
-    private final List<CompilerProvider> compilerProviders = new ArrayList<>();
-    private final List<FinalizerProvider> finalizerProviders = new ArrayList<>();
-    private final List<StringTableProvider> stringTableProviders = new ArrayList<>();
-    private final List<PoolProvider> poolProviders = new ArrayList<>();
-    private final List<GcCauseProvider> gcCauseProviders = new ArrayList<>();
-    private final List<MetaspaceProvider> metaspaceProviders = new ArrayList<>();
-    private final List<DynLibsProvider> dynLibsProviders = new ArrayList<>();
-    private final List<ClassStatProvider> classStatProviders = new ArrayList<>();
-    private final List<GcNewProvider> gcNewProviders = new ArrayList<>();
-    private final List<GcAgeProvider> gcAgeProviders = new ArrayList<>();
-    private final List<SymbolTableProvider> symbolTableProviders = new ArrayList<>();
-    private final List<ThreadDumpProvider> threadDumpProviders = new ArrayList<>();
-    private final List<BuffersProvider> buffersProviders = new ArrayList<>();
-    private final List<LoggerProvider> loggerProviders = new ArrayList<>();
-    private final List<SearchClassProvider> searchClassProviders = new ArrayList<>();
+    private final Map<Class<? extends DiagnosticProvider>, List<? extends DiagnosticProvider>> byCapability =
+            new IdentityHashMap<>();
 
     /**
      * Creates a registry with all built-in JDK providers.
@@ -105,270 +78,75 @@ public final class ProviderRegistry {
         registerAgentProviders(agentHost, agentPort);
     }
 
-    // -------------------------------------------------------------------------
-    // Provider registration
-    // -------------------------------------------------------------------------
+    /**
+     * Returns the highest-priority available provider for the given capability, or {@code null}.
+     *
+     * @param capability     capability interface class (e.g. {@code HistoProvider.class})
+     * @param pid            target process ID
+     * @param sourceOverride "auto" or {@code null} for automatic selection; otherwise a source name
+     */
+    public <T extends DiagnosticProvider> T find(Class<T> capability, long pid, String sourceOverride) {
+        @SuppressWarnings("unchecked")
+        List<T> candidates = (List<T>) byCapability.get(capability);
+        if (candidates == null) {
+            return null;
+        }
+        return findBest(candidates, pid, sourceOverride);
+    }
+
+    /**
+     * Convenience overload for capabilities where the PID is irrelevant (e.g. {@link ProcessProvider}).
+     */
+    public <T extends DiagnosticProvider> T find(Class<T> capability) {
+        return find(capability, 0L, null);
+    }
+
+    private <T extends DiagnosticProvider> void register(Class<T> capability, T provider) {
+        @SuppressWarnings("unchecked")
+        List<T> list = (List<T>) byCapability.computeIfAbsent(capability, k -> new ArrayList<T>());
+        list.add(provider);
+    }
 
     private void registerJdkProviders() {
-        histoProviders.add(new JdkHistoProvider());
-        threadProviders.add(new JdkThreadProvider());
-        gcProviders.add(new JdkGcProvider());
-        heapProviders.add(new JdkHeapProvider());
-        infoProviders.add(new JdkInfoProvider());
-        processProviders.add(new JdkProcessProvider());
-        gcUtilProviders.add(new JdkGcUtilProvider());
-        sysPropsProviders.add(new JdkSysPropsProvider());
-        vmFlagProviders.add(new JdkVmFlagProvider());
-        nmtProviders.add(new JdkNmtProvider());
-        classLoaderProviders.add(new JdkClassLoaderProvider());
-        jfrProviders.add(new JdkJfrProvider());
-        profileProviders.add(new AsProfProvider());
-        heapDumpProviders.add(new JdkHeapDumpProvider());
-        deadlockProviders.add(new JdkDeadlockProvider());
-        envProviders.add(new JdkEnvProvider());
-        compilerProviders.add(new JdkCompilerProvider());
-        finalizerProviders.add(new JdkFinalizerProvider());
-        stringTableProviders.add(new JdkStringTableProvider());
-        poolProviders.add(new JdkPoolProvider());
-        gcCauseProviders.add(new JdkGcCauseProvider());
-        metaspaceProviders.add(new JdkMetaspaceProvider());
-        dynLibsProviders.add(new JdkDynLibsProvider());
-        classStatProviders.add(new JdkClassStatProvider());
-        gcNewProviders.add(new JdkGcNewProvider());
-        gcAgeProviders.add(new JdkGcAgeProvider());
-        symbolTableProviders.add(new JdkSymbolTableProvider());
-        threadDumpProviders.add(new JdkThreadDumpProvider());
-        buffersProviders.add(new JdkBuffersProvider());
-        loggerProviders.add(new JdkLoggerProvider());
-        searchClassProviders.add(new JdkSearchClassProvider());
+        register(HistoProvider.class, new JdkHistoProvider());
+        register(ThreadProvider.class, new JdkThreadProvider());
+        register(GcProvider.class, new JdkGcProvider());
+        register(HeapProvider.class, new JdkHeapProvider());
+        register(InfoProvider.class, new JdkInfoProvider());
+        register(ProcessProvider.class, new JdkProcessProvider());
+        register(GcUtilProvider.class, new JdkGcUtilProvider());
+        register(SysPropsProvider.class, new JdkSysPropsProvider());
+        register(VmFlagProvider.class, new JdkVmFlagProvider());
+        register(NmtProvider.class, new JdkNmtProvider());
+        register(ClassLoaderProvider.class, new JdkClassLoaderProvider());
+        register(JfrProvider.class, new JdkJfrProvider());
+        register(ProfileProvider.class, new AsProfProvider());
+        register(HeapDumpProvider.class, new JdkHeapDumpProvider());
+        register(DeadlockProvider.class, new JdkDeadlockProvider());
+        register(EnvProvider.class, new JdkEnvProvider());
+        register(CompilerProvider.class, new JdkCompilerProvider());
+        register(FinalizerProvider.class, new JdkFinalizerProvider());
+        register(StringTableProvider.class, new JdkStringTableProvider());
+        register(PoolProvider.class, new JdkPoolProvider());
+        register(GcCauseProvider.class, new JdkGcCauseProvider());
+        register(MetaspaceProvider.class, new JdkMetaspaceProvider());
+        register(DynLibsProvider.class, new JdkDynLibsProvider());
+        register(ClassStatProvider.class, new JdkClassStatProvider());
+        register(GcNewProvider.class, new JdkGcNewProvider());
+        register(GcAgeProvider.class, new JdkGcAgeProvider());
+        register(SymbolTableProvider.class, new JdkSymbolTableProvider());
+        register(ThreadDumpProvider.class, new JdkThreadDumpProvider());
+        register(BuffersProvider.class, new JdkBuffersProvider());
+        register(LoggerProvider.class, new JdkLoggerProvider());
+        register(SearchClassProvider.class, new JdkSearchClassProvider());
     }
 
     private void registerAgentProviders(String host, int port) {
         AgentClient client = new AgentClient(host, port);
-        threadProviders.add(new AgentThreadProvider(client));
-        gcProviders.add(new AgentGcProvider(client));
-        heapProviders.add(new AgentHeapProvider(client));
+        register(ThreadProvider.class, new AgentThreadProvider(client));
+        register(GcProvider.class, new AgentGcProvider(client));
+        register(HeapProvider.class, new AgentHeapProvider(client));
     }
-
-    // -------------------------------------------------------------------------
-    // Provider lookup
-    // -------------------------------------------------------------------------
-
-    /**
-     * Finds the best HistoProvider for the given PID.
-     *
-     * @param pid            target process ID
-     * @param sourceOverride "auto" or null for automatic selection; otherwise a source name
-     * @return the best available provider, or {@code null} if none qualify
-     */
-    public HistoProvider findHistoProvider(long pid, String sourceOverride) {
-        return findBest(histoProviders, pid, sourceOverride);
-    }
-
-    /**
-     * Finds the best ThreadProvider for the given PID.
-     */
-    public ThreadProvider findThreadProvider(long pid, String sourceOverride) {
-        return findBest(threadProviders, pid, sourceOverride);
-    }
-
-    /**
-     * Finds the best GcProvider for the given PID.
-     */
-    public GcProvider findGcProvider(long pid, String sourceOverride) {
-        return findBest(gcProviders, pid, sourceOverride);
-    }
-
-    /**
-     * Finds the best HeapProvider for the given PID.
-     */
-    public HeapProvider findHeapProvider(long pid, String sourceOverride) {
-        return findBest(heapProviders, pid, sourceOverride);
-    }
-
-    /**
-     * Finds the best InfoProvider for the given PID.
-     */
-    public InfoProvider findInfoProvider(long pid, String sourceOverride) {
-        return findBest(infoProviders, pid, sourceOverride);
-    }
-
-    /**
-     * Finds the best ProcessProvider. PID is irrelevant for process listing.
-     */
-    public ProcessProvider findProcessProvider() {
-        return findBest(processProviders, 0L, null);
-    }
-
-    /**
-     * Finds the best GcUtilProvider for the given PID.
-     */
-    public GcUtilProvider findGcUtilProvider(long pid, String sourceOverride) {
-        return findBest(gcUtilProviders, pid, sourceOverride);
-    }
-
-    /**
-     * Finds the best SysPropsProvider for the given PID.
-     */
-    public SysPropsProvider findSysPropsProvider(long pid, String sourceOverride) {
-        return findBest(sysPropsProviders, pid, sourceOverride);
-    }
-
-    /**
-     * Finds the best VmFlagProvider for the given PID.
-     */
-    public VmFlagProvider findVmFlagProvider(long pid, String sourceOverride) {
-        return findBest(vmFlagProviders, pid, sourceOverride);
-    }
-
-    /**
-     * Finds the best NmtProvider for the given PID.
-     */
-    public NmtProvider findNmtProvider(long pid, String sourceOverride) {
-        return findBest(nmtProviders, pid, sourceOverride);
-    }
-
-    /**
-     * Finds the best ClassLoaderProvider for the given PID.
-     */
-    public ClassLoaderProvider findClassLoaderProvider(long pid, String sourceOverride) {
-        return findBest(classLoaderProviders, pid, sourceOverride);
-    }
-
-    /**
-     * Finds the best JfrProvider for the given PID.
-     */
-    public JfrProvider findJfrProvider(long pid, String sourceOverride) {
-        return findBest(jfrProviders, pid, sourceOverride);
-    }
-
-    /**
-     * Finds the best ProfileProvider for the given PID.
-     */
-    public ProfileProvider findProfileProvider(long pid, String sourceOverride) {
-        return findBest(profileProviders, pid, sourceOverride);
-    }
-
-    /**
-     * Finds the best HeapDumpProvider for the given PID.
-     */
-    public HeapDumpProvider findHeapDumpProvider(long pid, String sourceOverride) {
-        return findBest(heapDumpProviders, pid, sourceOverride);
-    }
-
-    /**
-     * Finds the best DeadlockProvider for the given PID.
-     */
-    public DeadlockProvider findDeadlockProvider(long pid, String sourceOverride) {
-        return findBest(deadlockProviders, pid, sourceOverride);
-    }
-
-    /**
-     * Finds the best EnvProvider for the given PID.
-     */
-    public EnvProvider findEnvProvider(long pid, String sourceOverride) {
-        return findBest(envProviders, pid, sourceOverride);
-    }
-
-    /**
-     * Finds the best CompilerProvider for the given PID.
-     */
-    public CompilerProvider findCompilerProvider(long pid, String sourceOverride) {
-        return findBest(compilerProviders, pid, sourceOverride);
-    }
-
-    /**
-     * Finds the best FinalizerProvider for the given PID.
-     */
-    public FinalizerProvider findFinalizerProvider(long pid, String sourceOverride) {
-        return findBest(finalizerProviders, pid, sourceOverride);
-    }
-
-    /**
-     * Finds the best StringTableProvider for the given PID.
-     */
-    public StringTableProvider findStringTableProvider(long pid, String sourceOverride) {
-        return findBest(stringTableProviders, pid, sourceOverride);
-    }
-
-    /**
-     * Finds the best PoolProvider for the given PID.
-     */
-    public PoolProvider findPoolProvider(long pid, String sourceOverride) {
-        return findBest(poolProviders, pid, sourceOverride);
-    }
-
-    /**
-     * Finds the best GcCauseProvider for the given PID.
-     */
-    public GcCauseProvider findGcCauseProvider(long pid, String sourceOverride) {
-        return findBest(gcCauseProviders, pid, sourceOverride);
-    }
-
-    /**
-     * Finds the best MetaspaceProvider for the given PID.
-     */
-    public MetaspaceProvider findMetaspaceProvider(long pid, String sourceOverride) {
-        return findBest(metaspaceProviders, pid, sourceOverride);
-    }
-
-    /**
-     * Finds the best DynLibsProvider for the given PID.
-     */
-    public DynLibsProvider findDynLibsProvider(long pid, String sourceOverride) {
-        return findBest(dynLibsProviders, pid, sourceOverride);
-    }
-
-    /**
-     * Finds the best ClassStatProvider for the given PID.
-     */
-    public ClassStatProvider findClassStatProvider(long pid, String sourceOverride) {
-        return findBest(classStatProviders, pid, sourceOverride);
-    }
-
-    /**
-     * Finds the best GcNewProvider for the given PID.
-     */
-    public GcNewProvider findGcNewProvider(long pid, String sourceOverride) {
-        return findBest(gcNewProviders, pid, sourceOverride);
-    }
-
-    /**
-     * Finds the best GcAgeProvider for the given PID.
-     */
-    public GcAgeProvider findGcAgeProvider(long pid, String sourceOverride) {
-        return findBest(gcAgeProviders, pid, sourceOverride);
-    }
-
-    /**
-     * Finds the best SymbolTableProvider for the given PID.
-     */
-    public SymbolTableProvider findSymbolTableProvider(long pid, String sourceOverride) {
-        return findBest(symbolTableProviders, pid, sourceOverride);
-    }
-
-    /**
-     * Finds the best ThreadDumpProvider for the given PID.
-     */
-    public ThreadDumpProvider findThreadDumpProvider(long pid, String sourceOverride) {
-        return findBest(threadDumpProviders, pid, sourceOverride);
-    }
-
-    public BuffersProvider findBuffersProvider(long pid, String sourceOverride) {
-        return findBest(buffersProviders, pid, sourceOverride);
-    }
-
-    public LoggerProvider findLoggerProvider(long pid, String sourceOverride) {
-        return findBest(loggerProviders, pid, sourceOverride);
-    }
-
-    public SearchClassProvider findSearchClassProvider(long pid, String sourceOverride) {
-        return findBest(searchClassProviders, pid, sourceOverride);
-    }
-
-    // -------------------------------------------------------------------------
-    // Generic selection logic
-    // -------------------------------------------------------------------------
 
     private <T extends DiagnosticProvider> T findBest(List<T> candidates, long pid, String sourceOverride) {
         boolean useOverride = sourceOverride != null && !sourceOverride.equalsIgnoreCase("auto");

--- a/argus-cli/src/main/java/io/argus/cli/tui/TuiApp.java
+++ b/argus-cli/src/main/java/io/argus/cli/tui/TuiApp.java
@@ -226,7 +226,7 @@ public final class TuiApp {
         execThread.setDaemon(true);
         execThread.start();
     }
-    private void refreshPs() { ProcessProvider pp=registry.findProcessProvider(); if(pp!=null) procs=pp.listProcesses(); }
+    private void refreshPs() { ProcessProvider pp=registry.find(ProcessProvider.class); if(pp!=null) procs=pp.listProcesses(); }
 
     // ═══ SAFE ROW BUILDER — all padding uses plain-text length ═══
 


### PR DESCRIPTION
## Summary

\`ProviderRegistry\` carried 31 \`List<XProvider>\` fields, 31 \`findXProvider(pid, source)\` methods, and a 31-line registration block — all 31 finders delegated to one \`findBest()\` helper. The interface was a textbook shallow surface: every line of public API mechanically restated what the type token already encoded at the call site.

Applying the deletion test: replacing 31 finders with one \`find(Class<T>, pid, source)\` removes complexity from the registry without rematerializing it in callers. Type tokens are statically known at every call site, so the migration is mechanical.

## Changes

- \`ProviderRegistry.java\`: **382 → 160 lines (−58%)**. Single \`Map<Class<? extends DiagnosticProvider>, List<…>>\` keyed by capability interface; one generic \`find(Class<T>, long, String)\` + a no-PID overload; one \`register(Class<T>, T)\` helper.
- **47 call sites across 37 files** migrated:
  - \`registry.findHistoProvider(pid, src)\` → \`registry.find(HistoProvider.class, pid, src)\`
  - \`registry.findProcessProvider()\` → \`registry.find(ProcessProvider.class)\` (no-PID overload)
- One file (\`CompareCommand\`) needed an explicit \`NmtProvider\` import — the type token had never been written there before.

Net: **−221 lines** across 38 files.

## Test plan

- [x] \`./gradlew :argus-cli:compileJava\` — green
- [x] \`./gradlew :argus-cli:test\` — green
- [ ] Smoke: spot-check \`argus histo\`, \`argus threads\`, \`argus gc\`, \`argus heap\`, \`argus ps\` against a live JVM (reviewer)

## Merge ordering

This PR overlaps with #211 (Wave 1 JmxAttachment seam) on \`MBeanCommand\`, \`SpringCommand\`, \`ThreadsCommand\`, \`ZgcCommand\`. The conflicts are mechanical (different lines in the same files). Suggested order: **merge #211 first**, then rebase this branch and resolve the trivial conflicts.