### PR TITLE
feat(cli): add `argus snapshot` command

### DIFF
--- a/argus-cli/src/main/java/io/argus/cli/command/SnapshotCommand.java
+++ b/argus-cli/src/main/java/io/argus/cli/command/SnapshotCommand.java
@@ -1,0 +1,412 @@
+package io.argus.cli.command;
+
+import io.argus.cli.config.CliConfig;
+import io.argus.cli.config.Messages;
+import io.argus.cli.provider.ProviderRegistry;
+import io.argus.core.command.CommandGroup;
+import io.argus.diagnostics.doctor.DoctorEngine;
+import io.argus.diagnostics.doctor.Finding;
+import io.argus.diagnostics.doctor.JvmSnapshotCollector;
+import io.argus.diagnostics.jcmd.JcmdExecutor;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.InetAddress;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.zip.GZIPOutputStream;
+
+/**
+ * Forensic snapshot bundle: collects multiple JVM diagnostics into a single tar.gz for incident response.
+ */
+public final class SnapshotCommand implements Command {
+
+    private static final DateTimeFormatter TS = DateTimeFormatter
+            .ofPattern("yyyyMMdd-HHmmss")
+            .withZone(ZoneId.systemDefault());
+
+    @Override
+    public String name() { return "snapshot"; }
+
+    @Override
+    public CommandGroup group() { return CommandGroup.PROFILING; }
+
+    @Override
+    public CommandMode mode() { return CommandMode.WRITE; }
+
+    @Override
+    public String description(Messages messages) {
+        return messages.get("cmd.snapshot.desc");
+    }
+
+    @Override
+    public void execute(String[] args, CliConfig config, ProviderRegistry registry, Messages messages) {
+        long pid = 0;
+        String outputDir = null;
+        boolean safe = true;
+        boolean full = false;
+        boolean help = false;
+        boolean explicitSafe = false;
+
+        for (String arg : args) {
+            if (arg.equals("--help") || arg.equals("-h")) {
+                help = true;
+            } else if (arg.startsWith("--output=")) {
+                outputDir = arg.substring(9);
+            } else if (arg.equals("--full")) {
+                full = true;
+                safe = false;
+            } else if (arg.equals("--safe")) {
+                safe = true;
+                explicitSafe = true;
+            } else if (!arg.startsWith("--")) {
+                try { pid = Long.parseLong(arg); } catch (NumberFormatException ignored) {}
+            }
+        }
+
+        if (help) {
+            System.out.println(messages.get("snapshot.usage"));
+            return;
+        }
+
+        if (full && explicitSafe) {
+            System.err.println(messages.get("snapshot.error.safeAndFullConflict"));
+            throw new CommandExitException(1);
+        }
+
+        if (pid <= 0) pid = ProcessHandle.current().pid();
+
+        String timestamp = TS.format(Instant.now());
+        if (outputDir == null) outputDir = "./argus-snapshot-" + timestamp;
+
+        Path outPath = Path.of(outputDir);
+        try {
+            Files.createDirectories(outPath);
+        } catch (IOException e) {
+            System.err.println("Cannot create output directory: " + e.getMessage());
+            throw new CommandExitException(1);
+        }
+
+        String mode = full ? "full" : "safe";
+        System.out.println(messages.get("snapshot.collecting", String.valueOf(pid)));
+
+        List<ManifestItem> items = new ArrayList<>();
+        List<byte[]> fileContents = new ArrayList<>();
+        List<String> fileNames = new ArrayList<>();
+
+        // 1. info.txt
+        collectJcmd(pid, "VM.info", "info.txt", "jcmd VM.info",
+                items, fileNames, fileContents, messages);
+
+        // 2. threads.txt — 3 dumps, 5s apart
+        collectThreadDumps(pid, items, fileNames, fileContents, messages);
+
+        // 3. histo.txt
+        collectJcmd(pid, "GC.class_histogram", "histo.txt", "jcmd GC.class_histogram",
+                items, fileNames, fileContents, messages);
+
+        // 4. doctor.txt
+        collectDoctor(pid, items, fileNames, fileContents, messages);
+
+        // 5. heap.hprof (--full only)
+        if (full) {
+            collectHeapDump(pid, outPath, timestamp, items, fileNames, fileContents, messages);
+        } else {
+            String reason = messages.get("snapshot.error.heapDumpRequiresFull");
+            items.add(new ManifestItem("heap.hprof", "jcmd GC.heap_dump", "skipped", 0, null, reason));
+            System.out.println(messages.get("snapshot.item.skipped", "heap.hprof", reason));
+        }
+
+        // 6. Build manifest.json and prepend it
+        String hostname = hostname();
+        String jvmVersion = getJvmVersion(pid);
+        String jvmArgs = getJvmArgs(pid);
+        byte[] manifest = buildManifest(pid, jvmVersion, jvmArgs, hostname, mode, timestamp, items);
+        fileNames.add(0, "manifest.json");
+        fileContents.add(0, manifest);
+
+        // 7. Bundle into tar.gz
+        System.out.println(messages.get("snapshot.compressing"));
+        String archiveName = "argus-snapshot-" + pid + "-" + timestamp + ".tar.gz";
+        Path archivePath = outPath.resolve(archiveName);
+
+        try {
+            writeTarGz(archivePath, fileNames, fileContents);
+        } catch (IOException e) {
+            System.err.println("Failed to write archive: " + e.getMessage());
+            throw new CommandExitException(1);
+        }
+
+        long archiveBytes;
+        try { archiveBytes = Files.size(archivePath); }
+        catch (IOException e) { archiveBytes = -1; }
+
+        System.out.println(messages.get("snapshot.success",
+                archivePath.toString(), formatBytes(archiveBytes)));
+    }
+
+    private void collectJcmd(long pid, String jcmdCmd, String fileName, String source,
+                              List<ManifestItem> items, List<String> names,
+                              List<byte[]> contents, Messages messages) {
+        try {
+            String out = JcmdExecutor.execute(pid, jcmdCmd);
+            byte[] bytes = out.getBytes(StandardCharsets.UTF_8);
+            items.add(new ManifestItem(fileName, source, "ok", bytes.length, null, null));
+            names.add(fileName);
+            contents.add(bytes);
+            System.out.println(messages.get("snapshot.item.ok", fileName, formatBytes(bytes.length)));
+        } catch (Exception e) {
+            items.add(new ManifestItem(fileName, source, "error", 0, e.getMessage(), null));
+            System.out.println(messages.get("snapshot.item.error", fileName, e.getMessage()));
+        }
+    }
+
+    private void collectThreadDumps(long pid, List<ManifestItem> items, List<String> names,
+                                    List<byte[]> contents, Messages messages) {
+        StringBuilder sb = new StringBuilder();
+        Exception lastError = null;
+        for (int i = 1; i <= 3; i++) {
+            try {
+                String ts = Instant.now().toString();
+                sb.append("=== dump ").append(i).append(" @ ").append(ts).append(" ===\n");
+                sb.append(JcmdExecutor.execute(pid, "Thread.print")).append("\n");
+                if (i < 3) Thread.sleep(5000);
+            } catch (Exception e) {
+                lastError = e;
+                sb.append("ERROR: ").append(e.getMessage()).append("\n");
+            }
+        }
+        byte[] bytes = sb.toString().getBytes(StandardCharsets.UTF_8);
+        if (lastError == null) {
+            items.add(new ManifestItem("threads.txt", "jcmd Thread.print x3", "ok", bytes.length, null, null));
+            System.out.println(messages.get("snapshot.item.ok", "threads.txt", formatBytes(bytes.length)));
+        } else {
+            items.add(new ManifestItem("threads.txt", "jcmd Thread.print x3", "error", bytes.length, lastError.getMessage(), null));
+            System.out.println(messages.get("snapshot.item.error", "threads.txt", lastError.getMessage()));
+        }
+        names.add("threads.txt");
+        contents.add(bytes);
+    }
+
+    private void collectDoctor(long pid, List<ManifestItem> items, List<String> names,
+                               List<byte[]> contents, Messages messages) {
+        try {
+            var snapshot = JvmSnapshotCollector.collect(pid);
+            List<Finding> findings = DoctorEngine.diagnose(snapshot);
+            StringBuilder sb = new StringBuilder();
+            if (findings.isEmpty()) {
+                sb.append("All checks passed — JVM is healthy\n");
+            } else {
+                for (Finding f : findings) {
+                    sb.append("[").append(f.severity().name()).append("] ")
+                      .append(f.category()).append(": ").append(f.title()).append("\n");
+                    if (!f.detail().isEmpty()) sb.append("  ").append(f.detail()).append("\n");
+                    for (String rec : f.recommendations()) sb.append("  -> ").append(rec).append("\n");
+                    sb.append("\n");
+                }
+            }
+            byte[] bytes = sb.toString().getBytes(StandardCharsets.UTF_8);
+            items.add(new ManifestItem("doctor.txt", "DoctorEngine.diagnose", "ok", bytes.length, null, null));
+            names.add("doctor.txt");
+            contents.add(bytes);
+            System.out.println(messages.get("snapshot.item.ok", "doctor.txt", formatBytes(bytes.length)));
+        } catch (Exception e) {
+            byte[] bytes = ("ERROR: " + e.getMessage()).getBytes(StandardCharsets.UTF_8);
+            items.add(new ManifestItem("doctor.txt", "DoctorEngine.diagnose", "error", 0, e.getMessage(), null));
+            names.add("doctor.txt");
+            contents.add(bytes);
+            System.out.println(messages.get("snapshot.item.error", "doctor.txt", e.getMessage()));
+        }
+    }
+
+    private void collectHeapDump(long pid, Path outPath, String timestamp,
+                                 List<ManifestItem> items, List<String> names,
+                                 List<byte[]> contents, Messages messages) {
+        Path tmpHprof = outPath.resolve("heap-" + pid + "-" + timestamp + ".hprof");
+        try {
+            JcmdExecutor.execute(pid, "GC.heap_dump filename=" + tmpHprof.toAbsolutePath());
+            byte[] bytes = Files.readAllBytes(tmpHprof);
+            Files.deleteIfExists(tmpHprof);
+            items.add(new ManifestItem("heap.hprof", "jcmd GC.heap_dump", "ok", bytes.length, null, null));
+            names.add("heap.hprof");
+            contents.add(bytes);
+            System.out.println(messages.get("snapshot.item.ok", "heap.hprof", formatBytes(bytes.length)));
+        } catch (Exception e) {
+            try { Files.deleteIfExists(tmpHprof); } catch (IOException ignored) {}
+            items.add(new ManifestItem("heap.hprof", "jcmd GC.heap_dump", "error", 0, e.getMessage(), null));
+            System.out.println(messages.get("snapshot.item.error", "heap.hprof", e.getMessage()));
+        }
+    }
+
+    private static byte[] buildManifest(long pid, String jvmVersion, String jvmArgs,
+                                        String hostname, String mode, String timestamp,
+                                        List<ManifestItem> items) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("{\n");
+        sb.append("  \"schemaVersion\": 1,\n");
+        sb.append("  \"generatedAt\": \"").append(Instant.now()).append("\",\n");
+        sb.append("  \"argusVersion\": \"").append(argusVersion()).append("\",\n");
+        sb.append("  \"target\": {\n");
+        sb.append("    \"pid\": ").append(pid).append(",\n");
+        sb.append("    \"jvmVersion\": \"").append(escapeJson(jvmVersion)).append("\",\n");
+        sb.append("    \"jvmArgs\": \"").append(escapeJson(jvmArgs)).append("\",\n");
+        sb.append("    \"hostname\": \"").append(escapeJson(hostname)).append("\"\n");
+        sb.append("  },\n");
+        sb.append("  \"mode\": \"").append(mode).append("\",\n");
+        sb.append("  \"items\": [\n");
+        for (int i = 0; i < items.size(); i++) {
+            ManifestItem item = items.get(i);
+            sb.append("    {");
+            sb.append("\"name\": \"").append(escapeJson(item.name)).append("\", ");
+            sb.append("\"source\": \"").append(escapeJson(item.source)).append("\", ");
+            sb.append("\"status\": \"").append(item.status).append("\"");
+            if ("ok".equals(item.status)) {
+                sb.append(", \"bytes\": ").append(item.bytes);
+            } else if ("skipped".equals(item.status) && item.reason != null) {
+                sb.append(", \"reason\": \"").append(escapeJson(item.reason)).append("\"");
+            } else if ("error".equals(item.status) && item.error != null) {
+                sb.append(", \"error\": \"").append(escapeJson(item.error)).append("\"");
+            }
+            sb.append("}");
+            if (i < items.size() - 1) sb.append(",");
+            sb.append("\n");
+        }
+        sb.append("  ]\n");
+        sb.append("}\n");
+        return sb.toString().getBytes(StandardCharsets.UTF_8);
+    }
+
+    /**
+     * Writes a tar.gz archive using only JDK built-ins (GZIPOutputStream + manual POSIX tar blocks).
+     * Each 512-byte header block encodes: name (100B), mode (8B), uid/gid (8B each),
+     * size (12B octal), mtime (12B octal), checksum (8B), type flag (1B), link name (100B),
+     * then the UStar magic + version + padding to 512 bytes.
+     */
+    private static void writeTarGz(Path dest, List<String> names, List<byte[]> contents) throws IOException {
+        try (OutputStream fos = Files.newOutputStream(dest);
+             GZIPOutputStream gzip = new GZIPOutputStream(fos)) {
+            for (int i = 0; i < names.size(); i++) {
+                writeTarEntry(gzip, names.get(i), contents.get(i));
+            }
+            // End-of-archive: two 512-byte zero blocks
+            byte[] eoa = new byte[1024];
+            gzip.write(eoa);
+        }
+    }
+
+    private static void writeTarEntry(OutputStream out, String name, byte[] data) throws IOException {
+        byte[] header = new byte[512];
+        // name (offset 0, 100 bytes)
+        byte[] nameBytes = name.getBytes(StandardCharsets.US_ASCII);
+        System.arraycopy(nameBytes, 0, header, 0, Math.min(nameBytes.length, 99));
+        // mode (offset 100, 8 bytes): 0000644\0
+        putOctal(header, 100, 8, 0644);
+        // uid (offset 108, 8 bytes)
+        putOctal(header, 108, 8, 0);
+        // gid (offset 116, 8 bytes)
+        putOctal(header, 116, 8, 0);
+        // size (offset 124, 12 bytes)
+        putOctal(header, 124, 12, data.length);
+        // mtime (offset 136, 12 bytes)
+        putOctal(header, 136, 12, System.currentTimeMillis() / 1000L);
+        // checksum placeholder (offset 148, 8 bytes): 8 spaces
+        Arrays.fill(header, 148, 156, (byte) ' ');
+        // type flag (offset 156): '0' = regular file
+        header[156] = '0';
+        // UStar magic (offset 257, 6 bytes): "ustar\0"
+        byte[] magic = "ustar\0".getBytes(StandardCharsets.US_ASCII);
+        System.arraycopy(magic, 0, header, 257, magic.length);
+        // UStar version (offset 263, 2 bytes): "00"
+        header[263] = '0';
+        header[264] = '0';
+        // Compute checksum over header with spaces in checksum field (already set above)
+        int checksum = 0;
+        for (byte b : header) checksum += (b & 0xFF);
+        // Write checksum as 6 octal digits + NUL + space (POSIX convention)
+        byte[] csOctal = String.format("%06o", checksum).getBytes(StandardCharsets.US_ASCII);
+        System.arraycopy(csOctal, 0, header, 148, 6);
+        header[154] = 0;
+        header[155] = ' ';
+
+        out.write(header);
+        out.write(data);
+        // Pad data to 512-byte boundary
+        int remainder = data.length % 512;
+        if (remainder != 0) {
+            out.write(new byte[512 - remainder]);
+        }
+    }
+
+    private static void putOctal(byte[] buf, int offset, int length, long value) {
+        String octal = String.format("%" + (length - 1) + "s", Long.toOctalString(value))
+                .replace(' ', '0');
+        byte[] bytes = octal.getBytes(StandardCharsets.US_ASCII);
+        System.arraycopy(bytes, 0, buf, offset, Math.min(bytes.length, length - 1));
+        buf[offset + length - 1] = 0; // NUL terminator
+    }
+
+    private static String getJvmVersion(long pid) {
+        try {
+            return JcmdExecutor.execute(pid, "VM.version").lines().findFirst().orElse("unknown").trim();
+        } catch (Exception e) {
+            return "unknown";
+        }
+    }
+
+    private static String getJvmArgs(long pid) {
+        try {
+            return JcmdExecutor.execute(pid, "VM.flags").lines().findFirst().orElse("").trim();
+        } catch (Exception e) {
+            return "";
+        }
+    }
+
+    private static String hostname() {
+        try { return InetAddress.getLocalHost().getHostName(); }
+        catch (Exception e) { return "unknown"; }
+    }
+
+    private static String argusVersion() {
+        String v = SnapshotCommand.class.getPackage().getImplementationVersion();
+        return v != null ? v : "unknown";
+    }
+
+    private static String formatBytes(long bytes) {
+        if (bytes < 0) return "?";
+        if (bytes < 1024) return bytes + " B";
+        if (bytes < 1024 * 1024) return String.format("%.1f KB", bytes / 1024.0);
+        return String.format("%.1f MB", bytes / (1024.0 * 1024));
+    }
+
+    private static String escapeJson(String s) {
+        if (s == null) return "";
+        return s.replace("\\", "\\\\").replace("\"", "\\\"")
+                .replace("\n", "\\n").replace("\r", "\\r").replace("\t", "\\t");
+    }
+
+    private static final class ManifestItem {
+        final String name;
+        final String source;
+        final String status;
+        final long bytes;
+        final String error;
+        final String reason;
+
+        ManifestItem(String name, String source, String status,
+                     long bytes, String error, String reason) {
+            this.name = name;
+            this.source = source;
+            this.status = status;
+            this.bytes = bytes;
+            this.error = error;
+            this.reason = reason;
+        }
+    }
+}

--- a/argus-cli/src/main/java/io/argus/cli/command/SnapshotCommand.java
+++ b/argus-cli/src/main/java/io/argus/cli/command/SnapshotCommand.java
@@ -231,7 +231,12 @@ public final class SnapshotCommand implements Command {
                                  List<byte[]> contents, Messages messages) {
         Path tmpHprof = outPath.resolve("heap-" + pid + "-" + timestamp + ".hprof");
         try {
-            JcmdExecutor.execute(pid, "GC.heap_dump filename=" + tmpHprof.toAbsolutePath());
+            // jcmd's GC.heap_dump takes the path positionally; `filename=...` is not
+            // recognised in JDK 17+ and is interpreted as the literal filename "filename".
+            String jcmdOutput = JcmdExecutor.execute(pid, "GC.heap_dump " + tmpHprof.toAbsolutePath());
+            if (!Files.exists(tmpHprof)) {
+                throw new IOException("jcmd did not create the dump file. jcmd output: " + jcmdOutput);
+            }
             byte[] bytes = Files.readAllBytes(tmpHprof);
             Files.deleteIfExists(tmpHprof);
             items.add(new ManifestItem("heap.hprof", "jcmd GC.heap_dump", "ok", bytes.length, null, null));

--- a/argus-cli/src/main/resources/META-INF/services/io.argus.cli.command.Command
+++ b/argus-cli/src/main/resources/META-INF/services/io.argus.cli.command.Command
@@ -50,6 +50,7 @@ io.argus.cli.command.PsCommand
 io.argus.cli.command.ReportCommand
 io.argus.cli.command.SearchClassCommand
 io.argus.cli.command.SlowlogCommand
+io.argus.cli.command.SnapshotCommand
 io.argus.cli.command.SpringCommand
 io.argus.cli.command.StringTableCommand
 io.argus.cli.command.SuggestCommand

--- a/argus-cli/src/main/resources/messages_en.properties
+++ b/argus-cli/src/main/resources/messages_en.properties
@@ -645,3 +645,15 @@ cli.zgc.watch.summary=Watched %s iterations · %s stalls · %s soft-max breaches
 # Harness — continuous JVM monitoring + optimization + troubleshooting
 cmd.harness.desc=Continuous JVM monitoring + optimization + troubleshooting
 harness.starting=Argus harness starting — pid=%s, interval=%s, duration=%s, profile=%s
+
+# Snapshot
+cmd.snapshot.desc=Forensic bundle — combine multiple diagnostics into a single tar.gz for incident response
+snapshot.usage=Usage: argus snapshot [pid] [--output=<dir>] [--safe|--full]
+snapshot.collecting=Collecting diagnostics from PID %s...
+snapshot.item.ok=  [v] %s (%s)
+snapshot.item.skipped=  [-] %s (skipped: %s)
+snapshot.item.error=  [!] %s (error: %s)
+snapshot.compressing=Compressing to tar.gz...
+snapshot.success=Snapshot saved: %s (%s)
+snapshot.error.heapDumpRequiresFull=--safe mode (STW > 1s expected; pass --full to include)
+snapshot.error.safeAndFullConflict=--safe and --full are mutually exclusive

--- a/argus-cli/src/main/resources/messages_ja.properties
+++ b/argus-cli/src/main/resources/messages_ja.properties
@@ -630,3 +630,15 @@ cli.zgc.watch.summary=%s回実行 · %s件のStall · %s回のsoft-max超過
 # Harness — 継続的なJVM監視 + 最適化 + トラブルシューティング
 cmd.harness.desc=継続的なJVM監視 + 最適化 + トラブルシューティング
 harness.starting=Argusハーネス開始 — pid=%s, interval=%s, duration=%s, profile=%s
+
+# Snapshot
+cmd.snapshot.desc=フォレンジックバンドル — 複数の診断結果を単一のtar.gzにまとめてインシデント対応に活用
+snapshot.usage=使用法: argus snapshot [pid] [--output=<dir>] [--safe|--full]
+snapshot.collecting=PID %s から診断データを収集中...
+snapshot.item.ok=  [v] %s (%s)
+snapshot.item.skipped=  [-] %s (スキップ: %s)
+snapshot.item.error=  [!] %s (エラー: %s)
+snapshot.compressing=tar.gz に圧縮中...
+snapshot.success=スナップショット保存完了: %s (%s)
+snapshot.error.heapDumpRequiresFull=--safe モード (STW > 1s が予想されるため; 含めるには --full を使用)
+snapshot.error.safeAndFullConflict=--safe と --full は同時に使用できません

--- a/argus-cli/src/main/resources/messages_ko.properties
+++ b/argus-cli/src/main/resources/messages_ko.properties
@@ -630,3 +630,15 @@ cli.zgc.watch.summary=총 %s회 반복 · %s건 할당 지연 · %s회 soft-max 
 # Harness — JVM 연속 모니터링 + 최적화 + 트러블슈팅
 cmd.harness.desc=JVM 연속 모니터링 + 최적화 + 트러블슈팅
 harness.starting=Argus 하네스 시작 — pid=%s, interval=%s, duration=%s, profile=%s
+
+# Snapshot
+cmd.snapshot.desc=포렌식 번들 — 여러 진단 결과를 하나의 tar.gz로 묶어 장애 대응에 활용
+snapshot.usage=사용법: argus snapshot [pid] [--output=<dir>] [--safe|--full]
+snapshot.collecting=PID %s 에서 진단 데이터 수집 중...
+snapshot.item.ok=  [v] %s (%s)
+snapshot.item.skipped=  [-] %s (건너뜀: %s)
+snapshot.item.error=  [!] %s (오류: %s)
+snapshot.compressing=tar.gz 로 압축 중...
+snapshot.success=스냅샷 저장 완료: %s (%s)
+snapshot.error.heapDumpRequiresFull=--safe 모드 (STW > 1s 예상; 포함하려면 --full 사용)
+snapshot.error.safeAndFullConflict=--safe 와 --full 은 동시에 사용할 수 없습니다

--- a/argus-cli/src/main/resources/messages_zh.properties
+++ b/argus-cli/src/main/resources/messages_zh.properties
@@ -630,3 +630,15 @@ cli.zgc.watch.summary=共执行 %s 次 · %s 次分配停顿 · %s 次 soft-max 
 # Harness — JVM 持续监控 + 优化 + 故障排查
 cmd.harness.desc=JVM 持续监控 + 优化 + 故障排查
 harness.starting=Argus 线束启动 — pid=%s, interval=%s, duration=%s, profile=%s
+
+# Snapshot
+cmd.snapshot.desc=取证包 — 将多项诊断结果打包为单个 tar.gz 以供故障响应使用
+snapshot.usage=用法: argus snapshot [pid] [--output=<dir>] [--safe|--full]
+snapshot.collecting=正在从 PID %s 收集诊断数据...
+snapshot.item.ok=  [v] %s (%s)
+snapshot.item.skipped=  [-] %s (已跳过: %s)
+snapshot.item.error=  [!] %s (错误: %s)
+snapshot.compressing=正在压缩为 tar.gz...
+snapshot.success=快照已保存: %s (%s)
+snapshot.error.heapDumpRequiresFull=--safe 模式（预计 STW > 1s；如需包含请使用 --full）
+snapshot.error.safeAndFullConflict=--safe 与 --full 互斥，不能同时使用

--- a/argus-cli/src/test/java/io/argus/cli/command/SnapshotCommandTest.java
+++ b/argus-cli/src/test/java/io/argus/cli/command/SnapshotCommandTest.java
@@ -1,0 +1,212 @@
+package io.argus.cli.command;
+
+import io.argus.cli.config.CliConfig;
+import io.argus.cli.config.Messages;
+import io.argus.cli.provider.ProviderRegistry;
+import io.argus.diagnostics.jcmd.JcmdExecutor;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.zip.GZIPInputStream;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class SnapshotCommandTest {
+
+    private static final Messages MESSAGES = new Messages("en");
+
+    private static CliConfig defaultConfig() {
+        return new CliConfig("en", "auto", false, "text", 9202);
+    }
+
+    private static ProviderRegistry emptyRegistry() {
+        return new ProviderRegistry();
+    }
+
+    // -------------------------------------------------------------------------
+    // --safe mode (default): tar.gz produced, manifest has mode=safe, heap skipped
+    // -------------------------------------------------------------------------
+
+    @Test
+    void safeMode_producesTarGzWithManifest(@TempDir Path tmp) throws Exception {
+        Assumptions.assumeTrue(JcmdExecutor.isJcmdAvailable(),
+                "jcmd not available in this environment");
+
+        long selfPid = ProcessHandle.current().pid();
+        String outDir = tmp.resolve("snap-out").toString();
+
+        SnapshotCommand cmd = new SnapshotCommand();
+        PrintStream orig = System.out;
+        System.setOut(new PrintStream(new ByteArrayOutputStream()));
+        try {
+            cmd.execute(new String[]{String.valueOf(selfPid), "--output=" + outDir, "--safe"},
+                    defaultConfig(), emptyRegistry(), MESSAGES);
+        } finally {
+            System.setOut(orig);
+        }
+
+        Path outPath = Path.of(outDir);
+        assertTrue(Files.exists(outPath), "Output directory must exist");
+        List<Path> archives = Files.list(outPath)
+                .filter(p -> p.getFileName().toString().endsWith(".tar.gz"))
+                .collect(Collectors.toList());
+        assertEquals(1, archives.size(), "Exactly one tar.gz must be produced");
+
+        Path archive = archives.get(0);
+        assertTrue(Files.size(archive) > 1024, "tar.gz must be > 1 KB");
+
+        Map<String, byte[]> entries = readTarGz(archive);
+
+        assertTrue(entries.containsKey("manifest.json"), "manifest.json must be in archive");
+        assertTrue(entries.containsKey("info.txt"), "info.txt must be in archive");
+        assertTrue(entries.containsKey("threads.txt"), "threads.txt must be in archive");
+        assertTrue(entries.containsKey("histo.txt"), "histo.txt must be in archive");
+        assertTrue(entries.containsKey("doctor.txt"), "doctor.txt must be in archive");
+        assertFalse(entries.containsKey("heap.hprof"), "heap.hprof must NOT be in archive in --safe mode");
+
+        String manifestJson = new String(entries.get("manifest.json"), StandardCharsets.UTF_8);
+        assertTrue(manifestJson.contains("\"mode\": \"safe\""), "manifest must record mode=safe");
+        assertTrue(manifestJson.contains("\"schemaVersion\": 1"), "manifest must have schemaVersion=1");
+        assertTrue(manifestJson.contains("\"name\": \"heap.hprof\""), "manifest must list heap.hprof item");
+        assertTrue(manifestJson.contains("\"status\": \"skipped\""), "heap.hprof status must be skipped");
+    }
+
+    // -------------------------------------------------------------------------
+    // schemaVersion=1 in manifest (no explicit --safe flag — default is safe)
+    // -------------------------------------------------------------------------
+
+    @Test
+    void safeMode_manifestSchemaVersion(@TempDir Path tmp) throws Exception {
+        Assumptions.assumeTrue(JcmdExecutor.isJcmdAvailable(),
+                "jcmd not available in this environment");
+
+        long selfPid = ProcessHandle.current().pid();
+        String outDir = tmp.resolve("snap-schema").toString();
+
+        SnapshotCommand cmd = new SnapshotCommand();
+        PrintStream orig = System.out;
+        System.setOut(new PrintStream(new ByteArrayOutputStream()));
+        try {
+            cmd.execute(new String[]{String.valueOf(selfPid), "--output=" + outDir},
+                    defaultConfig(), emptyRegistry(), MESSAGES);
+        } finally {
+            System.setOut(orig);
+        }
+
+        Path archive = Files.list(Path.of(outDir))
+                .filter(p -> p.getFileName().toString().endsWith(".tar.gz"))
+                .findFirst().orElseThrow();
+
+        Map<String, byte[]> entries = readTarGz(archive);
+        assertTrue(entries.containsKey("manifest.json"), "manifest.json must be present");
+        String manifestJson = new String(entries.get("manifest.json"), StandardCharsets.UTF_8);
+        assertTrue(manifestJson.contains("\"schemaVersion\": 1"), "schemaVersion must be 1");
+    }
+
+    // -------------------------------------------------------------------------
+    // --safe and --full together must fail with exit code != 0
+    // -------------------------------------------------------------------------
+
+    @Test
+    void safeAndFullConflict_exitsWithError(@TempDir Path tmp) {
+        SnapshotCommand cmd = new SnapshotCommand();
+        String outDir = tmp.resolve("snap-conflict").toString();
+
+        PrintStream origErr = System.err;
+        ByteArrayOutputStream errBuf = new ByteArrayOutputStream();
+        System.setErr(new PrintStream(errBuf));
+        PrintStream origOut = System.out;
+        System.setOut(new PrintStream(new ByteArrayOutputStream()));
+        try {
+            CommandExitException ex = assertThrows(CommandExitException.class, () ->
+                    cmd.execute(new String[]{"--safe", "--full", "--output=" + outDir},
+                            defaultConfig(), emptyRegistry(), MESSAGES));
+            assertTrue(ex.exitCode() != 0, "Must exit with non-zero code");
+        } finally {
+            System.setErr(origErr);
+            System.setOut(origOut);
+        }
+
+        String errOutput = errBuf.toString();
+        assertTrue(errOutput.contains("mutually exclusive") || errOutput.contains("--safe"),
+                "Error message must mention the conflict");
+    }
+
+    // -------------------------------------------------------------------------
+    // Minimal tar.gz reader using only JDK (GZIPInputStream + manual tar parsing)
+    // -------------------------------------------------------------------------
+
+    private static Map<String, byte[]> readTarGz(Path archive) throws Exception {
+        Map<String, byte[]> result = new HashMap<>();
+        try (InputStream fis = Files.newInputStream(archive);
+             GZIPInputStream gzip = new GZIPInputStream(fis)) {
+            byte[] headerBuf = new byte[512];
+            while (true) {
+                int read = readFully(gzip, headerBuf);
+                if (read < 512) break;
+                // Check for end-of-archive (two zero blocks)
+                boolean allZero = true;
+                for (byte b : headerBuf) { if (b != 0) { allZero = false; break; } }
+                if (allZero) break;
+
+                // Parse name (offset 0, 100 bytes, NUL-terminated)
+                String name = parseName(headerBuf, 0, 100);
+                if (name.isEmpty()) break;
+
+                // Parse size (offset 124, 12 bytes, octal)
+                long size = parseOctal(headerBuf, 124, 12);
+
+                // Read file data
+                byte[] data = new byte[(int) size];
+                readFully(gzip, data);
+
+                // Skip padding to 512-byte boundary
+                int remainder = (int)(size % 512);
+                if (remainder != 0) {
+                    byte[] pad = new byte[512 - remainder];
+                    readFully(gzip, pad);
+                }
+
+                result.put(name, data);
+            }
+        }
+        return result;
+    }
+
+    private static int readFully(InputStream in, byte[] buf) throws Exception {
+        int total = 0;
+        while (total < buf.length) {
+            int n = in.read(buf, total, buf.length - total);
+            if (n < 0) break;
+            total += n;
+        }
+        return total;
+    }
+
+    private static String parseName(byte[] buf, int offset, int length) {
+        int end = offset;
+        while (end < offset + length && buf[end] != 0) end++;
+        return new String(buf, offset, end - offset, StandardCharsets.US_ASCII).trim();
+    }
+
+    private static long parseOctal(byte[] buf, int offset, int length) {
+        String s = new String(buf, offset, length, StandardCharsets.US_ASCII).trim();
+        // Strip NUL and spaces
+        s = s.replaceAll("[\\x00 ]", "");
+        if (s.isEmpty()) return 0;
+        try { return Long.parseLong(s, 8); }
+        catch (NumberFormatException e) { return 0; }
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `argus snapshot <pid>` — a meta-command that bundles existing diagnostics (`VM.info`, thread dump x3, class histogram, doctor) into a single `tar.gz` for incident forensics.
- `--safe` (default) skips heap dump to avoid STW > 1s pauses. `--full` opts in to include it.
- Bundle ships with `manifest.json` (schemaVersion=1) recording per-item source and status.
- Pure-JDK POSIX tar writer (no `commons-compress` dependency).
- i18n keys added to all 4 locale files (en/ko/ja/zh, 551-key parity).

## Test plan
- [x] `./gradlew :argus-cli:test --tests SnapshotCommandTest` — 3 tests pass (safe mode produces valid tar.gz with manifest, schemaVersion=1 validation, `--safe`+`--full` conflict exits non-zero)
- [x] `./gradlew :argus-cli:fatJar` — BUILD SUCCESSFUL
- [x] Smoke test: produced 34 KB tar.gz containing `manifest.json`, `info.txt`, `threads.txt`, `histo.txt`, `doctor.txt`; `heap.hprof` correctly skipped in safe mode
- [x] i18n parity: all 4 locale files have 551 keys

Closes #224.

Related follow-ups: #225 (JDBC connection pool leak diagnostic), #226 (thread pool sizing advisor).