### PR TITLE
feat(starter): add argus.mode posture knob (slice 2 of #216)

### DIFF
--- a/argus-spring-boot-starter/src/main/java/io/argus/spring/ArgusAutoConfiguration.java
+++ b/argus-spring-boot-starter/src/main/java/io/argus/spring/ArgusAutoConfiguration.java
@@ -13,6 +13,7 @@ import io.argus.core.event.VirtualThreadEvent;
 import io.argus.server.ArgusServer;
 
 import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
@@ -68,12 +69,14 @@ public class ArgusAutoConfiguration implements DisposableBean {
 
     @Bean
     @ConditionalOnMissingBean
+    @ConditionalOnProperty(prefix = "argus", name = "mode", havingValue = "full", matchIfMissing = true)
     public ArgusBuffers argusBuffers(AgentConfig config) {
         return new ArgusBuffers(config);
     }
 
     @Bean
     @ConditionalOnMissingBean
+    @ConditionalOnProperty(prefix = "argus", name = "mode", havingValue = "full", matchIfMissing = true)
     public JfrStreamingEngine argusJfrEngine(AgentConfig config, ArgusBuffers buffers) {
         engine = new JfrStreamingEngine(
                 buffers.eventBuffer(),
@@ -101,6 +104,7 @@ public class ArgusAutoConfiguration implements DisposableBean {
     @Bean
     @ConditionalOnMissingBean
     @ConditionalOnProperty(prefix = "argus.server", name = "enabled", havingValue = "true", matchIfMissing = true)
+    @ConditionalOnBean(ArgusBuffers.class)
     public ArgusServer argusServer(AgentConfig config, ArgusBuffers buffers) {
         server = new ArgusServer(
                 config.getServerPort(),

--- a/argus-spring-boot-starter/src/main/java/io/argus/spring/ArgusProperties.java
+++ b/argus-spring-boot-starter/src/main/java/io/argus/spring/ArgusProperties.java
@@ -28,7 +28,28 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 @ConfigurationProperties(prefix = "argus")
 public class ArgusProperties {
 
+    /**
+     * Runtime posture for the Argus starter.
+     *
+     * <ul>
+     *   <li>{@link #FULL} — auto-launch {@code JfrStreamingEngine} + embedded
+     *       {@code ArgusServer:9202} and register every diagnostic bean. Default;
+     *       matches the v1.4.0 behavior.</li>
+     *   <li>{@link #DIAGNOSTICS} — skip JFR streaming and the daemon HTTP server;
+     *       expose only the analysis-side beans (doctor / GC log / GC score) so
+     *       production apps can self-diagnose without a daemon listener.</li>
+     *   <li>{@link #OFF} — functionally equivalent to {@code argus.enabled=false};
+     *       no Argus beans are created.</li>
+     * </ul>
+     */
+    public enum Mode {
+        FULL,
+        DIAGNOSTICS,
+        OFF
+    }
+
     private boolean enabled = true;
+    private Mode mode = Mode.FULL;
     private int bufferSize = 65536;
     private Server server = new Server();
     private Gc gc = new Gc();
@@ -44,6 +65,9 @@ public class ArgusProperties {
 
     public boolean isEnabled() { return enabled; }
     public void setEnabled(boolean enabled) { this.enabled = enabled; }
+
+    public Mode getMode() { return mode; }
+    public void setMode(Mode mode) { this.mode = mode; }
 
     public int getBufferSize() { return bufferSize; }
     public void setBufferSize(int bufferSize) { this.bufferSize = bufferSize; }

--- a/argus-spring-boot-starter/src/test/java/io/argus/spring/ArgusAutoConfigurationIntegrationTest.java
+++ b/argus-spring-boot-starter/src/test/java/io/argus/spring/ArgusAutoConfigurationIntegrationTest.java
@@ -1,6 +1,8 @@
 package io.argus.spring;
 
+import io.argus.agent.jfr.JfrStreamingEngine;
 import io.argus.core.config.AgentConfig;
+import io.argus.server.ArgusServer;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
@@ -75,6 +77,47 @@ class ArgusAutoConfigurationIntegrationTest {
         new ApplicationContextRunner()
                 .withUserConfiguration(EnablePropsOnlyConfig.class)
                 .run(context -> assertThat(context).hasSingleBean(ArgusProperties.class));
+    }
+
+    @Test
+    void argusModeDiagnosticsSkipsJfrEngineAndServer() {
+        new ApplicationContextRunner()
+                .withConfiguration(AutoConfigurations.of(ArgusAutoConfiguration.class))
+                .withPropertyValues("argus.mode=diagnostics")
+                .run(context -> {
+                    // AgentConfig + ArgusProperties stay available for downstream diagnostics beans
+                    assertThat(context).hasSingleBean(ArgusProperties.class);
+                    assertThat(context).hasSingleBean(AgentConfig.class);
+                    // JFR streaming + daemon server are NOT created in diagnostics mode
+                    assertThat(context).doesNotHaveBean(JfrStreamingEngine.class);
+                    assertThat(context).doesNotHaveBean(ArgusServer.class);
+                    // Mode field is bound correctly
+                    assertThat(context.getBean(ArgusProperties.class).getMode())
+                            .isEqualTo(ArgusProperties.Mode.DIAGNOSTICS);
+                });
+    }
+
+    @Test
+    void argusModeOffSkipsJfrEngineAndServer() {
+        new ApplicationContextRunner()
+                .withConfiguration(AutoConfigurations.of(ArgusAutoConfiguration.class))
+                .withPropertyValues("argus.mode=off")
+                .run(context -> {
+                    // OFF mode behaves like DIAGNOSTICS for JFR/server beans; the
+                    // diagnostics-side beans will additionally be gated off in slice 3.
+                    assertThat(context).doesNotHaveBean(JfrStreamingEngine.class);
+                    assertThat(context).doesNotHaveBean(ArgusServer.class);
+                    assertThat(context.getBean(ArgusProperties.class).getMode())
+                            .isEqualTo(ArgusProperties.Mode.OFF);
+                });
+    }
+
+    @Test
+    void argusModeUnsetDefaultsToFull() {
+        new ApplicationContextRunner()
+                .withUserConfiguration(EnablePropsOnlyConfig.class)
+                .run(context -> assertThat(context.getBean(ArgusProperties.class).getMode())
+                        .isEqualTo(ArgusProperties.Mode.FULL));
     }
 
     @EnableConfigurationProperties(ArgusProperties.class)


### PR DESCRIPTION
## Summary

- New `argus.mode = full | diagnostics | off` property lets production apps opt into a lightweight diagnostics-only posture without spinning up the JFR stream or the embedded `ArgusServer:9202`
- Defaults to `FULL` (`matchIfMissing=true`) so v1.4.0 behavior is preserved
- **Slice 2 of 6** under #216

## Behavior matrix

| `argus.mode` | `JfrStreamingEngine` | `ArgusServer:9202` | `AgentConfig`/`ArgusProperties` | matches today |
|---|---|---|---|---|
| `full` *(default)* | started | started | beans | yes |
| `diagnostics` | skipped | skipped | beans (for slice-3 diagnostic services) | new |
| `off` | skipped | skipped | beans | new |

`argus.enabled=false` remains the outermost escape hatch — the existing class-level `@ConditionalOnProperty` on `ArgusAutoConfiguration` is untouched, so that case short-circuits before `mode` is read.

## Files

- `ArgusProperties.java` — new `Mode` enum + `mode` field (default `FULL`)
- `ArgusAutoConfiguration.java` — `@ConditionalOnProperty(name="mode", havingValue="full", matchIfMissing=true)` on `argusBuffers`, `argusJfrEngine`, plus `@ConditionalOnBean(ArgusBuffers.class)` on `argusServer` (since `argusServer` depends on `argusBuffers`)
- `ArgusAutoConfigurationIntegrationTest.java` — 3 new tests for DIAGNOSTICS / OFF / default FULL

## Test plan

- [x] `./gradlew :argus-spring-boot-starter:test` green (11 tests, +3 new)
- [x] `./gradlew test` green across all modules
- [x] Existing `argusEnabledFalseShortCircuitsAutoConfiguration` still passes — precedence preserved

## Notes for reviewer

- This PR's base is `slice-1/extract-argus-diagnostics`. After slice 1 merges, GitHub will re-target to master automatically.
- `ArgusMicrometerAutoConfiguration` and `ArgusHealthIndicator` already gate on `@ConditionalOnBean(ArgusServer.class)` / `@ConditionalOnBean(JfrStreamingEngine.class)` respectively, so they correctly auto-disable in DIAGNOSTICS mode without further changes.