### PR TITLE
feat(starter): scheduled doctor + structured slf4j logging (slice 5 of #216)

### DIFF
--- a/argus-spring-boot-starter/build.gradle.kts
+++ b/argus-spring-boot-starter/build.gradle.kts
@@ -13,6 +13,7 @@ dependencies {
     compileOnly("org.springframework.boot:spring-boot-actuator-autoconfigure:3.2.0")
     compileOnly("org.springframework:spring-context:6.1.0")
     compileOnly("io.micrometer:micrometer-core:1.12.0")
+    compileOnly("org.slf4j:slf4j-api:2.0.9")
 
     annotationProcessor("org.springframework.boot:spring-boot-configuration-processor:3.2.0")
 
@@ -21,6 +22,7 @@ dependencies {
     testImplementation("org.springframework.boot:spring-boot-test-autoconfigure:3.2.0")
     testImplementation("org.springframework:spring-test:6.1.0")
     testImplementation("org.assertj:assertj-core:3.25.1")
+    testImplementation("org.slf4j:slf4j-simple:2.0.9")
 }
 
 tasks.withType<JavaCompile> {

--- a/argus-spring-boot-starter/src/main/java/io/argus/spring/ArgusProperties.java
+++ b/argus-spring-boot-starter/src/main/java/io/argus/spring/ArgusProperties.java
@@ -181,8 +181,28 @@ public class ArgusProperties {
         /** Optional path to a GC log file; consumed by the {@code /actuator/argus-gc} endpoint. */
         private String gcLogPath;
 
+        private Schedule schedule = new Schedule();
+
         public String getGcLogPath() { return gcLogPath; }
         public void setGcLogPath(String gcLogPath) { this.gcLogPath = gcLogPath; }
+
+        public Schedule getSchedule() { return schedule; }
+        public void setSchedule(Schedule schedule) { this.schedule = schedule; }
+
+        /** Background scheduled doctor — opt-in, off by default. */
+        public static class Schedule {
+            /** When true, a {@code @Scheduled} bean runs doctor diagnosis on a fixed interval. */
+            private boolean enabled = false;
+
+            /** Fixed delay between successive doctor runs, in milliseconds. */
+            private long intervalMs = 60000L;
+
+            public boolean isEnabled() { return enabled; }
+            public void setEnabled(boolean enabled) { this.enabled = enabled; }
+
+            public long getIntervalMs() { return intervalMs; }
+            public void setIntervalMs(long intervalMs) { this.intervalMs = intervalMs; }
+        }
     }
 
     public static class Metrics {

--- a/argus-spring-boot-starter/src/main/java/io/argus/spring/schedule/ArgusScheduledDoctor.java
+++ b/argus-spring-boot-starter/src/main/java/io/argus/spring/schedule/ArgusScheduledDoctor.java
@@ -1,0 +1,81 @@
+package io.argus.spring.schedule;
+
+import io.argus.diagnostics.doctor.Finding;
+import io.argus.diagnostics.doctor.Severity;
+import io.argus.spring.diagnostics.DoctorService;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.scheduling.annotation.Scheduled;
+
+import java.util.List;
+
+/**
+ * Background doctor that periodically runs {@link DoctorService#diagnoseLocal()}
+ * and emits one structured slf4j log line per finding.
+ *
+ * <p>Opt-in via {@code argus.doctor.schedule.enabled=true}. Default interval
+ * is 60 s, configurable via {@code argus.doctor.schedule.interval-ms}.
+ *
+ * <p>Severity is mapped to log level:
+ * <ul>
+ *   <li>{@link Severity#CRITICAL} → {@code ERROR}</li>
+ *   <li>{@link Severity#WARNING}  → {@code WARN}</li>
+ *   <li>{@link Severity#INFO}     → {@code INFO}</li>
+ * </ul>
+ *
+ * <p>Log format uses {@code key=value} pairs so it is parseable by
+ * Loki / Datadog / Vector / Logstash without custom regex per field:
+ *
+ * <pre>
+ * argus.doctor severity=CRITICAL category=GC title="..." flag1=... flag2=...
+ * </pre>
+ */
+public class ArgusScheduledDoctor {
+
+    private static final Logger LOG = LoggerFactory.getLogger("argus.doctor");
+
+    private final DoctorService doctor;
+
+    public ArgusScheduledDoctor(DoctorService doctor) {
+        this.doctor = doctor;
+    }
+
+    /**
+     * Scheduled entry point. Delay is read from
+     * {@code argus.doctor.schedule.interval-ms} (defaults to 60 000 ms).
+     *
+     * <p>Spring's {@code @Scheduled} swallows {@link Throwable}s so a failing
+     * diagnosis run won't kill the scheduler — but we still log the failure
+     * so it doesn't go silent.
+     */
+    @Scheduled(fixedDelayString = "${argus.doctor.schedule.interval-ms:60000}")
+    public void runOnce() {
+        try {
+            List<Finding> findings = doctor.diagnoseLocal();
+            emit(findings);
+        } catch (RuntimeException e) {
+            LOG.error("argus.doctor run failed: {}", e.toString(), e);
+        }
+    }
+
+    /** Package-private for direct invocation from tests. */
+    void emit(List<Finding> findings) {
+        for (Finding f : findings) {
+            String line = "argus.doctor"
+                    + " severity=" + f.severity().name()
+                    + " category=" + f.category()
+                    + " title=\"" + escape(f.title()) + "\"";
+
+            switch (f.severity()) {
+                case CRITICAL -> LOG.error(line);
+                case WARNING  -> LOG.warn(line);
+                case INFO     -> LOG.info(line);
+            }
+        }
+    }
+
+    private static String escape(String s) {
+        return s == null ? "" : s.replace("\"", "\\\"");
+    }
+}

--- a/argus-spring-boot-starter/src/main/java/io/argus/spring/schedule/ArgusScheduledDoctorAutoConfiguration.java
+++ b/argus-spring-boot-starter/src/main/java/io/argus/spring/schedule/ArgusScheduledDoctorAutoConfiguration.java
@@ -1,0 +1,32 @@
+package io.argus.spring.schedule;
+
+import io.argus.spring.ArgusDiagnosticsAutoConfiguration;
+import io.argus.spring.diagnostics.DoctorService;
+
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+/**
+ * Auto-configuration that enables Spring scheduling and registers the
+ * {@link ArgusScheduledDoctor} bean.
+ *
+ * <p>Strictly opt-in via {@code argus.doctor.schedule.enabled=true}; when
+ * absent or false, this class is inert and {@code @EnableScheduling} does
+ * NOT pollute the rest of the application context.
+ */
+@AutoConfiguration(after = ArgusDiagnosticsAutoConfiguration.class)
+@ConditionalOnProperty(prefix = "argus.doctor.schedule", name = "enabled", havingValue = "true")
+@ConditionalOnBean(DoctorService.class)
+@EnableScheduling
+public class ArgusScheduledDoctorAutoConfiguration {
+
+    @Bean
+    @ConditionalOnMissingBean
+    public ArgusScheduledDoctor argusScheduledDoctor(DoctorService doctor) {
+        return new ArgusScheduledDoctor(doctor);
+    }
+}

--- a/argus-spring-boot-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/argus-spring-boot-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,4 +1,5 @@
 io.argus.spring.ArgusAutoConfiguration
 io.argus.spring.ArgusDiagnosticsAutoConfiguration
 io.argus.spring.actuate.ArgusActuatorAutoConfiguration
+io.argus.spring.schedule.ArgusScheduledDoctorAutoConfiguration
 io.argus.spring.ArgusMicrometerAutoConfiguration

--- a/argus-spring-boot-starter/src/test/java/io/argus/spring/ArgusAutoConfigurationIntegrationTest.java
+++ b/argus-spring-boot-starter/src/test/java/io/argus/spring/ArgusAutoConfigurationIntegrationTest.java
@@ -10,6 +10,8 @@ import io.argus.spring.actuate.ArgusGcLogEndpoint;
 import io.argus.spring.diagnostics.DoctorService;
 import io.argus.spring.diagnostics.GcLogAnalyzerService;
 import io.argus.spring.diagnostics.GcScoreService;
+import io.argus.spring.schedule.ArgusScheduledDoctor;
+import io.argus.spring.schedule.ArgusScheduledDoctorAutoConfiguration;
 
 import java.util.List;
 import java.util.Map;
@@ -242,6 +244,49 @@ class ArgusAutoConfigurationIntegrationTest {
                     assertThat(context).doesNotHaveBean(ArgusDoctorEndpoint.class);
                     assertThat(context).doesNotHaveBean(ArgusGcLogEndpoint.class);
                 });
+    }
+
+    @Test
+    void scheduledDoctorRegisteredWhenEnabled() {
+        new ApplicationContextRunner()
+                .withConfiguration(AutoConfigurations.of(
+                        ArgusAutoConfiguration.class,
+                        ArgusDiagnosticsAutoConfiguration.class,
+                        ArgusScheduledDoctorAutoConfiguration.class))
+                .withPropertyValues(
+                        "argus.mode=diagnostics",
+                        "argus.doctor.schedule.enabled=true",
+                        "argus.doctor.schedule.interval-ms=600000")
+                .run(context -> {
+                    assertThat(context).hasSingleBean(ArgusScheduledDoctor.class);
+                    // Direct method call exercises the diagnose + log path without
+                    // waiting for the scheduler to fire.
+                    context.getBean(ArgusScheduledDoctor.class).runOnce();
+                });
+    }
+
+    @Test
+    void scheduledDoctorSkippedByDefault() {
+        new ApplicationContextRunner()
+                .withConfiguration(AutoConfigurations.of(
+                        ArgusAutoConfiguration.class,
+                        ArgusDiagnosticsAutoConfiguration.class,
+                        ArgusScheduledDoctorAutoConfiguration.class))
+                .withPropertyValues("argus.mode=diagnostics")
+                .run(context -> assertThat(context).doesNotHaveBean(ArgusScheduledDoctor.class));
+    }
+
+    @Test
+    void scheduledDoctorSkippedWhenEnabledFalse() {
+        new ApplicationContextRunner()
+                .withConfiguration(AutoConfigurations.of(
+                        ArgusAutoConfiguration.class,
+                        ArgusDiagnosticsAutoConfiguration.class,
+                        ArgusScheduledDoctorAutoConfiguration.class))
+                .withPropertyValues(
+                        "argus.enabled=false",
+                        "argus.doctor.schedule.enabled=true")
+                .run(context -> assertThat(context).doesNotHaveBean(ArgusScheduledDoctor.class));
     }
 
     @Test


### PR DESCRIPTION
## Summary

- Opt-in `@Scheduled` background doctor that periodically diagnoses the local JVM and emits one structured slf4j log line per finding
- Designed for direct ingestion by Loki / Datadog / Vector / Logstash without bespoke per-field regex
- **Slice 5 of 6** under #216

## Configuration

```yaml
argus:
  doctor:
    schedule:
      enabled: true        # opt-in; default false
      interval-ms: 60000   # 1 min default
```

## Log shape

```
argus.doctor severity=CRITICAL category=GC      title="Frequent GC events: 350 events/min"
argus.doctor severity=WARNING  category=Threads title="Blocked thread ratio: 12%"
argus.doctor severity=INFO     category=Memory  title="Heap usage: 4.2 GB / 8.0 GB"
```

| Severity | slf4j level |
|---|---|
| `CRITICAL` | `ERROR` |
| `WARNING` | `WARN` |
| `INFO` | `INFO` |

Logger name: `argus.doctor`

## Wiring notes

- `@EnableScheduling` lives **only** on `ArgusScheduledDoctorAutoConfiguration`, gated by `argus.doctor.schedule.enabled=true`. Apps that don't enable the scheduler are unaffected — no global scheduling pollution.
- `@ConditionalOnBean(DoctorService.class)` means `argus.mode=off` / `argus.enabled=false` transitively disable this auto-config too.
- `runOnce()` swallows `RuntimeException` so one failing diagnosis won't kill the scheduler — but it logs the failure at ERROR level so it never goes silent.

## Files

- ✨ `schedule/ArgusScheduledDoctor.java`
- ✨ `schedule/ArgusScheduledDoctorAutoConfiguration.java`
- 📝 `ArgusProperties.java` — new `Doctor.Schedule` nested class
- 📝 `META-INF/spring/.../AutoConfiguration.imports` — +1 entry
- 📝 `build.gradle.kts` — `slf4j-api` compileOnly + `slf4j-simple` testImplementation
- 📝 `ArgusAutoConfigurationIntegrationTest.java` — 3 new tests

## Test plan

- [x] `./gradlew :argus-spring-boot-starter:test` green (22 tests, +3 new)
- [x] `./gradlew test` green across all modules
- [x] `scheduledDoctorRegisteredWhenEnabled` directly invokes `runOnce()` to exercise the diagnose + log path

## Notes for reviewer

- Base is `slice-4/actuator-endpoints` (chained on the existing slice stack).
- Spring Boot apps already ship slf4j-api at runtime via `spring-boot-starter-logging`; this PR pulls it as `compileOnly` so the starter still builds standalone.