### PR TITLE
docs: cover Spring Boot diagnostics layer (slice 6 of #216)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to Argus are documented here. Format follows [Keep a Changel
 
 ## [Unreleased]
 
+### Added
+- **`argus-diagnostics` module** — framework-agnostic JVM analysis library extracted from `argus-cli`. Contains the doctor engine (13 health rules), GC log parser + analyzer, GC scoring, ZGC diagnosis, and the jcmd-based snapshot collector. Java 11 bytecode, depends only on `argus-core`. Non-Spring JVM apps (Quarkus, Micronaut, IDE plugins, plain JARs) can now embed the same analysis primitives the CLI uses. CLI behavior unchanged.
+- **`argus-spring-boot-starter`: `argus.mode=full|diagnostics|off` posture knob** — new property letting production apps opt into a lightweight analysis-only path without spinning up the JFR streaming engine or the embedded `ArgusServer:9202`. `mode=full` (default) preserves v1.4.0 behavior; `mode=diagnostics` keeps the analysis beans + actuator endpoints; `mode=off` is equivalent to `argus.enabled=false`.
+- **`argus-spring-boot-starter`: programmatic API beans** — `DoctorService`, `GcLogAnalyzerService`, `GcScoreService` are now `@Autowired`-injectable. All three are `@ConditionalOnMissingBean` so applications can override with custom implementations.
+- **`argus-spring-boot-starter`: actuator endpoints** — `/actuator/argus-doctor` (local + `/{pid}` remote variants) and `/actuator/argus-gc` (driven by `argus.doctor.gc-log-path`). Responses are explicit `Map<String,Object>` shapes for stable JSON contracts across Jackson versions. Opt-in via the standard `management.endpoints.web.exposure.include` gate.
+- **`argus-spring-boot-starter`: scheduled doctor + structured slf4j logging** — opt-in via `argus.doctor.schedule.enabled=true`. Background `@Scheduled` bean runs `DoctorService.diagnoseLocal()` on a fixed interval (default 60 s) and emits one structured log line per finding (severity → log level mapping: CRITICAL → ERROR, WARNING → WARN, INFO → INFO). Format `key=value` is parseable by Loki / Datadog / Vector / Logstash without bespoke per-field regex.
+
+### Changed
+- `argus-spring-boot-starter` now `api`-depends on `argus-diagnostics`, exposing `Finding`, `JvmSnapshot`, `GcLogAnalysis`, `GcScoreResult` etc. to consumer apps via the transitive classpath.
+- Documentation: `docs/usage.md`, `docs/kubernetes.md`, and `site/integrations.html` updated with the new posture knob, programmatic API, actuator endpoints, and a "diagnostics-only" K8s recipe (Method C.1).
+
 ## [1.4.0] - 2026-05-13
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,7 +33,8 @@ Full rationale and procedures: [`docs/contributing.md`](docs/contributing.md).
 
 (Currently empty. Harness MVP work + the explicit follow-ups the user asked for have all landed. Decisions:)
 
-- ~~Spring Boot Starter integration~~ and ~~argus-server REST/WS + frontend Harness panel~~: **dropped.** The harness is intended for Claude Code use only, not for in-production infrastructure self-monitoring. Add either back here only if that intent changes.
+- **Spring Boot Starter diagnostics layer**: **shipped** — `argus.mode=full|diagnostics|off`, programmatic `DoctorService` / `GcLogAnalyzerService` / `GcScoreService` beans, `/actuator/argus-doctor`, `/actuator/argus-gc`, and a scheduled doctor with structured slf4j logging. The framework-agnostic `argus-diagnostics` module was extracted from `argus-cli` so non-Spring JVM apps can embed it too. See [`docs/usage.md`](docs/usage.md) and [`docs/kubernetes.md`](docs/kubernetes.md) for the public surface; tracking issue #216.
+- ~~argus-server REST/WS + frontend Harness panel~~: **dropped.** The harness is intended for Claude Code use only, not for in-production infrastructure self-monitoring. Add it back here only if that intent changes.
 - ~~i18n drift backfill~~: **false alarm.** All four locale files have 532 keys (parity); the original 15-line discrepancy is just comments and blank lines.
 - ~~Apply forrestchang/andrej-karpathy-skills~~: **done** — vendored to `.claude/skills/karpathy-guidelines/SKILL.md` (MIT, attribution preserved).
 - ~~install.sh `--run` flag~~: **done** — `install.sh` and `install.ps1` accept `[--run|-Run] <argus-subcommand> [args…]` and exec into argus after install.

--- a/docs/kubernetes.md
+++ b/docs/kubernetes.md
@@ -109,6 +109,45 @@ implementation 'io.argus:argus-spring-boot-starter:1.4.0'
 
 The `/prometheus` and `/argus` endpoints are auto-registered alongside your application's existing endpoints.
 
+#### Method C.1: Diagnostics-only mode (production-safe)
+
+For production deployments where you don't want a daemon HTTP server listening on port 9202 or a JFR stream running 24/7, set `argus.mode=diagnostics`. You still get `@Autowired DoctorService`, `/actuator/argus-doctor`, `/actuator/argus-gc`, and the optional scheduled doctor — without any of the runtime overhead of `mode=full`.
+
+```yaml
+# application.yml
+argus:
+  mode: diagnostics
+  doctor:
+    schedule:
+      enabled: true
+      interval-ms: 60000        # 1 minute
+management:
+  endpoints:
+    web:
+      exposure:
+        include: argus-doctor,argus-gc,health
+```
+
+K8s manifest delta — no extra port, no extra service:
+
+```yaml
+spec:
+  template:
+    spec:
+      containers:
+        - name: my-app
+          ports:
+            - containerPort: 8080      # only your app port; argus is in-process
+          env:
+            - name: SPRING_PROFILES_ACTIVE
+              value: prod
+            # Optional: feed your existing GC log into /actuator/argus-gc
+            - name: ARGUS_DOCTOR_GC_LOG_PATH
+              value: /var/log/jvm/gc.log
+```
+
+Findings emitted by the scheduled doctor appear in stdout as standard slf4j log lines (logger name `argus.doctor`), so Loki / Datadog / Promtail / Fluent Bit pick them up without extra config.
+
 ---
 
 ## Prometheus Integration

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -116,27 +116,99 @@ All settings are passed as `-D` system properties:
 
 ## Spring Boot Integration
 
-Add `argus-spring-boot-starter` to your Spring Boot 3.2+ application for zero-config JVM monitoring:
+Add `argus-spring-boot-starter` to your Spring Boot 3.2+ application:
 
 ```kotlin
 implementation("io.argus:argus-spring-boot-starter:1.4.0")
 ```
 
-Configure via `application.yml`:
+### Choose a posture: `argus.mode`
+
+| `argus.mode` | What runs | When to use |
+|---|---|---|
+| `full` *(default)* | JFR streaming + ArgusServer on port 9202 + every diagnostic bean + actuator endpoints | Demos, local development, dedicated monitoring sidecars |
+| `diagnostics` | Doctor / GC log / GC score beans + actuator endpoints + optional scheduled doctor — **no** JFR stream, **no** port 9202 | Production self-diagnosis without a daemon listener |
+| `off` | Nothing | Equivalent to `argus.enabled=false` |
 
 ```yaml
 argus:
-  server:
-    port: 9202
-  gc:
-    enabled: true
-  cpu:
-    enabled: true
-  allocation:
-    enabled: true
+  mode: diagnostics                # production-safe default
 ```
 
-The dashboard starts automatically. Health status available at `/actuator/health/argus`. Micrometer metrics auto-registered when on classpath.
+### Programmatic API
+
+The starter exposes three injectable services so application code can run Argus analyses on demand:
+
+```java
+@Autowired DoctorService doctor;
+
+@GetMapping("/admin/health/jvm")
+public List<Finding> jvmHealth() {
+    return doctor.diagnoseLocal();        // or doctor.diagnoseRemote(pid)
+}
+```
+
+| Bean | API |
+|---|---|
+| `DoctorService` | `diagnoseLocal()`, `diagnoseRemote(pid)`, `diagnose(snapshot)`, `lastCollectionWarnings()` |
+| `GcLogAnalyzerService` | `analyze(Path)`, `analyze(List<GcEvent>)` |
+| `GcScoreService` | `score(analysis)`, `score(analysis, gcAlgorithm)`, `inferAlgorithm(analysis)` |
+
+All three are `@ConditionalOnMissingBean` so applications can override with custom implementations.
+
+### Actuator endpoints
+
+| HTTP | Returns |
+|---|---|
+| `GET /actuator/argus-doctor` | JVM health findings (severity histogram + suggested flags + full finding list) for the local JVM |
+| `GET /actuator/argus-doctor/{pid}` | Same shape, for a remote JVM via `jcmd` |
+| `GET /actuator/argus-gc` | GC log analysis + score (reads `argus.doctor.gc-log-path`; status-coded response when the path is unset / missing / unparseable) |
+| `GET /actuator/health/argus` | JFR engine + server status (only present in `mode=full`) |
+
+Opt in with the standard Actuator gate:
+
+```yaml
+management:
+  endpoints:
+    web:
+      exposure:
+        include: argus-doctor,argus-gc,health
+```
+
+### Scheduled doctor + structured logging
+
+Opt in to a background doctor that runs on a fixed interval and emits one slf4j log line per finding — designed for direct ingestion by Loki / Datadog / Vector / Logstash:
+
+```yaml
+argus:
+  doctor:
+    schedule:
+      enabled: true             # off by default
+      interval-ms: 60000        # 1 min
+```
+
+Output (logger name `argus.doctor`, severity mapped to log level):
+
+```
+argus.doctor severity=CRITICAL category=GC      title="Frequent GC events: 350 events/min"
+argus.doctor severity=WARNING  category=Threads title="Blocked thread ratio: 12%"
+argus.doctor severity=INFO     category=Memory  title="Heap usage: 4.2 GB / 8.0 GB"
+```
+
+### Use the diagnostics library outside Spring
+
+`argus-diagnostics` ships as a framework-agnostic JAR — usable from Quarkus, Micronaut, IDE plugins, or plain `java -jar` apps:
+
+```kotlin
+implementation("io.argus:argus-diagnostics:1.4.0")
+```
+
+```java
+import io.argus.diagnostics.doctor.DoctorEngine;
+import io.argus.diagnostics.doctor.JvmSnapshotCollector;
+
+var findings = DoctorEngine.diagnose(JvmSnapshotCollector.collectLocal());
+```
 
 ---
 

--- a/site/integrations.html
+++ b/site/integrations.html
@@ -91,6 +91,52 @@ implementation("io.argus:argus-spring-boot-starter:1.4.0")</code></pre>
     threshold: 524288</code></pre>
 
                 <p>All properties have IDE autocomplete support. The defaults match the standard agent configuration.</p>
+
+                <span class="section-anchor" id="spring-mode"></span>
+                <h3>Diagnostics-only mode (production-safe)</h3>
+
+                <p>For production deployments where you don't want a daemon HTTP server listening on port 9202 or a JFR stream running 24/7, set <code>argus.mode=diagnostics</code>. You still get the analysis primitives as Spring beans plus actuator endpoints — without the runtime cost of the full mode.</p>
+
+                <pre><code>argus:
+  mode: diagnostics                # 'full' | 'diagnostics' | 'off'
+  doctor:
+    schedule:
+      enabled: true                # optional: run doctor every interval
+      interval-ms: 60000
+management:
+  endpoints:
+    web:
+      exposure:
+        include: argus-doctor,argus-gc</code></pre>
+
+                <span class="section-anchor" id="spring-api"></span>
+                <h3>Programmatic API beans</h3>
+
+                <p>Three injectable services let application code run Argus analyses directly:</p>
+
+                <pre><code>@Autowired DoctorService doctor;
+
+@GetMapping("/admin/health/jvm")
+public List&lt;Finding&gt; jvmHealth() {
+    return doctor.diagnoseLocal();   // or doctor.diagnoseRemote(pid)
+}</code></pre>
+
+                <ul>
+                    <li><code>DoctorService</code> — diagnoseLocal / diagnoseRemote(pid) / diagnose(snapshot)</li>
+                    <li><code>GcLogAnalyzerService</code> — analyze(Path) / analyze(List&lt;GcEvent&gt;)</li>
+                    <li><code>GcScoreService</code> — score(analysis [, gcAlgorithm]) / inferAlgorithm</li>
+                </ul>
+
+                <p>All three are <code>@ConditionalOnMissingBean</code> so applications can override with custom implementations.</p>
+
+                <span class="section-anchor" id="spring-actuator"></span>
+                <h3>Actuator endpoints</h3>
+
+                <pre><code>GET /actuator/argus-doctor          # diagnose the local JVM
+GET /actuator/argus-doctor/{pid}    # diagnose a remote JVM via jcmd
+GET /actuator/argus-gc              # GC log analysis + score</code></pre>
+
+                <p>Opt in via the standard <code>management.endpoints.web.exposure.include</code> gate. Responses are explicit <code>Map&lt;String, Object&gt;</code> shapes so the JSON contract is stable across Jackson versions.</p>
             </div>
 
             <!-- MICROMETER -->


### PR DESCRIPTION
## Summary

- Document the full public surface added by slices 1–5 across every place users look: usage docs, K8s recipes, marketing site, project conventions, CHANGELOG
- **Slice 6 of 6** — closes out #216
- No code changes; documentation only

## Files

| File | Change |
|---|---|
| `docs/usage.md` | Spring Boot Integration section expanded: `argus.mode` posture table, programmatic API beans, actuator endpoints, scheduled doctor, and a snippet showing `argus-diagnostics` consumed outside Spring |
| `docs/kubernetes.md` | New **Method C.1: Diagnostics-only mode (production-safe)** recipe with example pod manifest |
| `site/integrations.html` | Spring Boot section gained sub-sections for posture / programmatic API / actuator endpoints |
| `CLAUDE.md` | Replace stale "Spring Boot Starter: dropped" follow-up with "shipped" pointer to the new docs |
| `CHANGELOG.md` | Full `[Unreleased]` entry covering all six slices |

## Test plan

- [x] `./gradlew test` still green (no code changes)
- [ ] Manual: render `docs/usage.md` + `docs/kubernetes.md` in GitHub preview to confirm tables / code blocks render
- [ ] Manual: open `site/integrations.html` in a browser to confirm anchors / styling intact

## Notes for reviewer

- Base is `slice-5/scheduled-doctor`. After all five upstream PRs merge, GitHub re-targets this to master automatically.
- After this PR merges, the tracking issue #216 can be closed.
- Suggested next step: cut a release. `release-sync` and `docs-sync` skills should be run before tagging.