### PR TITLE
feat(starter): actuator endpoints /actuator/argus-doctor and /actuator/argus-gc (slice 4 of #216)

### DIFF
--- a/argus-spring-boot-starter/src/main/java/io/argus/spring/ArgusProperties.java
+++ b/argus-spring-boot-starter/src/main/java/io/argus/spring/ArgusProperties.java
@@ -59,6 +59,7 @@ public class ArgusProperties {
     private Profiling profiling = new Profiling();
     private Contention contention = new Contention();
     private Correlation correlation = new Correlation();
+    private Doctor doctor = new Doctor();
     private Metrics metrics = new Metrics();
 
     // -- Top-level getters/setters --
@@ -95,6 +96,9 @@ public class ArgusProperties {
 
     public Correlation getCorrelation() { return correlation; }
     public void setCorrelation(Correlation correlation) { this.correlation = correlation; }
+
+    public Doctor getDoctor() { return doctor; }
+    public void setDoctor(Doctor doctor) { this.doctor = doctor; }
 
     public Metrics getMetrics() { return metrics; }
     public void setMetrics(Metrics metrics) { this.metrics = metrics; }
@@ -170,6 +174,15 @@ public class ArgusProperties {
 
         public boolean isEnabled() { return enabled; }
         public void setEnabled(boolean enabled) { this.enabled = enabled; }
+    }
+
+    /** Doctor / GC-log analysis configuration. Consumed by the diagnostics auto-config + actuator endpoints. */
+    public static class Doctor {
+        /** Optional path to a GC log file; consumed by the {@code /actuator/argus-gc} endpoint. */
+        private String gcLogPath;
+
+        public String getGcLogPath() { return gcLogPath; }
+        public void setGcLogPath(String gcLogPath) { this.gcLogPath = gcLogPath; }
     }
 
     public static class Metrics {

--- a/argus-spring-boot-starter/src/main/java/io/argus/spring/actuate/ArgusActuatorAutoConfiguration.java
+++ b/argus-spring-boot-starter/src/main/java/io/argus/spring/actuate/ArgusActuatorAutoConfiguration.java
@@ -1,0 +1,51 @@
+package io.argus.spring.actuate;
+
+import io.argus.spring.ArgusDiagnosticsAutoConfiguration;
+import io.argus.spring.ArgusProperties;
+import io.argus.spring.diagnostics.DoctorService;
+import io.argus.spring.diagnostics.GcLogAnalyzerService;
+import io.argus.spring.diagnostics.GcScoreService;
+
+import org.springframework.boot.actuate.endpoint.annotation.Endpoint;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.context.annotation.Bean;
+
+/**
+ * Registers Spring Boot Actuator endpoints for the Argus diagnostics:
+ *
+ * <ul>
+ *   <li>{@code /actuator/argus-doctor} — JVM health diagnosis</li>
+ *   <li>{@code /actuator/argus-gc}     — GC log analysis + score</li>
+ * </ul>
+ *
+ * <p>Activated when Spring Boot Actuator's {@code @Endpoint} annotation is
+ * on the classpath and the {@link DoctorService} bean exists (which means
+ * {@link ArgusDiagnosticsAutoConfiguration} ran first).
+ *
+ * <p>Users must opt in via {@code management.endpoints.web.exposure.include}
+ * — the standard Actuator gate. The endpoints themselves are registered
+ * unconditionally so {@code /actuator} discovery shows them.
+ */
+@AutoConfiguration(after = ArgusDiagnosticsAutoConfiguration.class)
+@ConditionalOnClass(Endpoint.class)
+@ConditionalOnBean(DoctorService.class)
+public class ArgusActuatorAutoConfiguration {
+
+    @Bean
+    @ConditionalOnMissingBean
+    public ArgusDoctorEndpoint argusDoctorEndpoint(DoctorService doctorService) {
+        return new ArgusDoctorEndpoint(doctorService);
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    @ConditionalOnBean({GcLogAnalyzerService.class, GcScoreService.class})
+    public ArgusGcLogEndpoint argusGcLogEndpoint(GcLogAnalyzerService analyzer,
+                                                 GcScoreService scorer,
+                                                 ArgusProperties properties) {
+        return new ArgusGcLogEndpoint(analyzer, scorer, properties);
+    }
+}

--- a/argus-spring-boot-starter/src/main/java/io/argus/spring/actuate/ArgusDoctorEndpoint.java
+++ b/argus-spring-boot-starter/src/main/java/io/argus/spring/actuate/ArgusDoctorEndpoint.java
@@ -1,0 +1,95 @@
+package io.argus.spring.actuate;
+
+import io.argus.diagnostics.doctor.DoctorEngine;
+import io.argus.diagnostics.doctor.Finding;
+import io.argus.spring.diagnostics.DoctorService;
+
+import org.springframework.boot.actuate.endpoint.annotation.Endpoint;
+import org.springframework.boot.actuate.endpoint.annotation.ReadOperation;
+import org.springframework.boot.actuate.endpoint.annotation.Selector;
+
+import java.util.ArrayList;
+import java.util.EnumMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Spring Boot Actuator endpoint exposing the Argus doctor diagnosis.
+ *
+ * <p>HTTP path: {@code /actuator/argus-doctor}. Expose via:
+ * <pre>
+ * management:
+ *   endpoints:
+ *     web:
+ *       exposure:
+ *         include: argus-doctor
+ * </pre>
+ *
+ * <p>The response payload is built as an explicit {@link Map} rather than
+ * letting Jackson serialize {@link Finding} directly, because {@code Finding}
+ * implements {@code JsonWritable} (hand-built JSON) and does not follow
+ * Jackson bean conventions — handing it to Jackson would produce a surprising
+ * shape (or fail outright on older Jackson versions).
+ */
+@Endpoint(id = "argus-doctor")
+public class ArgusDoctorEndpoint {
+
+    private final DoctorService doctor;
+
+    public ArgusDoctorEndpoint(DoctorService doctor) {
+        this.doctor = doctor;
+    }
+
+    /**
+     * Diagnose the local JVM (the one hosting this Spring application) and
+     * return findings grouped with severity histogram + suggested flags.
+     *
+     * <p>HTTP: {@code GET /actuator/argus-doctor}
+     */
+    @ReadOperation
+    public Map<String, Object> diagnoseLocal() {
+        List<Finding> findings = doctor.diagnoseLocal();
+        return buildResponse(findings, "local");
+    }
+
+    /**
+     * Diagnose a remote JVM by PID via {@code jcmd}.
+     *
+     * <p>HTTP: {@code GET /actuator/argus-doctor/{pid}}
+     */
+    @ReadOperation
+    public Map<String, Object> diagnoseRemote(@Selector long pid) {
+        List<Finding> findings = doctor.diagnoseRemote(pid);
+        return buildResponse(findings, Long.toString(pid));
+    }
+
+    private Map<String, Object> buildResponse(List<Finding> findings, String target) {
+        EnumMap<io.argus.diagnostics.doctor.Severity, Integer> severityCount =
+                new EnumMap<>(io.argus.diagnostics.doctor.Severity.class);
+        for (Finding f : findings) {
+            severityCount.merge(f.severity(), 1, Integer::sum);
+        }
+
+        List<Map<String, Object>> findingsJson = new ArrayList<>(findings.size());
+        for (Finding f : findings) {
+            Map<String, Object> entry = new LinkedHashMap<>();
+            entry.put("severity", f.severity().name());
+            entry.put("category", f.category());
+            entry.put("title", f.title());
+            entry.put("detail", f.detail());
+            entry.put("recommendations", f.recommendations());
+            entry.put("suggestedFlags", f.suggestedFlags());
+            findingsJson.add(entry);
+        }
+
+        Map<String, Object> response = new LinkedHashMap<>();
+        response.put("target", target);
+        response.put("exitCode", DoctorEngine.exitCode(findings));
+        response.put("findingCount", findings.size());
+        response.put("severityCount", severityCount);
+        response.put("suggestedFlags", DoctorEngine.collectSuggestedFlags(findings));
+        response.put("findings", findingsJson);
+        return response;
+    }
+}

--- a/argus-spring-boot-starter/src/main/java/io/argus/spring/actuate/ArgusGcLogEndpoint.java
+++ b/argus-spring-boot-starter/src/main/java/io/argus/spring/actuate/ArgusGcLogEndpoint.java
@@ -1,0 +1,105 @@
+package io.argus.spring.actuate;
+
+import io.argus.diagnostics.gclog.GcLogAnalysis;
+import io.argus.spring.ArgusProperties;
+import io.argus.spring.diagnostics.GcLogAnalyzerService;
+import io.argus.spring.diagnostics.GcScoreService;
+
+import org.springframework.boot.actuate.endpoint.annotation.Endpoint;
+import org.springframework.boot.actuate.endpoint.annotation.ReadOperation;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * Spring Boot Actuator endpoint exposing GC log analysis.
+ *
+ * <p>HTTP path: {@code /actuator/argus-gc}. Reads the GC log path from
+ * {@code argus.doctor.gc-log-path}; if unset, returns a status sentinel
+ * instead of failing.
+ */
+@Endpoint(id = "argus-gc")
+public class ArgusGcLogEndpoint {
+
+    private final GcLogAnalyzerService analyzer;
+    private final GcScoreService scorer;
+    private final ArgusProperties properties;
+
+    public ArgusGcLogEndpoint(GcLogAnalyzerService analyzer,
+                              GcScoreService scorer,
+                              ArgusProperties properties) {
+        this.analyzer = analyzer;
+        this.scorer = scorer;
+        this.properties = properties;
+    }
+
+    /**
+     * Parse the configured GC log path and return aggregated statistics
+     * plus an overall GC health score.
+     *
+     * <p>HTTP: {@code GET /actuator/argus-gc}
+     */
+    @ReadOperation
+    public Map<String, Object> analyze() {
+        String configuredPath = properties.getDoctor().getGcLogPath();
+        Map<String, Object> response = new LinkedHashMap<>();
+
+        if (configuredPath == null || configuredPath.isBlank()) {
+            response.put("status", "no_log_configured");
+            response.put("hint", "Set argus.doctor.gc-log-path=<path-to-gc.log>");
+            return response;
+        }
+
+        Path path = Path.of(configuredPath);
+        if (!Files.exists(path)) {
+            response.put("status", "log_not_found");
+            response.put("path", configuredPath);
+            return response;
+        }
+
+        try {
+            GcLogAnalysis analysis = analyzer.analyze(path);
+            response.put("status", "ok");
+            response.put("path", configuredPath);
+            response.put("analysis", toMap(analysis));
+            response.put("score", toScoreMap(scorer.score(analysis)));
+            return response;
+        } catch (IOException e) {
+            response.put("status", "parse_error");
+            response.put("path", configuredPath);
+            response.put("error", e.getMessage());
+            return response;
+        }
+    }
+
+    private Map<String, Object> toMap(GcLogAnalysis a) {
+        Map<String, Object> m = new LinkedHashMap<>();
+        m.put("totalEvents", a.totalEvents());
+        m.put("pauseEvents", a.pauseEvents());
+        m.put("fullGcEvents", a.fullGcEvents());
+        m.put("concurrentEvents", a.concurrentEvents());
+        m.put("durationSec", a.durationSec());
+        m.put("throughputPercent", a.throughputPercent());
+        m.put("totalPauseMs", a.totalPauseMs());
+        m.put("maxPauseMs", a.maxPauseMs());
+        m.put("p50PauseMs", a.p50PauseMs());
+        m.put("p95PauseMs", a.p95PauseMs());
+        m.put("p99PauseMs", a.p99PauseMs());
+        m.put("avgPauseMs", a.avgPauseMs());
+        m.put("peakHeapKB", a.peakHeapKB());
+        m.put("avgHeapAfterKB", a.avgHeapAfterKB());
+        return m;
+    }
+
+    private Map<String, Object> toScoreMap(io.argus.diagnostics.gcscore.GcScoreResult r) {
+        Map<String, Object> m = new LinkedHashMap<>();
+        m.put("overall", r.overall());
+        m.put("grade", r.grade());
+        m.put("summary", r.summary());
+        m.put("hints", r.hints());
+        return m;
+    }
+}

--- a/argus-spring-boot-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/argus-spring-boot-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,3 +1,4 @@
 io.argus.spring.ArgusAutoConfiguration
 io.argus.spring.ArgusDiagnosticsAutoConfiguration
+io.argus.spring.actuate.ArgusActuatorAutoConfiguration
 io.argus.spring.ArgusMicrometerAutoConfiguration

--- a/argus-spring-boot-starter/src/test/java/io/argus/spring/ArgusAutoConfigurationIntegrationTest.java
+++ b/argus-spring-boot-starter/src/test/java/io/argus/spring/ArgusAutoConfigurationIntegrationTest.java
@@ -4,11 +4,15 @@ import io.argus.agent.jfr.JfrStreamingEngine;
 import io.argus.core.config.AgentConfig;
 import io.argus.diagnostics.doctor.Finding;
 import io.argus.server.ArgusServer;
+import io.argus.spring.actuate.ArgusActuatorAutoConfiguration;
+import io.argus.spring.actuate.ArgusDoctorEndpoint;
+import io.argus.spring.actuate.ArgusGcLogEndpoint;
 import io.argus.spring.diagnostics.DoctorService;
 import io.argus.spring.diagnostics.GcLogAnalyzerService;
 import io.argus.spring.diagnostics.GcScoreService;
 
 import java.util.List;
+import java.util.Map;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
@@ -161,6 +165,82 @@ class ArgusAutoConfigurationIntegrationTest {
                 .withPropertyValues("argus.enabled=false")
                 .run(context -> {
                     assertThat(context).doesNotHaveBean(DoctorService.class);
+                });
+    }
+
+    @Test
+    void actuatorEndpointsAreRegisteredInDiagnosticsMode() {
+        new ApplicationContextRunner()
+                .withConfiguration(AutoConfigurations.of(
+                        ArgusAutoConfiguration.class,
+                        ArgusDiagnosticsAutoConfiguration.class,
+                        ArgusActuatorAutoConfiguration.class))
+                .withPropertyValues("argus.mode=diagnostics")
+                .run(context -> {
+                    assertThat(context).hasSingleBean(ArgusDoctorEndpoint.class);
+                    assertThat(context).hasSingleBean(ArgusGcLogEndpoint.class);
+                });
+    }
+
+    @Test
+    void argusDoctorEndpointReturnsValidShape() {
+        new ApplicationContextRunner()
+                .withConfiguration(AutoConfigurations.of(
+                        ArgusAutoConfiguration.class,
+                        ArgusDiagnosticsAutoConfiguration.class,
+                        ArgusActuatorAutoConfiguration.class))
+                .withPropertyValues("argus.mode=diagnostics")
+                .run(context -> {
+                    Map<String, Object> body = context.getBean(ArgusDoctorEndpoint.class).diagnoseLocal();
+                    assertThat(body).containsKeys(
+                            "target", "exitCode", "findingCount", "severityCount",
+                            "suggestedFlags", "findings");
+                    assertThat(body.get("target")).isEqualTo("local");
+                });
+    }
+
+    @Test
+    void argusGcLogEndpointReturnsNoLogConfiguredWhenPathUnset() {
+        new ApplicationContextRunner()
+                .withConfiguration(AutoConfigurations.of(
+                        ArgusAutoConfiguration.class,
+                        ArgusDiagnosticsAutoConfiguration.class,
+                        ArgusActuatorAutoConfiguration.class))
+                .withPropertyValues("argus.mode=diagnostics")
+                .run(context -> {
+                    Map<String, Object> body = context.getBean(ArgusGcLogEndpoint.class).analyze();
+                    assertThat(body).containsEntry("status", "no_log_configured");
+                    assertThat(body).containsKey("hint");
+                });
+    }
+
+    @Test
+    void argusGcLogEndpointReportsLogNotFoundForBogusPath() {
+        new ApplicationContextRunner()
+                .withConfiguration(AutoConfigurations.of(
+                        ArgusAutoConfiguration.class,
+                        ArgusDiagnosticsAutoConfiguration.class,
+                        ArgusActuatorAutoConfiguration.class))
+                .withPropertyValues(
+                        "argus.mode=diagnostics",
+                        "argus.doctor.gc-log-path=/tmp/does-not-exist-argus-test.log")
+                .run(context -> {
+                    Map<String, Object> body = context.getBean(ArgusGcLogEndpoint.class).analyze();
+                    assertThat(body).containsEntry("status", "log_not_found");
+                });
+    }
+
+    @Test
+    void actuatorEndpointsAreSkippedWhenModeOff() {
+        new ApplicationContextRunner()
+                .withConfiguration(AutoConfigurations.of(
+                        ArgusAutoConfiguration.class,
+                        ArgusDiagnosticsAutoConfiguration.class,
+                        ArgusActuatorAutoConfiguration.class))
+                .withPropertyValues("argus.mode=off")
+                .run(context -> {
+                    assertThat(context).doesNotHaveBean(ArgusDoctorEndpoint.class);
+                    assertThat(context).doesNotHaveBean(ArgusGcLogEndpoint.class);
                 });
     }
 


### PR DESCRIPTION
## Summary

- `/actuator/argus-doctor` — JVM health diagnosis (local + remote-by-pid variants)
- `/actuator/argus-gc` — GC log analysis + score (driven by `argus.doctor.gc-log-path`)
- **Slice 4 of 6** under #216

## Endpoints

| HTTP | Returns | Notes |
|---|---|---|
| `GET /actuator/argus-doctor` | findings for the local JVM | Includes severityCount histogram, suggestedFlags rollup, full findings list |
| `GET /actuator/argus-doctor/{pid}` | findings for a remote JVM | Uses jcmd under the hood; same response shape |
| `GET /actuator/argus-gc` | GC log analysis + score | Reads `argus.doctor.gc-log-path`; degrades gracefully (`no_log_configured`/`log_not_found`/`parse_error` statuses) when the file is absent or broken |

## Activation

```kotlin
@AutoConfiguration(after = ArgusDiagnosticsAutoConfiguration.class)
@ConditionalOnClass(Endpoint.class)
@ConditionalOnBean(DoctorService.class)
```

- Apps without `spring-boot-actuator` on the classpath are unaffected (no NoClassDefFoundError).
- `argus.mode=off` / `argus.enabled=false` skip `DoctorService` registration, which transitively skips the endpoints.
- Users still need the standard Actuator opt-in: `management.endpoints.web.exposure.include=argus-doctor,argus-gc`.

## JSON shape decision

`Finding` implements the project's own `JsonWritable` interface (hand-built JSON in `argus-diagnostics`), not Jackson getter conventions. The endpoints therefore build explicit `Map<String, Object>` responses rather than returning `List<Finding>` directly — this guarantees a stable JSON shape across Jackson versions and avoids surprising serialization.

## New property

```yaml
argus:
  doctor:
    gc-log-path: /var/log/jvm/gc.log
```

When unset → endpoint returns `{"status": "no_log_configured", "hint": "..."}`.

## Files

- ✨ `actuate/ArgusDoctorEndpoint.java`
- ✨ `actuate/ArgusGcLogEndpoint.java`
- ✨ `actuate/ArgusActuatorAutoConfiguration.java`
- 📝 `ArgusProperties.java` — new nested `Doctor` config class with `gcLogPath`
- 📝 `META-INF/spring/.../AutoConfiguration.imports` — +1 entry
- 📝 `ArgusAutoConfigurationIntegrationTest.java` — 5 new tests

## Test plan

- [x] `./gradlew :argus-spring-boot-starter:test` green (19 tests, +5 new)
- [x] `./gradlew test` green across all modules
- [x] `argusDoctorEndpointReturnsValidShape` invokes the endpoint and asserts the actual JSON contract

## Notes for reviewer

- Base is `slice-3/programmatic-diagnostics-beans` (chain on top of #217 / #218 / #219).
- This is bean-level testing only; HTTP-level testing of the endpoints (port binding, content negotiation) is left to the consumer app's own integration tests. The endpoint methods themselves are unit-tested by direct invocation.