### PR TITLE
feat(starter): expose DoctorService / GcLogAnalyzerService / GcScoreService beans (slice 3 of #216)

### DIFF
--- a/argus-spring-boot-starter/build.gradle.kts
+++ b/argus-spring-boot-starter/build.gradle.kts
@@ -7,6 +7,7 @@ dependencies {
     api(project(":argus-agent"))
     api(project(":argus-server"))
     api(project(":argus-micrometer"))
+    api(project(":argus-diagnostics"))
 
     compileOnly("org.springframework.boot:spring-boot-autoconfigure:3.2.0")
     compileOnly("org.springframework.boot:spring-boot-actuator-autoconfigure:3.2.0")

--- a/argus-spring-boot-starter/src/main/java/io/argus/spring/ArgusDiagnosticsAutoConfiguration.java
+++ b/argus-spring-boot-starter/src/main/java/io/argus/spring/ArgusDiagnosticsAutoConfiguration.java
@@ -1,0 +1,45 @@
+package io.argus.spring;
+
+import io.argus.spring.diagnostics.DoctorService;
+import io.argus.spring.diagnostics.GcLogAnalyzerService;
+import io.argus.spring.diagnostics.GcScoreService;
+
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+
+/**
+ * Programmatic-API auto-configuration: exposes the diagnostics library
+ * (doctor / GC log / GC score) as Spring beans so application code can
+ * {@code @Autowired} them.
+ *
+ * <p>Active in both {@code argus.mode=full} and {@code argus.mode=diagnostics}
+ * — only {@code argus.mode=off} or {@code argus.enabled=false} disables it.
+ */
+@AutoConfiguration(after = ArgusAutoConfiguration.class)
+@ConditionalOnProperty(prefix = "argus", name = "enabled", havingValue = "true", matchIfMissing = true)
+@ConditionalOnExpression("'${argus.mode:FULL}'.toUpperCase() != 'OFF'")
+@EnableConfigurationProperties(ArgusProperties.class)
+public class ArgusDiagnosticsAutoConfiguration {
+
+    @Bean
+    @ConditionalOnMissingBean
+    public DoctorService argusDoctorService() {
+        return new DoctorService();
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    public GcLogAnalyzerService argusGcLogAnalyzerService() {
+        return new GcLogAnalyzerService();
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    public GcScoreService argusGcScoreService() {
+        return new GcScoreService();
+    }
+}

--- a/argus-spring-boot-starter/src/main/java/io/argus/spring/diagnostics/DoctorService.java
+++ b/argus-spring-boot-starter/src/main/java/io/argus/spring/diagnostics/DoctorService.java
@@ -1,0 +1,67 @@
+package io.argus.spring.diagnostics;
+
+import io.argus.diagnostics.doctor.DoctorEngine;
+import io.argus.diagnostics.doctor.Finding;
+import io.argus.diagnostics.doctor.JvmSnapshot;
+import io.argus.diagnostics.doctor.JvmSnapshotCollector;
+
+import java.util.List;
+
+/**
+ * Programmatic entry point for the Argus doctor engine.
+ *
+ * <p>Wraps the static facades in {@link DoctorEngine} and
+ * {@link JvmSnapshotCollector} so applications can use Spring DI to
+ * inject and override diagnosis behavior.
+ *
+ * <pre>{@code
+ * @Autowired DoctorService doctor;
+ *
+ * @GetMapping("/admin/health/jvm")
+ * public List<Finding> jvmHealth() {
+ *     return doctor.diagnoseLocal();
+ * }
+ * }</pre>
+ */
+public class DoctorService {
+
+    /**
+     * Diagnose the JVM hosting the current process.
+     *
+     * @return sorted findings (CRITICAL first), never null
+     */
+    public List<Finding> diagnoseLocal() {
+        return DoctorEngine.diagnose(JvmSnapshotCollector.collectLocal());
+    }
+
+    /**
+     * Diagnose a remote JVM by PID via {@code jcmd}.
+     *
+     * @param pid target JVM process id (0 or current pid routes to local)
+     * @return sorted findings (CRITICAL first), never null
+     */
+    public List<Finding> diagnoseRemote(long pid) {
+        return DoctorEngine.diagnose(JvmSnapshotCollector.collect(pid));
+    }
+
+    /**
+     * Diagnose a pre-collected snapshot — useful for tests or for callers
+     * that source snapshots from somewhere other than this JVM / jcmd.
+     */
+    public List<Finding> diagnose(JvmSnapshot snapshot) {
+        return DoctorEngine.diagnose(snapshot);
+    }
+
+    /**
+     * Same as {@link #diagnose(JvmSnapshot)} but lets callers override the
+     * MaxPauseRule warning threshold (critical is set to {@code warning × 4}).
+     */
+    public List<Finding> diagnose(JvmSnapshot snapshot, long pauseThresholdMs) {
+        return DoctorEngine.diagnose(snapshot, pauseThresholdMs);
+    }
+
+    /** Warnings emitted by the most recent {@code diagnoseRemote} call (jcmd failures, etc.). */
+    public List<String> lastCollectionWarnings() {
+        return JvmSnapshotCollector.lastWarnings();
+    }
+}

--- a/argus-spring-boot-starter/src/main/java/io/argus/spring/diagnostics/GcLogAnalyzerService.java
+++ b/argus-spring-boot-starter/src/main/java/io/argus/spring/diagnostics/GcLogAnalyzerService.java
@@ -1,0 +1,37 @@
+package io.argus.spring.diagnostics;
+
+import io.argus.diagnostics.gclog.GcEvent;
+import io.argus.diagnostics.gclog.GcLogAnalysis;
+import io.argus.diagnostics.gclog.GcLogAnalyzer;
+import io.argus.diagnostics.gclog.GcLogParser;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.List;
+
+/**
+ * Parse a GC log and return aggregated analysis statistics.
+ *
+ * <p>Thin Spring-injectable wrapper around the static facades
+ * {@link GcLogParser} and {@link GcLogAnalyzer}.
+ */
+public class GcLogAnalyzerService {
+
+    /**
+     * Parse and analyze a GC log file in one call.
+     *
+     * @param gcLogPath absolute or relative path to a GC log produced by
+     *                  {@code -Xlog:gc*:file=...} or legacy {@code -Xloggc=...}
+     */
+    public GcLogAnalysis analyze(Path gcLogPath) throws IOException {
+        List<GcEvent> events = GcLogParser.parse(gcLogPath);
+        return GcLogAnalyzer.analyze(events);
+    }
+
+    /**
+     * Analyze an already-parsed event list (e.g. from a custom collector).
+     */
+    public GcLogAnalysis analyze(List<GcEvent> events) {
+        return GcLogAnalyzer.analyze(events);
+    }
+}

--- a/argus-spring-boot-starter/src/main/java/io/argus/spring/diagnostics/GcScoreService.java
+++ b/argus-spring-boot-starter/src/main/java/io/argus/spring/diagnostics/GcScoreService.java
@@ -1,0 +1,35 @@
+package io.argus.spring.diagnostics;
+
+import io.argus.diagnostics.gclog.GcLogAnalysis;
+import io.argus.diagnostics.gcscore.GcScoreCalculator;
+import io.argus.diagnostics.gcscore.GcScoreResult;
+
+/**
+ * Compute a multi-axis GC health score from a {@link GcLogAnalysis}.
+ *
+ * <p>Thin Spring-injectable wrapper around {@link GcScoreCalculator}.
+ */
+public class GcScoreService {
+
+    /**
+     * Score a GC analysis with auto-detected algorithm.
+     */
+    public GcScoreResult score(GcLogAnalysis analysis) {
+        return GcScoreCalculator.compute(analysis);
+    }
+
+    /**
+     * Score a GC analysis assuming the given GC algorithm
+     * (e.g. {@code "G1"}, {@code "ZGC"}, {@code "Parallel"}).
+     * Use when the algorithm is known a priori — bypasses inference and
+     * may apply algorithm-specific weight branches (notably ZGC).
+     */
+    public GcScoreResult score(GcLogAnalysis analysis, String gcAlgorithm) {
+        return GcScoreCalculator.compute(analysis, gcAlgorithm);
+    }
+
+    /** Infer the GC algorithm from analysis signals (collector cause / pattern). */
+    public String inferAlgorithm(GcLogAnalysis analysis) {
+        return GcScoreCalculator.inferAlgorithm(analysis);
+    }
+}

--- a/argus-spring-boot-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/argus-spring-boot-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,2 +1,3 @@
 io.argus.spring.ArgusAutoConfiguration
+io.argus.spring.ArgusDiagnosticsAutoConfiguration
 io.argus.spring.ArgusMicrometerAutoConfiguration

--- a/argus-spring-boot-starter/src/test/java/io/argus/spring/ArgusAutoConfigurationIntegrationTest.java
+++ b/argus-spring-boot-starter/src/test/java/io/argus/spring/ArgusAutoConfigurationIntegrationTest.java
@@ -2,7 +2,13 @@ package io.argus.spring;
 
 import io.argus.agent.jfr.JfrStreamingEngine;
 import io.argus.core.config.AgentConfig;
+import io.argus.diagnostics.doctor.Finding;
 import io.argus.server.ArgusServer;
+import io.argus.spring.diagnostics.DoctorService;
+import io.argus.spring.diagnostics.GcLogAnalyzerService;
+import io.argus.spring.diagnostics.GcScoreService;
+
+import java.util.List;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
@@ -109,6 +115,52 @@ class ArgusAutoConfigurationIntegrationTest {
                     assertThat(context).doesNotHaveBean(ArgusServer.class);
                     assertThat(context.getBean(ArgusProperties.class).getMode())
                             .isEqualTo(ArgusProperties.Mode.OFF);
+                });
+    }
+
+    @Test
+    void diagnosticsServicesAreAvailableInDiagnosticsMode() {
+        new ApplicationContextRunner()
+                .withConfiguration(AutoConfigurations.of(
+                        ArgusAutoConfiguration.class,
+                        ArgusDiagnosticsAutoConfiguration.class))
+                .withPropertyValues("argus.mode=diagnostics")
+                .run(context -> {
+                    assertThat(context).hasSingleBean(DoctorService.class);
+                    assertThat(context).hasSingleBean(GcLogAnalyzerService.class);
+                    assertThat(context).hasSingleBean(GcScoreService.class);
+                    // No JFR / server side effects
+                    assertThat(context).doesNotHaveBean(JfrStreamingEngine.class);
+                    assertThat(context).doesNotHaveBean(ArgusServer.class);
+                    // DoctorService can actually diagnose the test JVM
+                    List<Finding> findings = context.getBean(DoctorService.class).diagnoseLocal();
+                    assertThat(findings).isNotNull();
+                });
+    }
+
+    @Test
+    void diagnosticsServicesAreSkippedWhenModeOff() {
+        new ApplicationContextRunner()
+                .withConfiguration(AutoConfigurations.of(
+                        ArgusAutoConfiguration.class,
+                        ArgusDiagnosticsAutoConfiguration.class))
+                .withPropertyValues("argus.mode=off")
+                .run(context -> {
+                    assertThat(context).doesNotHaveBean(DoctorService.class);
+                    assertThat(context).doesNotHaveBean(GcLogAnalyzerService.class);
+                    assertThat(context).doesNotHaveBean(GcScoreService.class);
+                });
+    }
+
+    @Test
+    void diagnosticsServicesAreSkippedWhenEnabledFalse() {
+        new ApplicationContextRunner()
+                .withConfiguration(AutoConfigurations.of(
+                        ArgusAutoConfiguration.class,
+                        ArgusDiagnosticsAutoConfiguration.class))
+                .withPropertyValues("argus.enabled=false")
+                .run(context -> {
+                    assertThat(context).doesNotHaveBean(DoctorService.class);
                 });
     }
 


### PR DESCRIPTION
## Summary

- New `ArgusDiagnosticsAutoConfiguration` exposes the `argus-diagnostics` library as 3 injectable Spring beans
- Active in both `argus.mode=full` and `argus.mode=diagnostics`; skips when `argus.mode=off` or `argus.enabled=false`
- **Slice 3 of 6** under #216

## Services

| Bean | Wraps | API |
|---|---|---|
| `DoctorService` | `DoctorEngine` + `JvmSnapshotCollector` | `diagnoseLocal()`, `diagnoseRemote(pid)`, `diagnose(snapshot)`, `diagnose(snapshot, pauseThresholdMs)`, `lastCollectionWarnings()` |
| `GcLogAnalyzerService` | `GcLogParser` + `GcLogAnalyzer` | `analyze(Path)`, `analyze(List<GcEvent>)` |
| `GcScoreService` | `GcScoreCalculator` | `score(analysis)`, `score(analysis, algorithm)`, `inferAlgorithm(analysis)` |

All beans are `@ConditionalOnMissingBean` so applications can replace any of them with a custom implementation.

## Conditional logic

```java
@AutoConfiguration(after = ArgusAutoConfiguration.class)
@ConditionalOnProperty(prefix = "argus", name = "enabled", havingValue = "true", matchIfMissing = true)
@ConditionalOnExpression("'\${argus.mode:FULL}'.toUpperCase() != 'OFF'")
```

`@ConditionalOnExpression` is needed because Spring's `@ConditionalOnProperty` has no "not equals" mode and the auto-config needs to activate for both `FULL` and `DIAGNOSTICS`.

## Files

- ✨ `ArgusDiagnosticsAutoConfiguration.java`
- ✨ `diagnostics/DoctorService.java`
- ✨ `diagnostics/GcLogAnalyzerService.java`
- ✨ `diagnostics/GcScoreService.java`
- 📝 `META-INF/spring/.../AutoConfiguration.imports` — +1 entry
- 📝 `build.gradle.kts` — `api(project(":argus-diagnostics"))`
- 📝 `ArgusAutoConfigurationIntegrationTest.java` — 3 new tests

## Test plan

- [x] `./gradlew :argus-spring-boot-starter:test` green (14 tests, +3 new)
- [x] `./gradlew test` green across all modules
- [x] `diagnosticsServicesAreAvailableInDiagnosticsMode` actually invokes `DoctorService.diagnoseLocal()` against the test JVM and asserts a non-null finding list

## Notes for reviewer

- Base branch is `slice-2/argus-mode-posture`; GitHub will re-target to `master` automatically once slice 1 and slice 2 merge.
- The `@ConditionalOnExpression` resolves `argus.mode:FULL` (default to FULL when unset) and case-insensitive-compares against `OFF`, so users typing `argus.mode=off` or `argus.mode=OFF` both disable the diagnostics services.