### PR TITLE
refactor(cli): move printJson from commands into model.writeJson()

### DIFF
--- a/argus-cli/src/main/java/io/argus/cli/command/BuffersCommand.java
+++ b/argus-cli/src/main/java/io/argus/cli/command/BuffersCommand.java
@@ -2,6 +2,7 @@ package io.argus.cli.command;
 
 import io.argus.cli.config.CliConfig;
 import io.argus.cli.config.Messages;
+import io.argus.cli.json.JsonOutput;
 import io.argus.cli.model.BuffersResult;
 import io.argus.cli.model.BuffersResult.BufferPool;
 import io.argus.cli.provider.BuffersProvider;
@@ -53,7 +54,7 @@ public final class BuffersCommand implements Command {
         BuffersResult result = provider.getBuffers(pid);
 
         if (json) {
-            printJson(result);
+            JsonOutput.println(result);
             return;
         }
 
@@ -113,24 +114,5 @@ public final class BuffersCommand implements Command {
 
         System.out.println(RichRenderer.emptyLine(WIDTH));
         System.out.println(RichRenderer.boxFooter(useColor, null, WIDTH));
-    }
-
-    private static void printJson(BuffersResult result) {
-        StringBuilder sb = new StringBuilder();
-        sb.append("{\"totalCount\":").append(result.totalCount());
-        sb.append(",\"totalCapacity\":").append(result.totalCapacity());
-        sb.append(",\"totalUsed\":").append(result.totalUsed());
-        sb.append(",\"pools\":[");
-        for (int i = 0; i < result.pools().size(); i++) {
-            BufferPool pool = result.pools().get(i);
-            if (i > 0) sb.append(',');
-            sb.append("{\"name\":\"").append(RichRenderer.escapeJson(pool.name())).append('"');
-            sb.append(",\"count\":").append(pool.count());
-            sb.append(",\"totalCapacity\":").append(pool.totalCapacity());
-            sb.append(",\"memoryUsed\":").append(pool.memoryUsed());
-            sb.append('}');
-        }
-        sb.append("]}");
-        System.out.println(sb);
     }
 }

--- a/argus-cli/src/main/java/io/argus/cli/command/ClassLoaderCommand.java
+++ b/argus-cli/src/main/java/io/argus/cli/command/ClassLoaderCommand.java
@@ -2,6 +2,7 @@ package io.argus.cli.command;
 
 import io.argus.cli.config.CliConfig;
 import io.argus.cli.config.Messages;
+import io.argus.cli.json.JsonOutput;
 import io.argus.cli.model.ClassLoaderResult;
 import io.argus.cli.model.ClassLoaderResult.ClassLoaderInfo;
 import io.argus.cli.provider.ClassLoaderProvider;
@@ -51,7 +52,7 @@ public final class ClassLoaderCommand implements Command {
         ClassLoaderResult result = provider.getClassLoaders(pid);
 
         if (json) {
-            printJson(result);
+            JsonOutput.println(result);
         } else {
             boolean useColor = config.color();
             System.out.print(RichRenderer.brandedHeader(useColor, "classloader",
@@ -123,23 +124,4 @@ public final class ClassLoaderCommand implements Command {
         return depths;
     }
 
-    private static void printJson(ClassLoaderResult result) {
-        StringBuilder sb = new StringBuilder();
-        sb.append("{\"loaders\":[");
-        boolean first = true;
-        for (ClassLoaderInfo loader : result.loaders()) {
-            if (!first) sb.append(',');
-            first = false;
-            sb.append("{\"name\":\"").append(RichRenderer.escapeJson(loader.name())).append('"');
-            sb.append(",\"classCount\":").append(loader.classCount());
-            if (loader.parent() != null) {
-                sb.append(",\"parent\":\"").append(RichRenderer.escapeJson(loader.parent())).append('"');
-            } else {
-                sb.append(",\"parent\":null");
-            }
-            sb.append('}');
-        }
-        sb.append("],\"totalClasses\":").append(result.totalClasses()).append('}');
-        System.out.println(sb);
-    }
 }

--- a/argus-cli/src/main/java/io/argus/cli/command/ClassStatCommand.java
+++ b/argus-cli/src/main/java/io/argus/cli/command/ClassStatCommand.java
@@ -2,6 +2,7 @@ package io.argus.cli.command;
 
 import io.argus.cli.config.CliConfig;
 import io.argus.cli.config.Messages;
+import io.argus.cli.json.JsonOutput;
 import io.argus.cli.model.ClassStatResult;
 import io.argus.cli.provider.ClassStatProvider;
 import io.argus.cli.provider.ProviderRegistry;
@@ -43,7 +44,7 @@ public final class ClassStatCommand implements Command {
 
         ClassStatResult result = provider.getClassStats(pid);
 
-        if (json) { printJson(result); return; }
+        if (json) { JsonOutput.println(result); return; }
 
         System.out.print(RichRenderer.brandedHeader(useColor, "classstat", messages.get("desc.classstat")));
         System.out.println(RichRenderer.boxHeader(useColor, messages.get("header.classstat"), WIDTH, "pid:" + pid, "source:" + source));
@@ -82,11 +83,4 @@ public final class ClassStatCommand implements Command {
         System.out.println(RichRenderer.boxFooter(useColor, null, WIDTH));
     }
 
-    private static void printJson(ClassStatResult r) {
-        System.out.println("{\"loaded\":" + r.loaded()
-                + ",\"loadedBytes\":" + r.loadedBytes()
-                + ",\"unloaded\":" + r.unloaded()
-                + ",\"unloadedBytes\":" + r.unloadedBytes()
-                + ",\"timeMs\":" + r.timeMs() + "}");
-    }
 }

--- a/argus-cli/src/main/java/io/argus/cli/command/CompilerCommand.java
+++ b/argus-cli/src/main/java/io/argus/cli/command/CompilerCommand.java
@@ -2,6 +2,7 @@ package io.argus.cli.command;
 
 import io.argus.cli.config.CliConfig;
 import io.argus.cli.config.Messages;
+import io.argus.cli.json.JsonOutput;
 import io.argus.cli.model.CompilerResult;
 import io.argus.cli.provider.CompilerProvider;
 import io.argus.cli.provider.ProviderRegistry;
@@ -44,7 +45,7 @@ public final class CompilerCommand implements Command {
 
         CompilerResult result = provider.getCompilerInfo(pid);
 
-        if (json) { printJson(result); return; }
+        if (json) { JsonOutput.println(result); return; }
 
         System.out.print(RichRenderer.brandedHeader(useColor, "compiler", messages.get("desc.compiler")));
         System.out.println(RichRenderer.boxHeader(useColor, messages.get("header.compiler"), WIDTH, "pid:" + pid, "source:" + source));
@@ -100,18 +101,5 @@ public final class CompilerCommand implements Command {
         }
 
         System.out.println(RichRenderer.boxFooter(useColor, null, WIDTH));
-    }
-
-    private static void printJson(CompilerResult result) {
-        System.out.println("{\"codeCacheSizeKb\":" + result.codeCacheSizeKb()
-                + ",\"codeCacheUsedKb\":" + result.codeCacheUsedKb()
-                + ",\"codeCacheMaxUsedKb\":" + result.codeCacheMaxUsedKb()
-                + ",\"codeCacheFreeKb\":" + result.codeCacheFreeKb()
-                + ",\"totalBlobs\":" + result.totalBlobs()
-                + ",\"nmethods\":" + result.nmethods()
-                + ",\"adapters\":" + result.adapters()
-                + ",\"compilationEnabled\":" + result.compilationEnabled()
-                + ",\"queueSize\":" + result.queueSize()
-                + ",\"deoptCount\":" + result.deoptCount() + "}");
     }
 }

--- a/argus-cli/src/main/java/io/argus/cli/command/DeadlockCommand.java
+++ b/argus-cli/src/main/java/io/argus/cli/command/DeadlockCommand.java
@@ -2,6 +2,7 @@ package io.argus.cli.command;
 
 import io.argus.cli.config.CliConfig;
 import io.argus.cli.config.Messages;
+import io.argus.cli.json.JsonOutput;
 import io.argus.cli.model.DeadlockResult;
 import io.argus.cli.provider.DeadlockProvider;
 import io.argus.cli.provider.ProviderRegistry;
@@ -51,7 +52,7 @@ public final class DeadlockCommand implements Command {
         DeadlockResult result = provider.detectDeadlocks(pid);
 
         if (json) {
-            printJson(result);
+            JsonOutput.println(result);
             return;
         }
 
@@ -133,29 +134,4 @@ public final class DeadlockCommand implements Command {
         System.out.println(RichRenderer.boxFooter(useColor, null, WIDTH));
     }
 
-    private static void printJson(DeadlockResult result) {
-        StringBuilder sb = new StringBuilder();
-        sb.append("{\"deadlockCount\":").append(result.deadlockCount());
-        sb.append(",\"chains\":[");
-        for (int c = 0; c < result.chains().size(); c++) {
-            DeadlockResult.DeadlockChain chain = result.chains().get(c);
-            if (c > 0) sb.append(',');
-            sb.append("{\"threads\":[");
-            for (int t = 0; t < chain.threads().size(); t++) {
-                DeadlockResult.DeadlockThread thread = chain.threads().get(t);
-                if (t > 0) sb.append(',');
-                sb.append("{\"name\":\"").append(RichRenderer.escapeJson(thread.name())).append('"');
-                sb.append(",\"state\":\"").append(RichRenderer.escapeJson(thread.state())).append('"');
-                sb.append(",\"waitingLock\":\"").append(RichRenderer.escapeJson(thread.waitingLock())).append('"');
-                sb.append(",\"waitingLockClass\":\"").append(RichRenderer.escapeJson(thread.waitingLockClass())).append('"');
-                sb.append(",\"heldLock\":\"").append(RichRenderer.escapeJson(thread.heldLock())).append('"');
-                sb.append(",\"heldLockClass\":\"").append(RichRenderer.escapeJson(thread.heldLockClass())).append('"');
-                sb.append(",\"stackTop\":\"").append(RichRenderer.escapeJson(thread.stackTop())).append('"');
-                sb.append('}');
-            }
-            sb.append("]}");
-        }
-        sb.append("]}");
-        System.out.println(sb);
-    }
 }

--- a/argus-cli/src/main/java/io/argus/cli/command/DynLibsCommand.java
+++ b/argus-cli/src/main/java/io/argus/cli/command/DynLibsCommand.java
@@ -2,6 +2,7 @@ package io.argus.cli.command;
 
 import io.argus.cli.config.CliConfig;
 import io.argus.cli.config.Messages;
+import io.argus.cli.json.JsonOutput;
 import io.argus.cli.model.DynLibsResult;
 import io.argus.cli.provider.DynLibsProvider;
 import io.argus.cli.provider.ProviderRegistry;
@@ -45,7 +46,7 @@ public final class DynLibsCommand implements Command {
 
         DynLibsResult result = provider.getDynLibs(pid);
 
-        if (json) { printJson(result); return; }
+        if (json) { JsonOutput.println(result); return; }
 
         System.out.print(RichRenderer.brandedHeader(useColor, "dynlibs", messages.get("desc.dynlibs")));
         System.out.println(RichRenderer.boxHeader(useColor, messages.get("header.dynlibs"), WIDTH, "pid:" + pid, "source:" + source));
@@ -96,16 +97,4 @@ public final class DynLibsCommand implements Command {
         System.out.println(RichRenderer.boxFooter(useColor, null, WIDTH));
     }
 
-    private static void printJson(DynLibsResult result) {
-        StringBuilder sb = new StringBuilder();
-        sb.append("{\"totalCount\":").append(result.totalCount()).append(",\"libraries\":[");
-        for (int i = 0; i < result.libraries().size(); i++) {
-            DynLibsResult.LibInfo lib = result.libraries().get(i);
-            if (i > 0) sb.append(',');
-            sb.append("{\"path\":\"").append(RichRenderer.escapeJson(lib.path())).append('"');
-            sb.append(",\"category\":\"").append(lib.category()).append("\"}");
-        }
-        sb.append("]}");
-        System.out.println(sb);
-    }
 }

--- a/argus-cli/src/main/java/io/argus/cli/command/EnvCommand.java
+++ b/argus-cli/src/main/java/io/argus/cli/command/EnvCommand.java
@@ -2,6 +2,7 @@ package io.argus.cli.command;
 
 import io.argus.cli.config.CliConfig;
 import io.argus.cli.config.Messages;
+import io.argus.cli.json.JsonOutput;
 import io.argus.cli.model.EnvResult;
 import io.argus.cli.provider.EnvProvider;
 import io.argus.cli.provider.ProviderRegistry;
@@ -43,7 +44,7 @@ public final class EnvCommand implements Command {
 
         EnvResult result = provider.getEnv(pid);
 
-        if (json) { printJson(result); return; }
+        if (json) { JsonOutput.println(result); return; }
 
         System.out.print(RichRenderer.brandedHeader(useColor, "env", messages.get("desc.env")));
         System.out.println(RichRenderer.boxHeader(useColor, messages.get("header.env"), WIDTH, "pid:" + pid, "source:" + source));
@@ -95,18 +96,4 @@ public final class EnvCommand implements Command {
         System.out.println(RichRenderer.boxLine(line, WIDTH));
     }
 
-    private static void printJson(EnvResult result) {
-        StringBuilder sb = new StringBuilder();
-        sb.append("{\"commandLine\":\"").append(RichRenderer.escapeJson(result.commandLine())).append('"');
-        sb.append(",\"javaHome\":\"").append(RichRenderer.escapeJson(result.javaHome())).append('"');
-        sb.append(",\"classPath\":\"").append(RichRenderer.escapeJson(result.classPath())).append('"');
-        sb.append(",\"workingDir\":\"").append(RichRenderer.escapeJson(result.workingDir())).append('"');
-        sb.append(",\"vmArgs\":[");
-        for (int i = 0; i < result.vmArgs().size(); i++) {
-            if (i > 0) sb.append(',');
-            sb.append('"').append(RichRenderer.escapeJson(result.vmArgs().get(i))).append('"');
-        }
-        sb.append("]}");
-        System.out.println(sb);
-    }
 }

--- a/argus-cli/src/main/java/io/argus/cli/command/FinalizerCommand.java
+++ b/argus-cli/src/main/java/io/argus/cli/command/FinalizerCommand.java
@@ -2,6 +2,7 @@ package io.argus.cli.command;
 
 import io.argus.cli.config.CliConfig;
 import io.argus.cli.config.Messages;
+import io.argus.cli.json.JsonOutput;
 import io.argus.cli.model.FinalizerResult;
 import io.argus.cli.provider.FinalizerProvider;
 import io.argus.cli.provider.ProviderRegistry;
@@ -43,7 +44,7 @@ public final class FinalizerCommand implements Command {
 
         FinalizerResult result = provider.getFinalizerInfo(pid);
 
-        if (json) { printJson(result); return; }
+        if (json) { JsonOutput.println(result); return; }
 
         System.out.print(RichRenderer.brandedHeader(useColor, "finalizer", messages.get("desc.finalizer")));
         System.out.println(RichRenderer.boxHeader(useColor, messages.get("header.finalizer"), WIDTH, "pid:" + pid, "source:" + source));
@@ -85,8 +86,4 @@ public final class FinalizerCommand implements Command {
         System.out.println(RichRenderer.boxFooter(useColor, null, WIDTH));
     }
 
-    private static void printJson(FinalizerResult result) {
-        System.out.println("{\"pendingCount\":" + result.pendingCount()
-                + ",\"finalizerThreadState\":\"" + RichRenderer.escapeJson(result.finalizerThreadState()) + "\"}");
-    }
 }

--- a/argus-cli/src/main/java/io/argus/cli/command/GcCauseCommand.java
+++ b/argus-cli/src/main/java/io/argus/cli/command/GcCauseCommand.java
@@ -2,6 +2,7 @@ package io.argus.cli.command;
 
 import io.argus.cli.config.CliConfig;
 import io.argus.cli.config.Messages;
+import io.argus.cli.json.JsonOutput;
 import io.argus.cli.model.GcCauseResult;
 import io.argus.cli.provider.GcCauseProvider;
 import io.argus.cli.provider.ProviderRegistry;
@@ -44,7 +45,7 @@ public final class GcCauseCommand implements Command {
 
         GcCauseResult result = provider.getGcCause(pid);
 
-        if (json) { printJson(result); return; }
+        if (json) { JsonOutput.println(result); return; }
 
         System.out.print(RichRenderer.brandedHeader(useColor, "gccause", messages.get("desc.gccause")));
         System.out.println(RichRenderer.boxHeader(useColor, messages.get("header.gccause"), WIDTH, "pid:" + pid, "source:" + source));
@@ -86,14 +87,4 @@ public final class GcCauseCommand implements Command {
         System.out.println(RichRenderer.boxLine(line, WIDTH));
     }
 
-    private static void printJson(GcCauseResult r) {
-        System.out.println("{\"s0\":" + r.s0() + ",\"s1\":" + r.s1()
-                + ",\"eden\":" + r.eden() + ",\"old\":" + r.old()
-                + ",\"meta\":" + r.meta() + ",\"ccs\":" + r.ccs()
-                + ",\"ygc\":" + r.ygc() + ",\"ygct\":" + r.ygct()
-                + ",\"fgc\":" + r.fgc() + ",\"fgct\":" + r.fgct()
-                + ",\"gct\":" + r.gct()
-                + ",\"lastGcCause\":\"" + RichRenderer.escapeJson(r.lastGcCause()) + "\""
-                + ",\"currentGcCause\":\"" + RichRenderer.escapeJson(r.currentGcCause()) + "\"}");
-    }
 }

--- a/argus-cli/src/main/java/io/argus/cli/command/GcCommand.java
+++ b/argus-cli/src/main/java/io/argus/cli/command/GcCommand.java
@@ -2,6 +2,7 @@ package io.argus.cli.command;
 
 import io.argus.cli.config.CliConfig;
 import io.argus.cli.config.Messages;
+import io.argus.cli.json.JsonOutput;
 import io.argus.cli.model.GcResult;
 import io.argus.cli.provider.GcProvider;
 import io.argus.cli.provider.ProviderRegistry;
@@ -51,7 +52,7 @@ public final class GcCommand implements Command {
         GcResult result = provider.getGcInfo(pid);
 
         if (json) {
-            printJson(result);
+            JsonOutput.println(result);
             return;
         }
 
@@ -100,27 +101,6 @@ public final class GcCommand implements Command {
         }
 
         System.out.println(RichRenderer.boxFooter(useColor, null, WIDTH));
-    }
-
-    private static void printJson(GcResult result) {
-        StringBuilder sb = new StringBuilder();
-        sb.append("{\"totalEvents\":").append(result.totalEvents())
-          .append(",\"totalPauseMs\":").append(result.totalPauseMs())
-          .append(",\"overheadPercent\":").append(result.overheadPercent())
-          .append(",\"lastCause\":\"").append(RichRenderer.escapeJson(result.lastCause())).append('"')
-          .append(",\"heapUsed\":").append(result.heapUsed())
-          .append(",\"heapCommitted\":").append(result.heapCommitted())
-          .append(",\"collectors\":[");
-        for (int i = 0; i < result.collectors().size(); i++) {
-            GcResult.CollectorInfo c = result.collectors().get(i);
-            if (i > 0) sb.append(',');
-            sb.append("{\"name\":\"").append(RichRenderer.escapeJson(c.name())).append('"')
-              .append(",\"count\":").append(c.count())
-              .append(",\"totalMs\":").append(c.totalMs())
-              .append('}');
-        }
-        sb.append("]}");
-        System.out.println(sb);
     }
 
 }

--- a/argus-cli/src/main/java/io/argus/cli/command/GcNewCommand.java
+++ b/argus-cli/src/main/java/io/argus/cli/command/GcNewCommand.java
@@ -2,6 +2,7 @@ package io.argus.cli.command;
 
 import io.argus.cli.config.CliConfig;
 import io.argus.cli.config.Messages;
+import io.argus.cli.json.JsonOutput;
 import io.argus.cli.model.AgeDistribution;
 import io.argus.cli.model.GcNewResult;
 import io.argus.cli.provider.GcAgeProvider;
@@ -52,7 +53,7 @@ public final class GcNewCommand implements Command {
 
         GcNewResult result = provider.getGcNew(pid);
 
-        if (json) { printJson(result); return; }
+        if (json) { JsonOutput.println(result); return; }
 
         System.out.print(RichRenderer.brandedHeader(useColor, "gcnew", messages.get("desc.gcnew")));
         System.out.println(RichRenderer.boxHeader(useColor, messages.get("header.gcnew"), WIDTH, "pid:" + pid, "source:" + source));
@@ -237,11 +238,4 @@ public final class GcNewCommand implements Command {
         System.out.println(RichRenderer.boxLine("  " + line, WIDTH));
     }
 
-    private static void printJson(GcNewResult r) {
-        System.out.println("{\"s0c\":" + r.s0c() + ",\"s1c\":" + r.s1c()
-                + ",\"s0u\":" + r.s0u() + ",\"s1u\":" + r.s1u()
-                + ",\"tt\":" + r.tt() + ",\"mtt\":" + r.mtt()
-                + ",\"dss\":" + r.dss() + ",\"ec\":" + r.ec() + ",\"eu\":" + r.eu()
-                + ",\"ygc\":" + r.ygc() + ",\"ygct\":" + r.ygct() + "}");
-    }
 }

--- a/argus-cli/src/main/java/io/argus/cli/command/GcUtilCommand.java
+++ b/argus-cli/src/main/java/io/argus/cli/command/GcUtilCommand.java
@@ -2,6 +2,7 @@ package io.argus.cli.command;
 
 import io.argus.cli.config.CliConfig;
 import io.argus.cli.config.Messages;
+import io.argus.cli.json.JsonOutput;
 import io.argus.cli.model.GcUtilResult;
 import io.argus.cli.provider.GcUtilProvider;
 import io.argus.cli.provider.ProviderRegistry;
@@ -61,7 +62,7 @@ public final class GcUtilCommand implements Command {
         } else {
             GcUtilResult result = provider.getGcUtil(pid);
             if (json) {
-                printJson(result);
+                JsonOutput.println(result);
             } else {
                 System.out.print(RichRenderer.brandedHeader(useColor, "gcutil", messages.get("desc.gcutil")));
                 printTable(result, pid, source, useColor, messages, true);
@@ -164,20 +165,4 @@ public final class GcUtilCommand implements Command {
         return color + RichRenderer.padRight(formatted, width) + reset;
     }
 
-    private static void printJson(GcUtilResult r) {
-        StringBuilder sb = new StringBuilder();
-        sb.append("{\"s0\":").append(r.s0())
-          .append(",\"s1\":").append(r.s1())
-          .append(",\"eden\":").append(r.eden())
-          .append(",\"old\":").append(r.old())
-          .append(",\"meta\":").append(r.meta())
-          .append(",\"ccs\":").append(r.ccs())
-          .append(",\"ygc\":").append(r.ygc())
-          .append(",\"ygct\":").append(r.ygct())
-          .append(",\"fgc\":").append(r.fgc())
-          .append(",\"fgct\":").append(r.fgct())
-          .append(",\"gct\":").append(r.gct())
-          .append('}');
-        System.out.println(sb);
-    }
 }

--- a/argus-cli/src/main/java/io/argus/cli/command/GcWhyCommand.java
+++ b/argus-cli/src/main/java/io/argus/cli/command/GcWhyCommand.java
@@ -8,6 +8,7 @@ import io.argus.cli.gcwhy.GcWhyAnalyzer;
 import io.argus.cli.gcwhy.GcWhyJfrCollector;
 import io.argus.cli.gcwhy.GcWhyResult;
 import io.argus.cli.jfr.JfrCaptureFailed;
+import io.argus.cli.json.JsonOutput;
 import io.argus.cli.jfr.JfrCaptureSession;
 import io.argus.cli.provider.ProviderRegistry;
 import io.argus.cli.render.AnsiStyle;
@@ -157,7 +158,7 @@ public final class GcWhyCommand implements Command {
         }
 
         if (json) {
-            printJson(result);
+            JsonOutput.println(result);
         } else {
             printReport(result, useColor, messages, windowSec);
         }
@@ -196,28 +197,6 @@ public final class GcWhyCommand implements Command {
         }
 
         System.out.println(RichRenderer.boxFooter(useColor, null, WIDTH));
-    }
-
-    private static void printJson(GcWhyResult r) {
-        StringBuilder sb = new StringBuilder();
-        sb.append("{\"timestampSec\":").append(r.timestampSec())
-                .append(",\"type\":\"").append(RichRenderer.escapeJson(r.type())).append('"')
-                .append(",\"cause\":\"").append(RichRenderer.escapeJson(r.cause())).append('"')
-                .append(",\"pauseMs\":").append(r.pauseMs())
-                .append(",\"bullets\":[");
-        for (int i = 0; i < r.bullets().size(); i++) {
-            if (i > 0) sb.append(',');
-            sb.append('"').append(RichRenderer.escapeJson(r.bullets().get(i))).append('"');
-        }
-        sb.append("],\"counters\":{");
-        int i = 0;
-        for (Map.Entry<String, String> e : r.counters().entrySet()) {
-            if (i++ > 0) sb.append(',');
-            sb.append('"').append(RichRenderer.escapeJson(e.getKey())).append("\":\"")
-                    .append(RichRenderer.escapeJson(e.getValue())).append('"');
-        }
-        sb.append("}}");
-        System.out.println(sb);
     }
 
     // ── Helpers ─────────────────────────────────────────────────────────────

--- a/argus-cli/src/main/java/io/argus/cli/command/HeapCommand.java
+++ b/argus-cli/src/main/java/io/argus/cli/command/HeapCommand.java
@@ -2,6 +2,7 @@ package io.argus.cli.command;
 
 import io.argus.cli.config.CliConfig;
 import io.argus.cli.config.Messages;
+import io.argus.cli.json.JsonOutput;
 import io.argus.cli.model.GcResult;
 import io.argus.cli.model.HeapResult;
 import io.argus.cli.provider.GcProvider;
@@ -56,7 +57,7 @@ public final class HeapCommand implements Command {
         HeapResult result = provider.getHeapInfo(pid);
 
         if (json) {
-            printJson(result);
+            JsonOutput.println(result);
             return;
         }
 
@@ -174,28 +175,6 @@ public final class HeapCommand implements Command {
         }
 
         System.out.println(RichRenderer.boxFooter(useColor, null, WIDTH));
-    }
-
-    private static void printJson(HeapResult result) {
-        StringBuilder sb = new StringBuilder();
-        sb.append("{\"used\":").append(result.used())
-          .append(",\"committed\":").append(result.committed())
-          .append(",\"max\":").append(result.max())
-          .append(",\"spaces\":{");
-        boolean first = true;
-        for (Map.Entry<String, HeapResult.SpaceInfo> e : result.spaces().entrySet()) {
-            if (!first) sb.append(',');
-            HeapResult.SpaceInfo s = e.getValue();
-            sb.append('"').append(RichRenderer.escapeJson(e.getKey())).append("\":")
-              .append("{\"name\":\"").append(RichRenderer.escapeJson(s.name())).append('"')
-              .append(",\"used\":").append(s.used())
-              .append(",\"committed\":").append(s.committed())
-              .append(",\"max\":").append(s.max())
-              .append('}');
-            first = false;
-        }
-        sb.append("}}");
-        System.out.println(sb);
     }
 
 

--- a/argus-cli/src/main/java/io/argus/cli/command/HeapDumpCommand.java
+++ b/argus-cli/src/main/java/io/argus/cli/command/HeapDumpCommand.java
@@ -2,6 +2,7 @@ package io.argus.cli.command;
 
 import io.argus.cli.config.CliConfig;
 import io.argus.cli.config.Messages;
+import io.argus.cli.json.JsonOutput;
 import io.argus.cli.model.HeapDumpResult;
 import io.argus.cli.provider.HeapDumpProvider;
 import io.argus.cli.provider.ProviderRegistry;
@@ -119,7 +120,7 @@ public final class HeapDumpCommand implements Command {
         HeapDumpResult result = provider.heapDump(pid, filePath, liveOnly);
 
         if (json) {
-            printJson(result);
+            JsonOutput.println(result);
         } else {
             boolean useColor = config.color();
             System.out.print(RichRenderer.brandedHeader(useColor, "heapdump",
@@ -196,20 +197,6 @@ public final class HeapDumpCommand implements Command {
         System.out.println(RichRenderer.boxLine(
                 RichRenderer.padRight("  --yes, -y", 28) + "Skip the STW confirmation prompt", WIDTH));
         System.out.println(RichRenderer.boxFooter(useColor, null, WIDTH));
-    }
-
-    private static void printJson(HeapDumpResult result) {
-        StringBuilder sb = new StringBuilder();
-        sb.append("{\"status\":\"").append(RichRenderer.escapeJson(result.status())).append('"');
-        sb.append(",\"filePath\":\"").append(RichRenderer.escapeJson(result.filePath())).append('"');
-        sb.append(",\"fileSizeBytes\":").append(result.fileSizeBytes());
-        if (result.errorMessage() != null) {
-            sb.append(",\"errorMessage\":\"").append(RichRenderer.escapeJson(result.errorMessage())).append('"');
-        } else {
-            sb.append(",\"errorMessage\":null");
-        }
-        sb.append('}');
-        System.out.println(sb);
     }
 
     // -------------------------------------------------------------------------

--- a/argus-cli/src/main/java/io/argus/cli/command/HistoCommand.java
+++ b/argus-cli/src/main/java/io/argus/cli/command/HistoCommand.java
@@ -2,6 +2,7 @@ package io.argus.cli.command;
 
 import io.argus.cli.config.CliConfig;
 import io.argus.cli.config.Messages;
+import io.argus.cli.json.JsonOutput;
 import io.argus.cli.model.HistoResult;
 import io.argus.cli.provider.HistoProvider;
 import io.argus.cli.provider.ProviderRegistry;
@@ -56,7 +57,7 @@ public final class HistoCommand implements Command {
         HistoResult result = provider.getHistogram(pid, topN);
 
         if (json) {
-            printJson(result);
+            JsonOutput.println(result);
             return;
         }
 
@@ -91,24 +92,6 @@ public final class HistoCommand implements Command {
                 + " objects \u00b7 " + RichRenderer.formatBytes(result.totalBytes());
         System.out.println(RichRenderer.boxLine(summary, WIDTH));
         System.out.println(RichRenderer.boxFooter(useColor, null, WIDTH));
-    }
-
-    private static void printJson(HistoResult result) {
-        StringBuilder sb = new StringBuilder();
-        sb.append("{\"totalInstances\":").append(result.totalInstances())
-          .append(",\"totalBytes\":").append(result.totalBytes())
-          .append(",\"entries\":[");
-        for (int i = 0; i < result.entries().size(); i++) {
-            HistoResult.Entry e = result.entries().get(i);
-            if (i > 0) sb.append(',');
-            sb.append("{\"rank\":").append(e.rank())
-              .append(",\"className\":\"").append(RichRenderer.escapeJson(e.className())).append('"')
-              .append(",\"instances\":").append(e.instances())
-              .append(",\"bytes\":").append(e.bytes())
-              .append('}');
-        }
-        sb.append("]}");
-        System.out.println(sb);
     }
 
     private static String formatCount(long n) {

--- a/argus-cli/src/main/java/io/argus/cli/command/InfoCommand.java
+++ b/argus-cli/src/main/java/io/argus/cli/command/InfoCommand.java
@@ -2,14 +2,13 @@ package io.argus.cli.command;
 
 import io.argus.cli.config.CliConfig;
 import io.argus.cli.config.Messages;
+import io.argus.cli.json.JsonOutput;
 import io.argus.cli.model.InfoResult;
 import io.argus.cli.provider.InfoProvider;
 import io.argus.cli.provider.ProviderRegistry;
 import io.argus.cli.render.AnsiStyle;
 import io.argus.cli.render.RichRenderer;
 import io.argus.core.command.CommandGroup;
-
-import java.util.Map;
 
 /**
  * Shows JVM information for a given PID.
@@ -52,7 +51,7 @@ public final class InfoCommand implements Command {
         InfoResult result = provider.getVmInfo(pid);
 
         if (json) {
-            printJson(result);
+            JsonOutput.println(result);
             return;
         }
 
@@ -120,35 +119,5 @@ public final class InfoCommand implements Command {
 
         System.out.println(RichRenderer.boxFooter(useColor, null, WIDTH));
     }
-
-    private static void printJson(InfoResult result) {
-        StringBuilder sb = new StringBuilder();
-        sb.append("{\"vmName\":\"").append(RichRenderer.escapeJson(result.vmName())).append('"')
-          .append(",\"vmVersion\":\"").append(RichRenderer.escapeJson(result.vmVersion())).append('"')
-          .append(",\"vmVendor\":\"").append(RichRenderer.escapeJson(result.vmVendor())).append('"')
-          .append(",\"uptimeMs\":").append(result.uptimeMs())
-          .append(",\"pid\":").append(result.pid())
-          .append(",\"vmFlags\":[");
-        for (int i = 0; i < result.vmFlags().size(); i++) {
-            if (i > 0) sb.append(',');
-            sb.append('"').append(RichRenderer.escapeJson(result.vmFlags().get(i))).append('"');
-        }
-        sb.append("],\"systemProperties\":{");
-        boolean first = true;
-        for (Map.Entry<String, String> e : result.systemProperties().entrySet()) {
-            if (!first) sb.append(',');
-            sb.append('"').append(RichRenderer.escapeJson(e.getKey())).append("\":\"")
-              .append(RichRenderer.escapeJson(e.getValue())).append('"');
-            first = false;
-        }
-        sb.append("}");
-        sb.append(",\"processCpuLoad\":").append(result.processCpuLoad());
-        sb.append(",\"systemCpuLoad\":").append(result.systemCpuLoad());
-        sb.append(",\"availableProcessors\":").append(result.availableProcessors());
-        sb.append(",\"systemLoadAverage\":").append(result.systemLoadAverage());
-        sb.append('}');
-        System.out.println(sb);
-    }
-
 
 }

--- a/argus-cli/src/main/java/io/argus/cli/command/JfrCommand.java
+++ b/argus-cli/src/main/java/io/argus/cli/command/JfrCommand.java
@@ -2,6 +2,7 @@ package io.argus.cli.command;
 
 import io.argus.cli.config.CliConfig;
 import io.argus.cli.config.Messages;
+import io.argus.cli.json.JsonOutput;
 import io.argus.cli.model.JfrResult;
 import io.argus.cli.provider.JfrProvider;
 import io.argus.cli.provider.ProviderRegistry;
@@ -89,7 +90,7 @@ public final class JfrCommand implements Command {
         if (result == null) return;
 
         if (json) {
-            printJson(result);
+            JsonOutput.println(result);
         } else {
             boolean useColor = config.color();
             System.out.print(RichRenderer.brandedHeader(useColor, "jfr " + subcommand,
@@ -156,17 +157,4 @@ public final class JfrCommand implements Command {
         System.out.println(RichRenderer.boxFooter(useColor, null, WIDTH));
     }
 
-    private static void printJson(JfrResult result) {
-        StringBuilder sb = new StringBuilder();
-        sb.append("{\"status\":\"").append(RichRenderer.escapeJson(result.status())).append('"');
-        sb.append(",\"message\":\"").append(RichRenderer.escapeJson(result.message())).append('"');
-        if (result.recordingInfo() != null) {
-            sb.append(",\"recordingInfo\":\"")
-              .append(RichRenderer.escapeJson(result.recordingInfo())).append('"');
-        } else {
-            sb.append(",\"recordingInfo\":null");
-        }
-        sb.append('}');
-        System.out.println(sb);
-    }
 }

--- a/argus-cli/src/main/java/io/argus/cli/command/MetaspaceCommand.java
+++ b/argus-cli/src/main/java/io/argus/cli/command/MetaspaceCommand.java
@@ -2,6 +2,7 @@ package io.argus.cli.command;
 
 import io.argus.cli.config.CliConfig;
 import io.argus.cli.config.Messages;
+import io.argus.cli.json.JsonOutput;
 import io.argus.cli.model.MetaspaceResult;
 import io.argus.cli.provider.MetaspaceProvider;
 import io.argus.cli.provider.ProviderRegistry;
@@ -44,7 +45,7 @@ public final class MetaspaceCommand implements Command {
 
         MetaspaceResult result = provider.getMetaspaceInfo(pid);
 
-        if (json) { printJson(result); return; }
+        if (json) { JsonOutput.println(result); return; }
 
         System.out.print(RichRenderer.brandedHeader(useColor, "metaspace", messages.get("desc.metaspace")));
         System.out.println(RichRenderer.boxHeader(useColor, messages.get("header.metaspace"), WIDTH, "pid:" + pid, "source:" + source));
@@ -97,21 +98,4 @@ public final class MetaspaceCommand implements Command {
         System.out.println(RichRenderer.boxFooter(useColor, null, WIDTH));
     }
 
-    private static void printJson(MetaspaceResult r) {
-        StringBuilder sb = new StringBuilder();
-        sb.append("{\"totalReserved\":").append(r.totalReserved());
-        sb.append(",\"totalCommitted\":").append(r.totalCommitted());
-        sb.append(",\"totalUsed\":").append(r.totalUsed());
-        sb.append(",\"spaces\":[");
-        for (int i = 0; i < r.spaces().size(); i++) {
-            MetaspaceResult.SpaceInfo sp = r.spaces().get(i);
-            if (i > 0) sb.append(',');
-            sb.append("{\"name\":\"").append(sp.name()).append('"');
-            sb.append(",\"reserved\":").append(sp.reserved());
-            sb.append(",\"committed\":").append(sp.committed());
-            sb.append(",\"used\":").append(sp.used()).append('}');
-        }
-        sb.append("]}");
-        System.out.println(sb);
-    }
 }

--- a/argus-cli/src/main/java/io/argus/cli/command/NmtCommand.java
+++ b/argus-cli/src/main/java/io/argus/cli/command/NmtCommand.java
@@ -2,6 +2,7 @@ package io.argus.cli.command;
 
 import io.argus.cli.config.CliConfig;
 import io.argus.cli.config.Messages;
+import io.argus.cli.json.JsonOutput;
 import io.argus.cli.model.NmtBaseline;
 import io.argus.cli.model.NmtResult;
 import io.argus.cli.provider.NmtProvider;
@@ -109,7 +110,7 @@ public final class NmtCommand implements Command {
         }
 
         if (json) {
-            printJson(result);
+            JsonOutput.println(result);
         } else {
             System.out.print(RichRenderer.brandedHeader(useColor, "nmt", messages.get("desc.nmt")));
             printTable(result, pid, provider.source(), useColor, messages);
@@ -496,21 +497,4 @@ public final class NmtCommand implements Command {
         System.out.println(RichRenderer.boxFooter(useColor, cats.size() + " categories", WIDTH));
     }
 
-    private static void printJson(NmtResult result) {
-        StringBuilder sb = new StringBuilder();
-        sb.append("{\"totalReservedKB\":").append(result.totalReservedKB())
-          .append(",\"totalCommittedKB\":").append(result.totalCommittedKB())
-          .append(",\"categories\":[");
-        boolean first = true;
-        for (NmtResult.NmtCategory cat : result.categories()) {
-            if (!first) sb.append(',');
-            sb.append("{\"name\":\"").append(RichRenderer.escapeJson(cat.name())).append('"')
-              .append(",\"reservedKB\":").append(cat.reservedKB())
-              .append(",\"committedKB\":").append(cat.committedKB())
-              .append('}');
-            first = false;
-        }
-        sb.append("]}");
-        System.out.println(sb);
-    }
 }

--- a/argus-cli/src/main/java/io/argus/cli/command/PoolCommand.java
+++ b/argus-cli/src/main/java/io/argus/cli/command/PoolCommand.java
@@ -2,6 +2,7 @@ package io.argus.cli.command;
 
 import io.argus.cli.config.CliConfig;
 import io.argus.cli.config.Messages;
+import io.argus.cli.json.JsonOutput;
 import io.argus.cli.model.PoolResult;
 import io.argus.cli.provider.PoolProvider;
 import io.argus.cli.provider.ProviderRegistry;
@@ -50,7 +51,7 @@ public final class PoolCommand implements Command {
 
         PoolResult result = provider.getPoolInfo(pid);
 
-        if (json) { printJson(result); return; }
+        if (json) { JsonOutput.println(result); return; }
 
         System.out.print(RichRenderer.brandedHeader(useColor, "pool", messages.get("desc.pool")));
         System.out.println(RichRenderer.boxHeader(useColor, messages.get("header.pool"), WIDTH, "pid:" + pid, "source:" + source));
@@ -124,26 +125,4 @@ public final class PoolCommand implements Command {
         }
     }
 
-    private static void printJson(PoolResult result) {
-        StringBuilder sb = new StringBuilder();
-        sb.append("{\"totalThreads\":").append(result.totalThreads());
-        sb.append(",\"totalPools\":").append(result.totalPools());
-        sb.append(",\"pools\":[");
-        for (int i = 0; i < result.pools().size(); i++) {
-            PoolResult.PoolInfo p = result.pools().get(i);
-            if (i > 0) sb.append(',');
-            sb.append("{\"name\":\"").append(RichRenderer.escapeJson(p.name())).append('"');
-            sb.append(",\"threadCount\":").append(p.threadCount());
-            sb.append(",\"states\":{");
-            boolean first = true;
-            for (Map.Entry<String, Integer> e : p.stateDistribution().entrySet()) {
-                if (!first) sb.append(',');
-                sb.append('"').append(e.getKey()).append("\":").append(e.getValue());
-                first = false;
-            }
-            sb.append("}}");
-        }
-        sb.append("]}");
-        System.out.println(sb);
-    }
 }

--- a/argus-cli/src/main/java/io/argus/cli/command/StringTableCommand.java
+++ b/argus-cli/src/main/java/io/argus/cli/command/StringTableCommand.java
@@ -2,6 +2,7 @@ package io.argus.cli.command;
 
 import io.argus.cli.config.CliConfig;
 import io.argus.cli.config.Messages;
+import io.argus.cli.json.JsonOutput;
 import io.argus.cli.model.StringTableResult;
 import io.argus.cli.provider.ProviderRegistry;
 import io.argus.cli.provider.StringTableProvider;
@@ -43,7 +44,7 @@ public final class StringTableCommand implements Command {
 
         StringTableResult result = provider.getStringTableInfo(pid);
 
-        if (json) { printJson(result); return; }
+        if (json) { JsonOutput.println(result); return; }
 
         System.out.print(RichRenderer.brandedHeader(useColor, "stringtable", messages.get("desc.stringtable")));
         System.out.println(RichRenderer.boxHeader(useColor, messages.get("header.stringtable"), WIDTH, "pid:" + pid, "source:" + source));
@@ -89,14 +90,4 @@ public final class StringTableCommand implements Command {
         System.out.println(RichRenderer.boxLine(line, WIDTH));
     }
 
-    private static void printJson(StringTableResult result) {
-        System.out.println("{\"bucketCount\":" + result.bucketCount()
-                + ",\"entryCount\":" + result.entryCount()
-                + ",\"literalCount\":" + result.literalCount()
-                + ",\"bucketBytes\":" + result.bucketBytes()
-                + ",\"entryBytes\":" + result.entryBytes()
-                + ",\"literalBytes\":" + result.literalBytes()
-                + ",\"totalBytes\":" + result.totalBytes()
-                + ",\"avgLiteralSize\":" + result.avgLiteralSize() + "}");
-    }
 }

--- a/argus-cli/src/main/java/io/argus/cli/command/SymbolTableCommand.java
+++ b/argus-cli/src/main/java/io/argus/cli/command/SymbolTableCommand.java
@@ -2,6 +2,7 @@ package io.argus.cli.command;
 
 import io.argus.cli.config.CliConfig;
 import io.argus.cli.config.Messages;
+import io.argus.cli.json.JsonOutput;
 import io.argus.cli.model.SymbolTableResult;
 import io.argus.cli.provider.ProviderRegistry;
 import io.argus.cli.provider.SymbolTableProvider;
@@ -43,7 +44,7 @@ public final class SymbolTableCommand implements Command {
 
         SymbolTableResult result = provider.getSymbolTableInfo(pid);
 
-        if (json) { printJson(result); return; }
+        if (json) { JsonOutput.println(result); return; }
 
         System.out.print(RichRenderer.brandedHeader(useColor, "symboltable", messages.get("desc.symboltable")));
         System.out.println(RichRenderer.boxHeader(useColor, messages.get("header.symboltable"), WIDTH, "pid:" + pid, "source:" + source));
@@ -87,14 +88,4 @@ public final class SymbolTableCommand implements Command {
         System.out.println(RichRenderer.boxLine(line, WIDTH));
     }
 
-    private static void printJson(SymbolTableResult r) {
-        System.out.println("{\"bucketCount\":" + r.bucketCount()
-                + ",\"entryCount\":" + r.entryCount()
-                + ",\"literalCount\":" + r.literalCount()
-                + ",\"bucketBytes\":" + r.bucketBytes()
-                + ",\"entryBytes\":" + r.entryBytes()
-                + ",\"literalBytes\":" + r.literalBytes()
-                + ",\"totalBytes\":" + r.totalBytes()
-                + ",\"avgLiteralSize\":" + r.avgLiteralSize() + "}");
-    }
 }

--- a/argus-cli/src/main/java/io/argus/cli/command/ThreadDumpCommand.java
+++ b/argus-cli/src/main/java/io/argus/cli/command/ThreadDumpCommand.java
@@ -2,6 +2,7 @@ package io.argus.cli.command;
 
 import io.argus.cli.config.CliConfig;
 import io.argus.cli.config.Messages;
+import io.argus.cli.json.JsonOutput;
 import io.argus.cli.model.ThreadDumpResult;
 import io.argus.cli.model.ThreadDumpResult.ThreadInfo;
 import io.argus.cli.provider.ProviderRegistry;
@@ -69,7 +70,7 @@ public final class ThreadDumpCommand implements Command {
         }
 
         if (json) {
-            printJson(result);
+            JsonOutput.println(result);
             return;
         }
 
@@ -180,36 +181,4 @@ public final class ThreadDumpCommand implements Command {
         }
     }
 
-    private static void printJson(ThreadDumpResult result) {
-        StringBuilder sb = new StringBuilder();
-        sb.append("{\"totalThreads\":").append(result.totalThreads());
-        sb.append(",\"threads\":[");
-        for (int i = 0; i < result.threads().size(); i++) {
-            ThreadInfo t = result.threads().get(i);
-            if (i > 0) sb.append(',');
-            sb.append("{\"name\":\"").append(RichRenderer.escapeJson(t.name())).append('"');
-            sb.append(",\"tid\":").append(t.tid());
-            sb.append(",\"nid\":").append(t.nid());
-            sb.append(",\"state\":\"").append(t.state()).append('"');
-            sb.append(",\"daemon\":").append(t.daemon());
-            sb.append(",\"priority\":").append(t.priority());
-            if (!t.waitingOn().isEmpty()) {
-                sb.append(",\"waitingOn\":\"").append(RichRenderer.escapeJson(t.waitingOn())).append('"');
-            }
-            sb.append(",\"locksHeld\":[");
-            for (int j = 0; j < t.locksHeld().size(); j++) {
-                if (j > 0) sb.append(',');
-                sb.append('"').append(RichRenderer.escapeJson(t.locksHeld().get(j))).append('"');
-            }
-            sb.append("]");
-            sb.append(",\"stackTrace\":[");
-            for (int j = 0; j < t.stackTrace().size(); j++) {
-                if (j > 0) sb.append(',');
-                sb.append('"').append(RichRenderer.escapeJson(t.stackTrace().get(j))).append('"');
-            }
-            sb.append("]}");
-        }
-        sb.append("]}");
-        System.out.println(sb);
-    }
 }

--- a/argus-cli/src/main/java/io/argus/cli/command/ThreadsCommand.java
+++ b/argus-cli/src/main/java/io/argus/cli/command/ThreadsCommand.java
@@ -4,6 +4,7 @@ import io.argus.cli.config.CliConfig;
 import io.argus.cli.config.Messages;
 import io.argus.cli.jmx.JmxAttachment;
 import io.argus.cli.jmx.JmxAttachmentException;
+import io.argus.cli.json.JsonOutput;
 import io.argus.cli.model.ThreadResult;
 import io.argus.cli.provider.ProviderRegistry;
 import io.argus.cli.provider.ThreadProvider;
@@ -88,7 +89,7 @@ public final class ThreadsCommand implements Command {
         ThreadResult result = provider.getThreadDump(pid);
 
         if (json) {
-            printJson(result);
+            JsonOutput.println(result);
             return;
         }
 
@@ -340,31 +341,5 @@ public final class ThreadsCommand implements Command {
         long cpuDelta() { return cpuDelta; }
         long totalCpu() { return totalCpu; }
     }
-
-    private static void printJson(ThreadResult result) {
-        StringBuilder sb = new StringBuilder();
-        sb.append("{\"totalThreads\":").append(result.totalThreads())
-          .append(",\"virtualThreads\":").append(result.virtualThreads())
-          .append(",\"platformThreads\":").append(result.platformThreads())
-          .append(",\"stateDistribution\":{");
-        boolean first = true;
-        for (Map.Entry<String, Integer> e : result.stateDistribution().entrySet()) {
-            if (!first) sb.append(',');
-            sb.append('"').append(e.getKey()).append("\":").append(e.getValue());
-            first = false;
-        }
-        sb.append("},\"deadlocks\":[");
-        for (int i = 0; i < result.deadlocks().size(); i++) {
-            ThreadResult.DeadlockInfo dl = result.deadlocks().get(i);
-            if (i > 0) sb.append(',');
-            sb.append("{\"thread1\":\"").append(RichRenderer.escapeJson(dl.thread1())).append('"')
-              .append(",\"thread2\":\"").append(RichRenderer.escapeJson(dl.thread2())).append('"')
-              .append(",\"lockClass\":\"").append(RichRenderer.escapeJson(dl.lockClass())).append('"')
-              .append('}');
-        }
-        sb.append("]}");
-        System.out.println(sb);
-    }
-
 
 }

--- a/argus-cli/src/main/java/io/argus/cli/gcwhy/GcWhyResult.java
+++ b/argus-cli/src/main/java/io/argus/cli/gcwhy/GcWhyResult.java
@@ -1,5 +1,8 @@
 package io.argus.cli.gcwhy;
 
+import io.argus.cli.json.JsonWritable;
+import io.argus.cli.render.RichRenderer;
+
 import java.util.List;
 import java.util.Map;
 
@@ -7,7 +10,7 @@ import java.util.Map;
  * Result of the gcwhy correlation engine: the worst pause in the window,
  * a small set of "why" bullets, and a map of related counters to display.
  */
-public final class GcWhyResult {
+public final class GcWhyResult implements JsonWritable {
     private final double timestampSec;
     private final String type;
     private final String cause;
@@ -31,6 +34,27 @@ public final class GcWhyResult {
     public double pauseMs() { return pauseMs; }
     public List<String> bullets() { return bullets; }
     public Map<String, String> counters() { return counters; }
+
+    @Override
+    public void writeJson(StringBuilder out) {
+        out.append("{\"timestampSec\":").append(timestampSec)
+           .append(",\"type\":\"").append(RichRenderer.escapeJson(type)).append('"')
+           .append(",\"cause\":\"").append(RichRenderer.escapeJson(cause)).append('"')
+           .append(",\"pauseMs\":").append(pauseMs)
+           .append(",\"bullets\":[");
+        for (int i = 0; i < bullets.size(); i++) {
+            if (i > 0) out.append(',');
+            out.append('"').append(RichRenderer.escapeJson(bullets.get(i))).append('"');
+        }
+        out.append("],\"counters\":{");
+        int i = 0;
+        for (Map.Entry<String, String> e : counters.entrySet()) {
+            if (i++ > 0) out.append(',');
+            out.append('"').append(RichRenderer.escapeJson(e.getKey())).append("\":\"")
+               .append(RichRenderer.escapeJson(e.getValue())).append('"');
+        }
+        out.append("}}");
+    }
 
     public static GcWhyResult empty() {
         return new GcWhyResult(0, "", "", 0, List.of(), Map.of());

--- a/argus-cli/src/main/java/io/argus/cli/json/JsonOutput.java
+++ b/argus-cli/src/main/java/io/argus/cli/json/JsonOutput.java
@@ -1,0 +1,21 @@
+package io.argus.cli.json;
+
+/**
+ * Thin entry point for JSON rendering: models own the schema via {@link JsonWritable#writeJson(StringBuilder)},
+ * commands call {@link #println(JsonWritable)} (or {@link #render(JsonWritable)} when they need the string).
+ */
+public final class JsonOutput {
+    private JsonOutput() {}
+
+    public static String render(JsonWritable result) {
+        StringBuilder sb = new StringBuilder();
+        result.writeJson(sb);
+        return sb.toString();
+    }
+
+    public static void println(JsonWritable result) {
+        StringBuilder sb = new StringBuilder();
+        result.writeJson(sb);
+        System.out.println(sb);
+    }
+}

--- a/argus-cli/src/main/java/io/argus/cli/json/JsonWritable.java
+++ b/argus-cli/src/main/java/io/argus/cli/json/JsonWritable.java
@@ -1,0 +1,10 @@
+package io.argus.cli.json;
+
+/**
+ * Marker for models whose JSON shape is owned by the model itself.
+ * Implementations append a complete JSON value (typically an object) to {@code out}
+ * with no surrounding whitespace and no trailing newline.
+ */
+public interface JsonWritable {
+    void writeJson(StringBuilder out);
+}

--- a/argus-cli/src/main/java/io/argus/cli/model/BuffersResult.java
+++ b/argus-cli/src/main/java/io/argus/cli/model/BuffersResult.java
@@ -1,11 +1,14 @@
 package io.argus.cli.model;
 
+import io.argus.cli.json.JsonWritable;
+import io.argus.cli.render.RichRenderer;
+
 import java.util.List;
 
 /**
  * Result of NIO buffer pool query via BufferPoolMXBean.
  */
-public final class BuffersResult {
+public final class BuffersResult implements JsonWritable {
 
     private final List<BufferPool> pools;
     private final long totalCount;
@@ -23,6 +26,24 @@ public final class BuffersResult {
     public long totalCount() { return totalCount; }
     public long totalCapacity() { return totalCapacity; }
     public long totalUsed() { return totalUsed; }
+
+    @Override
+    public void writeJson(StringBuilder out) {
+        out.append("{\"totalCount\":").append(totalCount)
+           .append(",\"totalCapacity\":").append(totalCapacity)
+           .append(",\"totalUsed\":").append(totalUsed)
+           .append(",\"pools\":[");
+        for (int i = 0; i < pools.size(); i++) {
+            BufferPool pool = pools.get(i);
+            if (i > 0) out.append(',');
+            out.append("{\"name\":\"").append(RichRenderer.escapeJson(pool.name())).append('"')
+               .append(",\"count\":").append(pool.count())
+               .append(",\"totalCapacity\":").append(pool.totalCapacity())
+               .append(",\"memoryUsed\":").append(pool.memoryUsed())
+               .append('}');
+        }
+        out.append("]}");
+    }
 
     public static final class BufferPool {
         private final String name;

--- a/argus-cli/src/main/java/io/argus/cli/model/ClassLoaderResult.java
+++ b/argus-cli/src/main/java/io/argus/cli/model/ClassLoaderResult.java
@@ -1,11 +1,14 @@
 package io.argus.cli.model;
 
+import io.argus.cli.json.JsonWritable;
+import io.argus.cli.render.RichRenderer;
+
 import java.util.List;
 
 /**
  * Snapshot of classloader hierarchy from jcmd VM.classloaders.
  */
-public final class ClassLoaderResult {
+public final class ClassLoaderResult implements JsonWritable {
     private final List<ClassLoaderInfo> loaders;
     private final long totalClasses;
 
@@ -16,6 +19,25 @@ public final class ClassLoaderResult {
 
     public List<ClassLoaderInfo> loaders() { return loaders; }
     public long totalClasses() { return totalClasses; }
+
+    @Override
+    public void writeJson(StringBuilder out) {
+        out.append("{\"loaders\":[");
+        boolean first = true;
+        for (ClassLoaderInfo loader : loaders) {
+            if (!first) out.append(',');
+            first = false;
+            out.append("{\"name\":\"").append(RichRenderer.escapeJson(loader.name())).append('"')
+               .append(",\"classCount\":").append(loader.classCount());
+            if (loader.parent() != null) {
+                out.append(",\"parent\":\"").append(RichRenderer.escapeJson(loader.parent())).append('"');
+            } else {
+                out.append(",\"parent\":null");
+            }
+            out.append('}');
+        }
+        out.append("],\"totalClasses\":").append(totalClasses).append('}');
+    }
 
     public static final class ClassLoaderInfo {
         private final String name;

--- a/argus-cli/src/main/java/io/argus/cli/model/ClassStatResult.java
+++ b/argus-cli/src/main/java/io/argus/cli/model/ClassStatResult.java
@@ -1,9 +1,11 @@
 package io.argus.cli.model;
 
+import io.argus.cli.json.JsonWritable;
+
 /**
  * Class loading statistics from jstat -class.
  */
-public final class ClassStatResult {
+public final class ClassStatResult implements JsonWritable {
     private final long loaded;
     private final double loadedBytes;
     private final long unloaded;
@@ -24,4 +26,14 @@ public final class ClassStatResult {
     public long unloaded() { return unloaded; }
     public double unloadedBytes() { return unloadedBytes; }
     public double timeMs() { return timeMs; }
+
+    @Override
+    public void writeJson(StringBuilder out) {
+        out.append("{\"loaded\":").append(loaded)
+           .append(",\"loadedBytes\":").append(loadedBytes)
+           .append(",\"unloaded\":").append(unloaded)
+           .append(",\"unloadedBytes\":").append(unloadedBytes)
+           .append(",\"timeMs\":").append(timeMs)
+           .append('}');
+    }
 }

--- a/argus-cli/src/main/java/io/argus/cli/model/CompilerResult.java
+++ b/argus-cli/src/main/java/io/argus/cli/model/CompilerResult.java
@@ -1,9 +1,11 @@
 package io.argus.cli.model;
 
+import io.argus.cli.json.JsonWritable;
+
 /**
  * JIT compiler and code cache statistics.
  */
-public final class CompilerResult {
+public final class CompilerResult implements JsonWritable {
     private final long codeCacheSizeKb;
     private final long codeCacheUsedKb;
     private final long codeCacheMaxUsedKb;
@@ -48,4 +50,19 @@ public final class CompilerResult {
     public int queueSize() { return queueSize; }
     /** Total runtime deoptimizations since JVM start; 0 when unknown. */
     public long deoptCount() { return deoptCount; }
+
+    @Override
+    public void writeJson(StringBuilder out) {
+        out.append("{\"codeCacheSizeKb\":").append(codeCacheSizeKb)
+           .append(",\"codeCacheUsedKb\":").append(codeCacheUsedKb)
+           .append(",\"codeCacheMaxUsedKb\":").append(codeCacheMaxUsedKb)
+           .append(",\"codeCacheFreeKb\":").append(codeCacheFreeKb)
+           .append(",\"totalBlobs\":").append(totalBlobs)
+           .append(",\"nmethods\":").append(nmethods)
+           .append(",\"adapters\":").append(adapters)
+           .append(",\"compilationEnabled\":").append(compilationEnabled)
+           .append(",\"queueSize\":").append(queueSize)
+           .append(",\"deoptCount\":").append(deoptCount)
+           .append('}');
+    }
 }

--- a/argus-cli/src/main/java/io/argus/cli/model/DeadlockResult.java
+++ b/argus-cli/src/main/java/io/argus/cli/model/DeadlockResult.java
@@ -1,11 +1,14 @@
 package io.argus.cli.model;
 
+import io.argus.cli.json.JsonWritable;
+import io.argus.cli.render.RichRenderer;
+
 import java.util.List;
 
 /**
  * Deadlock detection result with detailed chain information.
  */
-public final class DeadlockResult {
+public final class DeadlockResult implements JsonWritable {
     private final int deadlockCount;
     private final List<DeadlockChain> chains;
 
@@ -16,6 +19,31 @@ public final class DeadlockResult {
 
     public int deadlockCount() { return deadlockCount; }
     public List<DeadlockChain> chains() { return chains; }
+
+    @Override
+    public void writeJson(StringBuilder out) {
+        out.append("{\"deadlockCount\":").append(deadlockCount)
+           .append(",\"chains\":[");
+        for (int c = 0; c < chains.size(); c++) {
+            DeadlockChain chain = chains.get(c);
+            if (c > 0) out.append(',');
+            out.append("{\"threads\":[");
+            for (int t = 0; t < chain.threads().size(); t++) {
+                DeadlockThread thread = chain.threads().get(t);
+                if (t > 0) out.append(',');
+                out.append("{\"name\":\"").append(RichRenderer.escapeJson(thread.name())).append('"')
+                   .append(",\"state\":\"").append(RichRenderer.escapeJson(thread.state())).append('"')
+                   .append(",\"waitingLock\":\"").append(RichRenderer.escapeJson(thread.waitingLock())).append('"')
+                   .append(",\"waitingLockClass\":\"").append(RichRenderer.escapeJson(thread.waitingLockClass())).append('"')
+                   .append(",\"heldLock\":\"").append(RichRenderer.escapeJson(thread.heldLock())).append('"')
+                   .append(",\"heldLockClass\":\"").append(RichRenderer.escapeJson(thread.heldLockClass())).append('"')
+                   .append(",\"stackTop\":\"").append(RichRenderer.escapeJson(thread.stackTop())).append('"')
+                   .append('}');
+            }
+            out.append("]}");
+        }
+        out.append("]}");
+    }
 
     /**
      * A single deadlock chain involving two or more threads.

--- a/argus-cli/src/main/java/io/argus/cli/model/DynLibsResult.java
+++ b/argus-cli/src/main/java/io/argus/cli/model/DynLibsResult.java
@@ -1,11 +1,14 @@
 package io.argus.cli.model;
 
+import io.argus.cli.json.JsonWritable;
+import io.argus.cli.render.RichRenderer;
+
 import java.util.List;
 
 /**
  * Native libraries loaded in the JVM.
  */
-public final class DynLibsResult {
+public final class DynLibsResult implements JsonWritable {
     private final int totalCount;
     private final List<LibInfo> libraries;
 
@@ -16,6 +19,18 @@ public final class DynLibsResult {
 
     public int totalCount() { return totalCount; }
     public List<LibInfo> libraries() { return libraries; }
+
+    @Override
+    public void writeJson(StringBuilder out) {
+        out.append("{\"totalCount\":").append(totalCount).append(",\"libraries\":[");
+        for (int i = 0; i < libraries.size(); i++) {
+            LibInfo lib = libraries.get(i);
+            if (i > 0) out.append(',');
+            out.append("{\"path\":\"").append(RichRenderer.escapeJson(lib.path())).append('"')
+               .append(",\"category\":\"").append(lib.category()).append("\"}");
+        }
+        out.append("]}");
+    }
 
     public static final class LibInfo {
         private final String path;

--- a/argus-cli/src/main/java/io/argus/cli/model/EnvResult.java
+++ b/argus-cli/src/main/java/io/argus/cli/model/EnvResult.java
@@ -1,11 +1,14 @@
 package io.argus.cli.model;
 
+import io.argus.cli.json.JsonWritable;
+import io.argus.cli.render.RichRenderer;
+
 import java.util.List;
 
 /**
  * JVM launch environment result.
  */
-public final class EnvResult {
+public final class EnvResult implements JsonWritable {
     private final String commandLine;
     private final String javaHome;
     private final String classPath;
@@ -26,4 +29,18 @@ public final class EnvResult {
     public String classPath() { return classPath; }
     public String workingDir() { return workingDir; }
     public List<String> vmArgs() { return vmArgs; }
+
+    @Override
+    public void writeJson(StringBuilder out) {
+        out.append("{\"commandLine\":\"").append(RichRenderer.escapeJson(commandLine)).append('"')
+           .append(",\"javaHome\":\"").append(RichRenderer.escapeJson(javaHome)).append('"')
+           .append(",\"classPath\":\"").append(RichRenderer.escapeJson(classPath)).append('"')
+           .append(",\"workingDir\":\"").append(RichRenderer.escapeJson(workingDir)).append('"')
+           .append(",\"vmArgs\":[");
+        for (int i = 0; i < vmArgs.size(); i++) {
+            if (i > 0) out.append(',');
+            out.append('"').append(RichRenderer.escapeJson(vmArgs.get(i))).append('"');
+        }
+        out.append("]}");
+    }
 }

--- a/argus-cli/src/main/java/io/argus/cli/model/FinalizerResult.java
+++ b/argus-cli/src/main/java/io/argus/cli/model/FinalizerResult.java
@@ -1,9 +1,12 @@
 package io.argus.cli.model;
 
+import io.argus.cli.json.JsonWritable;
+import io.argus.cli.render.RichRenderer;
+
 /**
  * Finalizer queue status.
  */
-public final class FinalizerResult {
+public final class FinalizerResult implements JsonWritable {
     private final int pendingCount;
     private final String finalizerThreadState;
 
@@ -14,4 +17,11 @@ public final class FinalizerResult {
 
     public int pendingCount() { return pendingCount; }
     public String finalizerThreadState() { return finalizerThreadState; }
+
+    @Override
+    public void writeJson(StringBuilder out) {
+        out.append("{\"pendingCount\":").append(pendingCount)
+           .append(",\"finalizerThreadState\":\"").append(RichRenderer.escapeJson(finalizerThreadState))
+           .append("\"}");
+    }
 }

--- a/argus-cli/src/main/java/io/argus/cli/model/GcCauseResult.java
+++ b/argus-cli/src/main/java/io/argus/cli/model/GcCauseResult.java
@@ -1,9 +1,12 @@
 package io.argus.cli.model;
 
+import io.argus.cli.json.JsonWritable;
+import io.argus.cli.render.RichRenderer;
+
 /**
  * GC cause result from jstat -gccause. Extends gcutil with last/current GC cause.
  */
-public final class GcCauseResult {
+public final class GcCauseResult implements JsonWritable {
     private final double s0;
     private final double s1;
     private final double eden;
@@ -40,4 +43,16 @@ public final class GcCauseResult {
     public double gct() { return gct; }
     public String lastGcCause() { return lastGcCause; }
     public String currentGcCause() { return currentGcCause; }
+
+    @Override
+    public void writeJson(StringBuilder out) {
+        out.append("{\"s0\":").append(s0).append(",\"s1\":").append(s1)
+           .append(",\"eden\":").append(eden).append(",\"old\":").append(old)
+           .append(",\"meta\":").append(meta).append(",\"ccs\":").append(ccs)
+           .append(",\"ygc\":").append(ygc).append(",\"ygct\":").append(ygct)
+           .append(",\"fgc\":").append(fgc).append(",\"fgct\":").append(fgct)
+           .append(",\"gct\":").append(gct)
+           .append(",\"lastGcCause\":\"").append(RichRenderer.escapeJson(lastGcCause)).append('"')
+           .append(",\"currentGcCause\":\"").append(RichRenderer.escapeJson(currentGcCause)).append("\"}");
+    }
 }

--- a/argus-cli/src/main/java/io/argus/cli/model/GcNewResult.java
+++ b/argus-cli/src/main/java/io/argus/cli/model/GcNewResult.java
@@ -1,9 +1,11 @@
 package io.argus.cli.model;
 
+import io.argus.cli.json.JsonWritable;
+
 /**
  * Young generation GC detail from jstat -gcnew.
  */
-public final class GcNewResult {
+public final class GcNewResult implements JsonWritable {
     private final double s0c;   // Survivor 0 capacity (KB)
     private final double s1c;   // Survivor 1 capacity (KB)
     private final double s0u;   // Survivor 0 used (KB)
@@ -35,4 +37,13 @@ public final class GcNewResult {
     public double eu() { return eu; }
     public long ygc() { return ygc; }
     public double ygct() { return ygct; }
+
+    @Override
+    public void writeJson(StringBuilder out) {
+        out.append("{\"s0c\":").append(s0c).append(",\"s1c\":").append(s1c)
+           .append(",\"s0u\":").append(s0u).append(",\"s1u\":").append(s1u)
+           .append(",\"tt\":").append(tt).append(",\"mtt\":").append(mtt)
+           .append(",\"dss\":").append(dss).append(",\"ec\":").append(ec).append(",\"eu\":").append(eu)
+           .append(",\"ygc\":").append(ygc).append(",\"ygct\":").append(ygct).append('}');
+    }
 }

--- a/argus-cli/src/main/java/io/argus/cli/model/GcResult.java
+++ b/argus-cli/src/main/java/io/argus/cli/model/GcResult.java
@@ -1,11 +1,14 @@
 package io.argus.cli.model;
 
+import io.argus.cli.json.JsonWritable;
+import io.argus.cli.render.RichRenderer;
+
 import java.util.List;
 
 /**
  * GC statistics result.
  */
-public final class GcResult {
+public final class GcResult implements JsonWritable {
     private final long totalEvents;
     private final double totalPauseMs;
     private final double overheadPercent;
@@ -33,6 +36,26 @@ public final class GcResult {
     public long heapUsed() { return heapUsed; }
     public long heapCommitted() { return heapCommitted; }
     public List<CollectorInfo> collectors() { return collectors; }
+
+    @Override
+    public void writeJson(StringBuilder out) {
+        out.append("{\"totalEvents\":").append(totalEvents)
+           .append(",\"totalPauseMs\":").append(totalPauseMs)
+           .append(",\"overheadPercent\":").append(overheadPercent)
+           .append(",\"lastCause\":\"").append(RichRenderer.escapeJson(lastCause)).append('"')
+           .append(",\"heapUsed\":").append(heapUsed)
+           .append(",\"heapCommitted\":").append(heapCommitted)
+           .append(",\"collectors\":[");
+        for (int i = 0; i < collectors.size(); i++) {
+            CollectorInfo c = collectors.get(i);
+            if (i > 0) out.append(',');
+            out.append("{\"name\":\"").append(RichRenderer.escapeJson(c.name())).append('"')
+               .append(",\"count\":").append(c.count())
+               .append(",\"totalMs\":").append(c.totalMs())
+               .append('}');
+        }
+        out.append("]}");
+    }
 
     public static final class CollectorInfo {
         private final String name;

--- a/argus-cli/src/main/java/io/argus/cli/model/GcUtilResult.java
+++ b/argus-cli/src/main/java/io/argus/cli/model/GcUtilResult.java
@@ -1,9 +1,11 @@
 package io.argus.cli.model;
 
+import io.argus.cli.json.JsonWritable;
+
 /**
  * GC utilization snapshot from jstat -gcutil.
  */
-public final class GcUtilResult {
+public final class GcUtilResult implements JsonWritable {
     private final double s0;       // Survivor 0 usage %
     private final double s1;       // Survivor 1 usage %
     private final double eden;     // Eden usage %
@@ -42,4 +44,20 @@ public final class GcUtilResult {
     public long fgc() { return fgc; }
     public double fgct() { return fgct; }
     public double gct() { return gct; }
+
+    @Override
+    public void writeJson(StringBuilder out) {
+        out.append("{\"s0\":").append(s0)
+           .append(",\"s1\":").append(s1)
+           .append(",\"eden\":").append(eden)
+           .append(",\"old\":").append(old)
+           .append(",\"meta\":").append(meta)
+           .append(",\"ccs\":").append(ccs)
+           .append(",\"ygc\":").append(ygc)
+           .append(",\"ygct\":").append(ygct)
+           .append(",\"fgc\":").append(fgc)
+           .append(",\"fgct\":").append(fgct)
+           .append(",\"gct\":").append(gct)
+           .append('}');
+    }
 }

--- a/argus-cli/src/main/java/io/argus/cli/model/HeapDumpResult.java
+++ b/argus-cli/src/main/java/io/argus/cli/model/HeapDumpResult.java
@@ -1,9 +1,12 @@
 package io.argus.cli.model;
 
+import io.argus.cli.json.JsonWritable;
+import io.argus.cli.render.RichRenderer;
+
 /**
  * Result of a heap dump operation.
  */
-public final class HeapDumpResult {
+public final class HeapDumpResult implements JsonWritable {
 
     private final String status;
     private final String filePath;
@@ -31,5 +34,18 @@ public final class HeapDumpResult {
 
     public String errorMessage() {
         return errorMessage;
+    }
+
+    @Override
+    public void writeJson(StringBuilder out) {
+        out.append("{\"status\":\"").append(RichRenderer.escapeJson(status)).append('"')
+           .append(",\"filePath\":\"").append(RichRenderer.escapeJson(filePath)).append('"')
+           .append(",\"fileSizeBytes\":").append(fileSizeBytes);
+        if (errorMessage != null) {
+            out.append(",\"errorMessage\":\"").append(RichRenderer.escapeJson(errorMessage)).append('"');
+        } else {
+            out.append(",\"errorMessage\":null");
+        }
+        out.append('}');
     }
 }

--- a/argus-cli/src/main/java/io/argus/cli/model/HeapResult.java
+++ b/argus-cli/src/main/java/io/argus/cli/model/HeapResult.java
@@ -1,11 +1,14 @@
 package io.argus.cli.model;
 
+import io.argus.cli.json.JsonWritable;
+import io.argus.cli.render.RichRenderer;
+
 import java.util.Map;
 
 /**
  * Heap memory usage result.
  */
-public final class HeapResult {
+public final class HeapResult implements JsonWritable {
     private final long used;
     private final long committed;
     private final long max;
@@ -22,6 +25,27 @@ public final class HeapResult {
     public long committed() { return committed; }
     public long max() { return max; }
     public Map<String, SpaceInfo> spaces() { return spaces; }
+
+    @Override
+    public void writeJson(StringBuilder out) {
+        out.append("{\"used\":").append(used)
+           .append(",\"committed\":").append(committed)
+           .append(",\"max\":").append(max)
+           .append(",\"spaces\":{");
+        boolean first = true;
+        for (Map.Entry<String, SpaceInfo> e : spaces.entrySet()) {
+            if (!first) out.append(',');
+            SpaceInfo s = e.getValue();
+            out.append('"').append(RichRenderer.escapeJson(e.getKey())).append("\":")
+               .append("{\"name\":\"").append(RichRenderer.escapeJson(s.name())).append('"')
+               .append(",\"used\":").append(s.used())
+               .append(",\"committed\":").append(s.committed())
+               .append(",\"max\":").append(s.max())
+               .append('}');
+            first = false;
+        }
+        out.append("}}");
+    }
 
     public static final class SpaceInfo {
         private final String name;

--- a/argus-cli/src/main/java/io/argus/cli/model/HistoResult.java
+++ b/argus-cli/src/main/java/io/argus/cli/model/HistoResult.java
@@ -1,11 +1,14 @@
 package io.argus.cli.model;
 
+import io.argus.cli.json.JsonWritable;
+import io.argus.cli.render.RichRenderer;
+
 import java.util.List;
 
 /**
  * Heap object histogram result.
  */
-public final class HistoResult {
+public final class HistoResult implements JsonWritable {
     private final List<Entry> entries;
     private final long totalInstances;
     private final long totalBytes;
@@ -19,6 +22,23 @@ public final class HistoResult {
     public List<Entry> entries() { return entries; }
     public long totalInstances() { return totalInstances; }
     public long totalBytes() { return totalBytes; }
+
+    @Override
+    public void writeJson(StringBuilder out) {
+        out.append("{\"totalInstances\":").append(totalInstances)
+           .append(",\"totalBytes\":").append(totalBytes)
+           .append(",\"entries\":[");
+        for (int i = 0; i < entries.size(); i++) {
+            Entry e = entries.get(i);
+            if (i > 0) out.append(',');
+            out.append("{\"rank\":").append(e.rank())
+               .append(",\"className\":\"").append(RichRenderer.escapeJson(e.className())).append('"')
+               .append(",\"instances\":").append(e.instances())
+               .append(",\"bytes\":").append(e.bytes())
+               .append('}');
+        }
+        out.append("]}");
+    }
 
     public static final class Entry {
         private final int rank;

--- a/argus-cli/src/main/java/io/argus/cli/model/InfoResult.java
+++ b/argus-cli/src/main/java/io/argus/cli/model/InfoResult.java
@@ -1,12 +1,15 @@
 package io.argus.cli.model;
 
+import io.argus.cli.json.JsonWritable;
+import io.argus.cli.render.RichRenderer;
+
 import java.util.List;
 import java.util.Map;
 
 /**
  * JVM information result.
  */
-public final class InfoResult {
+public final class InfoResult implements JsonWritable {
     private final String vmName;
     private final String vmVersion;
     private final String vmVendor;
@@ -54,4 +57,32 @@ public final class InfoResult {
     public double systemCpuLoad() { return systemCpuLoad; }
     public int availableProcessors() { return availableProcessors; }
     public double systemLoadAverage() { return systemLoadAverage; }
+
+    @Override
+    public void writeJson(StringBuilder out) {
+        out.append("{\"vmName\":\"").append(RichRenderer.escapeJson(vmName)).append('"')
+           .append(",\"vmVersion\":\"").append(RichRenderer.escapeJson(vmVersion)).append('"')
+           .append(",\"vmVendor\":\"").append(RichRenderer.escapeJson(vmVendor)).append('"')
+           .append(",\"uptimeMs\":").append(uptimeMs)
+           .append(",\"pid\":").append(pid)
+           .append(",\"vmFlags\":[");
+        for (int i = 0; i < vmFlags.size(); i++) {
+            if (i > 0) out.append(',');
+            out.append('"').append(RichRenderer.escapeJson(vmFlags.get(i))).append('"');
+        }
+        out.append("],\"systemProperties\":{");
+        boolean first = true;
+        for (Map.Entry<String, String> e : systemProperties.entrySet()) {
+            if (!first) out.append(',');
+            out.append('"').append(RichRenderer.escapeJson(e.getKey())).append("\":\"")
+               .append(RichRenderer.escapeJson(e.getValue())).append('"');
+            first = false;
+        }
+        out.append("}")
+           .append(",\"processCpuLoad\":").append(processCpuLoad)
+           .append(",\"systemCpuLoad\":").append(systemCpuLoad)
+           .append(",\"availableProcessors\":").append(availableProcessors)
+           .append(",\"systemLoadAverage\":").append(systemLoadAverage)
+           .append('}');
+    }
 }

--- a/argus-cli/src/main/java/io/argus/cli/model/JfrResult.java
+++ b/argus-cli/src/main/java/io/argus/cli/model/JfrResult.java
@@ -1,9 +1,12 @@
 package io.argus.cli.model;
 
+import io.argus.cli.json.JsonWritable;
+import io.argus.cli.render.RichRenderer;
+
 /**
  * Result of a JFR Flight Recorder control command.
  */
-public final class JfrResult {
+public final class JfrResult implements JsonWritable {
     private final String status;
     private final String message;
     private final String recordingInfo;
@@ -17,4 +20,16 @@ public final class JfrResult {
     public String status() { return status; }
     public String message() { return message; }
     public String recordingInfo() { return recordingInfo; }
+
+    @Override
+    public void writeJson(StringBuilder out) {
+        out.append("{\"status\":\"").append(RichRenderer.escapeJson(status)).append('"')
+           .append(",\"message\":\"").append(RichRenderer.escapeJson(message)).append('"');
+        if (recordingInfo != null) {
+            out.append(",\"recordingInfo\":\"").append(RichRenderer.escapeJson(recordingInfo)).append('"');
+        } else {
+            out.append(",\"recordingInfo\":null");
+        }
+        out.append('}');
+    }
 }

--- a/argus-cli/src/main/java/io/argus/cli/model/MetaspaceResult.java
+++ b/argus-cli/src/main/java/io/argus/cli/model/MetaspaceResult.java
@@ -1,11 +1,13 @@
 package io.argus.cli.model;
 
+import io.argus.cli.json.JsonWritable;
+
 import java.util.List;
 
 /**
  * Detailed metaspace statistics from jcmd VM.metaspace.
  */
-public final class MetaspaceResult {
+public final class MetaspaceResult implements JsonWritable {
     private final long totalReserved;
     private final long totalCommitted;
     private final long totalUsed;
@@ -23,6 +25,23 @@ public final class MetaspaceResult {
     public long totalCommitted() { return totalCommitted; }
     public long totalUsed() { return totalUsed; }
     public List<SpaceInfo> spaces() { return spaces; }
+
+    @Override
+    public void writeJson(StringBuilder out) {
+        out.append("{\"totalReserved\":").append(totalReserved)
+           .append(",\"totalCommitted\":").append(totalCommitted)
+           .append(",\"totalUsed\":").append(totalUsed)
+           .append(",\"spaces\":[");
+        for (int i = 0; i < spaces.size(); i++) {
+            SpaceInfo sp = spaces.get(i);
+            if (i > 0) out.append(',');
+            out.append("{\"name\":\"").append(sp.name()).append('"')
+               .append(",\"reserved\":").append(sp.reserved())
+               .append(",\"committed\":").append(sp.committed())
+               .append(",\"used\":").append(sp.used()).append('}');
+        }
+        out.append("]}");
+    }
 
     public static final class SpaceInfo {
         private final String name;

--- a/argus-cli/src/main/java/io/argus/cli/model/NmtResult.java
+++ b/argus-cli/src/main/java/io/argus/cli/model/NmtResult.java
@@ -1,11 +1,14 @@
 package io.argus.cli.model;
 
+import io.argus.cli.json.JsonWritable;
+import io.argus.cli.render.RichRenderer;
+
 import java.util.List;
 
 /**
  * Snapshot of native memory tracking from jcmd VM.native_memory summary.
  */
-public final class NmtResult {
+public final class NmtResult implements JsonWritable {
     private final long totalReservedKB;
     private final long totalCommittedKB;
     private final List<NmtCategory> categories;
@@ -36,6 +39,23 @@ public final class NmtResult {
     public long totalReservedKB() { return totalReservedKB; }
     public long totalCommittedKB() { return totalCommittedKB; }
     public List<NmtCategory> categories() { return categories; }
+
+    @Override
+    public void writeJson(StringBuilder out) {
+        out.append("{\"totalReservedKB\":").append(totalReservedKB)
+           .append(",\"totalCommittedKB\":").append(totalCommittedKB)
+           .append(",\"categories\":[");
+        boolean first = true;
+        for (NmtCategory cat : categories) {
+            if (!first) out.append(',');
+            out.append("{\"name\":\"").append(RichRenderer.escapeJson(cat.name())).append('"')
+               .append(",\"reservedKB\":").append(cat.reservedKB())
+               .append(",\"committedKB\":").append(cat.committedKB())
+               .append('}');
+            first = false;
+        }
+        out.append("]}");
+    }
 
     public static final class NmtCategory {
         private final String name;

--- a/argus-cli/src/main/java/io/argus/cli/model/PoolResult.java
+++ b/argus-cli/src/main/java/io/argus/cli/model/PoolResult.java
@@ -1,12 +1,15 @@
 package io.argus.cli.model;
 
+import io.argus.cli.json.JsonWritable;
+import io.argus.cli.render.RichRenderer;
+
 import java.util.List;
 import java.util.Map;
 
 /**
  * Thread pool analysis result.
  */
-public final class PoolResult {
+public final class PoolResult implements JsonWritable {
     private final int totalThreads;
     private final int totalPools;
     private final List<PoolInfo> pools;
@@ -20,6 +23,28 @@ public final class PoolResult {
     public int totalThreads() { return totalThreads; }
     public int totalPools() { return totalPools; }
     public List<PoolInfo> pools() { return pools; }
+
+    @Override
+    public void writeJson(StringBuilder out) {
+        out.append("{\"totalThreads\":").append(totalThreads)
+           .append(",\"totalPools\":").append(totalPools)
+           .append(",\"pools\":[");
+        for (int i = 0; i < pools.size(); i++) {
+            PoolInfo p = pools.get(i);
+            if (i > 0) out.append(',');
+            out.append("{\"name\":\"").append(RichRenderer.escapeJson(p.name())).append('"')
+               .append(",\"threadCount\":").append(p.threadCount())
+               .append(",\"states\":{");
+            boolean first = true;
+            for (Map.Entry<String, Integer> e : p.stateDistribution().entrySet()) {
+                if (!first) out.append(',');
+                out.append('"').append(e.getKey()).append("\":").append(e.getValue());
+                first = false;
+            }
+            out.append("}}");
+        }
+        out.append("]}");
+    }
 
     public static final class PoolInfo {
         private final String name;

--- a/argus-cli/src/main/java/io/argus/cli/model/StringTableResult.java
+++ b/argus-cli/src/main/java/io/argus/cli/model/StringTableResult.java
@@ -1,9 +1,11 @@
 package io.argus.cli.model;
 
+import io.argus.cli.json.JsonWritable;
+
 /**
  * String table (interned strings) statistics.
  */
-public final class StringTableResult {
+public final class StringTableResult implements JsonWritable {
     private final long bucketCount;
     private final long entryCount;
     private final long literalCount;
@@ -34,4 +36,17 @@ public final class StringTableResult {
     public long literalBytes() { return literalBytes; }
     public long totalBytes() { return totalBytes; }
     public double avgLiteralSize() { return avgLiteralSize; }
+
+    @Override
+    public void writeJson(StringBuilder out) {
+        out.append("{\"bucketCount\":").append(bucketCount)
+           .append(",\"entryCount\":").append(entryCount)
+           .append(",\"literalCount\":").append(literalCount)
+           .append(",\"bucketBytes\":").append(bucketBytes)
+           .append(",\"entryBytes\":").append(entryBytes)
+           .append(",\"literalBytes\":").append(literalBytes)
+           .append(",\"totalBytes\":").append(totalBytes)
+           .append(",\"avgLiteralSize\":").append(avgLiteralSize)
+           .append('}');
+    }
 }

--- a/argus-cli/src/main/java/io/argus/cli/model/SymbolTableResult.java
+++ b/argus-cli/src/main/java/io/argus/cli/model/SymbolTableResult.java
@@ -1,9 +1,11 @@
 package io.argus.cli.model;
 
+import io.argus.cli.json.JsonWritable;
+
 /**
  * Symbol table statistics from jcmd VM.symboltable.
  */
-public final class SymbolTableResult {
+public final class SymbolTableResult implements JsonWritable {
     private final long bucketCount;
     private final long entryCount;
     private final long literalCount;
@@ -34,4 +36,17 @@ public final class SymbolTableResult {
     public long literalBytes() { return literalBytes; }
     public long totalBytes() { return totalBytes; }
     public double avgLiteralSize() { return avgLiteralSize; }
+
+    @Override
+    public void writeJson(StringBuilder out) {
+        out.append("{\"bucketCount\":").append(bucketCount)
+           .append(",\"entryCount\":").append(entryCount)
+           .append(",\"literalCount\":").append(literalCount)
+           .append(",\"bucketBytes\":").append(bucketBytes)
+           .append(",\"entryBytes\":").append(entryBytes)
+           .append(",\"literalBytes\":").append(literalBytes)
+           .append(",\"totalBytes\":").append(totalBytes)
+           .append(",\"avgLiteralSize\":").append(avgLiteralSize)
+           .append('}');
+    }
 }

--- a/argus-cli/src/main/java/io/argus/cli/model/ThreadDumpResult.java
+++ b/argus-cli/src/main/java/io/argus/cli/model/ThreadDumpResult.java
@@ -1,11 +1,14 @@
 package io.argus.cli.model;
 
+import io.argus.cli.json.JsonWritable;
+import io.argus.cli.render.RichRenderer;
+
 import java.util.List;
 
 /**
  * Result of a full thread dump capture via jcmd Thread.print.
  */
-public final class ThreadDumpResult {
+public final class ThreadDumpResult implements JsonWritable {
 
     private final int totalThreads;
     private final List<ThreadInfo> threads;
@@ -20,6 +23,37 @@ public final class ThreadDumpResult {
     public int totalThreads() { return totalThreads; }
     public List<ThreadInfo> threads() { return threads; }
     public String rawOutput() { return rawOutput; }
+
+    @Override
+    public void writeJson(StringBuilder out) {
+        out.append("{\"totalThreads\":").append(totalThreads)
+           .append(",\"threads\":[");
+        for (int i = 0; i < threads.size(); i++) {
+            ThreadInfo t = threads.get(i);
+            if (i > 0) out.append(',');
+            out.append("{\"name\":\"").append(RichRenderer.escapeJson(t.name())).append('"')
+               .append(",\"tid\":").append(t.tid())
+               .append(",\"nid\":").append(t.nid())
+               .append(",\"state\":\"").append(t.state()).append('"')
+               .append(",\"daemon\":").append(t.daemon())
+               .append(",\"priority\":").append(t.priority());
+            if (!t.waitingOn().isEmpty()) {
+                out.append(",\"waitingOn\":\"").append(RichRenderer.escapeJson(t.waitingOn())).append('"');
+            }
+            out.append(",\"locksHeld\":[");
+            for (int j = 0; j < t.locksHeld().size(); j++) {
+                if (j > 0) out.append(',');
+                out.append('"').append(RichRenderer.escapeJson(t.locksHeld().get(j))).append('"');
+            }
+            out.append("],\"stackTrace\":[");
+            for (int j = 0; j < t.stackTrace().size(); j++) {
+                if (j > 0) out.append(',');
+                out.append('"').append(RichRenderer.escapeJson(t.stackTrace().get(j))).append('"');
+            }
+            out.append("]}");
+        }
+        out.append("]}");
+    }
 
     public static final class ThreadInfo {
         private final String name;

--- a/argus-cli/src/main/java/io/argus/cli/model/ThreadResult.java
+++ b/argus-cli/src/main/java/io/argus/cli/model/ThreadResult.java
@@ -1,12 +1,15 @@
 package io.argus.cli.model;
 
+import io.argus.cli.json.JsonWritable;
+import io.argus.cli.render.RichRenderer;
+
 import java.util.List;
 import java.util.Map;
 
 /**
  * Thread dump summary result.
  */
-public final class ThreadResult {
+public final class ThreadResult implements JsonWritable {
     private final int totalThreads;
     private final int virtualThreads;
     private final int platformThreads;
@@ -44,6 +47,30 @@ public final class ThreadResult {
     public Map<String, Integer> stateDistribution() { return stateDistribution; }
     public List<DeadlockInfo> deadlocks() { return deadlocks; }
     public List<ThreadInfo> threads() { return threads; }
+
+    @Override
+    public void writeJson(StringBuilder out) {
+        out.append("{\"totalThreads\":").append(totalThreads)
+           .append(",\"virtualThreads\":").append(virtualThreads)
+           .append(",\"platformThreads\":").append(platformThreads)
+           .append(",\"stateDistribution\":{");
+        boolean first = true;
+        for (Map.Entry<String, Integer> e : stateDistribution.entrySet()) {
+            if (!first) out.append(',');
+            out.append('"').append(e.getKey()).append("\":").append(e.getValue());
+            first = false;
+        }
+        out.append("},\"deadlocks\":[");
+        for (int i = 0; i < deadlocks.size(); i++) {
+            DeadlockInfo dl = deadlocks.get(i);
+            if (i > 0) out.append(',');
+            out.append("{\"thread1\":\"").append(RichRenderer.escapeJson(dl.thread1())).append('"')
+               .append(",\"thread2\":\"").append(RichRenderer.escapeJson(dl.thread2())).append('"')
+               .append(",\"lockClass\":\"").append(RichRenderer.escapeJson(dl.lockClass())).append('"')
+               .append('}');
+        }
+        out.append("]}");
+    }
 
     public static final class DeadlockInfo {
         private final String thread1;


### PR DESCRIPTION
Each of 47 commands had a private printJson(R) for a single model class. The JSON shape lives with the model, so the serialization belongs there. Adds io.argus.cli.json.JsonWritable + JsonOutput; migrates 23 models. Build + tests green. Overlaps with #211 / #212 on command files — merge in order.