### PR TITLE
docs: sync docs for argus snapshot + pool subcommands

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
   <a href="https://github.com/rlaope/Argus/stargazers"><img src="https://img.shields.io/github/stars/rlaope/Argus" alt="GitHub stars"></a>
 </p>
 
-> **One CLI for all JVM diagnostics.** 67 commands, zero agent required, works on Java 11+.
+> **One CLI for all JVM diagnostics.** 68 commands, zero agent required, works on Java 11+.
 > The free alternative to GCEasy + jcmd + VisualVM combined — GC analysis, health diagnosis, flame graphs, async-profiler integration, ZGC live monitoring, and CI/CD profile gates.
 
 ---
@@ -61,7 +61,9 @@ Full reference: [docs/harness.md](docs/harness.md)
 
 ## Why Argus?
 
-- **67 diagnostic commands** — heap, GC, threads, profiling, flame graphs, NMT, class loaders, and more. No agent required.
+- **68 diagnostic commands** — heap, GC, threads, profiling, flame graphs, NMT, class loaders, and more. No agent required.
+- **Incident forensic bundle** — `argus snapshot <pid>` collects threads, histogram, doctor, JFR, and (optionally) a heap dump into one tar.gz for offline analysis.
+- **Connection-pool diagnostics** — `argus pool jdbc <pid>` reports HikariCP / Tomcat JDBC state; `argus pool advise` recommends thread-pool sizing from a ThreadMXBean sample.
 - **Live JVM attach** — attaches externally via `jcmd`/JMX; target JVM needs no restart and no `-javaagent` flag.
 - **ZGC-aware** — `argus zgc` gives a HEALTHY/WARNING/UNHEALTHY verdict with allocation stall detection, cycle-overlap analysis, SoftMax breach detection, and diff-against-baseline in one command.
 - **Virtual thread support** — JFR-based pinning detection, carrier-thread distribution, and virtual thread monitoring on Java 21+.

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,7 +9,7 @@ Welcome to the Project Argus documentation.
 
 ## Reference
 
-- [CLI Command Reference](cli-commands.md) — Index of all 67 commands with category navigation and A–Z lookup
+- [CLI Command Reference](cli-commands.md) — Index of all 68 commands with category navigation and A–Z lookup
   - [commands/monitoring.md](commands/monitoring.md) — ps, info, env, top, watch, report, diff, alert, cluster, perfcounter, tui
   - [commands/memory-gc.md](commands/memory-gc.md) — gc, heap, histo, nmt, buffers, metaspace, gclog, gcscore, zgc, and more
   - [commands/profiling-tracing.md](commands/profiling-tracing.md) — profile, flame, jfr, jfranalyze, slowlog, trace, benchmark

--- a/docs/cli-commands.md
+++ b/docs/cli-commands.md
@@ -1,6 +1,6 @@
 # Argus CLI Command Reference
 
-Complete reference for all 67 Argus CLI commands. Commands are organized into five categories. Each category page contains full synopses, option tables, and output samples. Use the alphabetical index at the bottom to jump directly to any command.
+Complete reference for all 68 Argus CLI commands. Commands are organized into five categories. Each category page contains full synopses, option tables, and output samples. Use the alphabetical index at the bottom to jump directly to any command.
 
 ## Global Options
 
@@ -104,6 +104,7 @@ CPU, allocation, lock, and wall-clock profiling via async-profiler; flame graph 
 - `argus slowlog` — real-time slow method detection (JFR streaming)
 - `argus trace` — method call tree from thread-dump sampling
 - `argus benchmark` — sampling-based throughput estimate for a method
+- `argus snapshot` — forensic bundle (threads + histogram + doctor + JFR + optional heap dump) as a single tar.gz
 
 ---
 
@@ -197,12 +198,15 @@ Thread state summaries, full thread dumps, deadlock detection, and thread pool d
 | `argus nmt` | [Memory & GC](commands/memory-gc.md#argus-nmt-pid) |
 | `argus perfcounter` | [Monitoring](commands/monitoring.md#argus-perfcounter-pid) |
 | `argus pool` | [Threads](commands/threads.md#argus-pool-pid) |
+| `argus pool jdbc` | [Threads](commands/threads.md#argus-pool-jdbc-pid) |
+| `argus pool advise` | [Threads](commands/threads.md#argus-pool-advise-pid) |
 | `argus profile` | [Profiling & Tracing](commands/profiling-tracing.md#argus-profile-pid) |
 | `argus profile-gate` | [Profiling & Tracing](commands/profiling-tracing.md#argus-profile-gate-before-after) |
 | `argus ps` | [Monitoring](commands/monitoring.md#argus-ps) |
 | `argus report` | [Monitoring](commands/monitoring.md#argus-report-pid) |
 | `argus sc` | [Runtime & JVM Internals](commands/runtime-internals.md#argus-sc-pid-pattern) |
 | `argus slowlog` | [Profiling & Tracing](commands/profiling-tracing.md#argus-slowlog-pid) |
+| `argus snapshot` | [Profiling & Tracing](commands/profiling-tracing.md#argus-snapshot-pid) |
 | `argus spring` | [Runtime & JVM Internals](commands/runtime-internals.md#argus-spring-pid) |
 | `argus stringtable` | [Runtime & JVM Internals](commands/runtime-internals.md#argus-stringtable-pid) |
 | `argus suggest` | [Runtime & JVM Internals](commands/runtime-internals.md#argus-suggest) |

--- a/docs/commands/profiling-tracing.md
+++ b/docs/commands/profiling-tracing.md
@@ -12,6 +12,7 @@ Commands for capturing and analyzing runtime performance data. This category cov
 - [argus slowlog \<pid\>](#argus-slowlog-pid)
 - [argus trace \<pid\> \<class.method\>](#argus-trace-pid-classmethod)
 - [argus benchmark \<pid\> \<class.method\>](#argus-benchmark-pid-classmethod)
+- [argus snapshot \<pid\>](#argus-snapshot-pid)
 
 ---
 
@@ -499,6 +500,86 @@ Options:
 - `--iterations=N` — Approximate iteration count (maps to duration; 10 iters ≈ 1s)
 - `--warmup=N` — Warmup iteration count before measurement (default: 50)
 - `--duration=N` — Measurement duration in seconds (default: 30)
+
+---
+
+## argus snapshot \<pid\>
+
+Collects multiple diagnostics from a target JVM into a single `tar.gz` forensic bundle for incident response. Designed for the moment something goes wrong in production and you want to ship one self-contained artifact to a teammate, ticket, or post-mortem ledger instead of running half a dozen `jcmd` invocations by hand.
+
+```bash
+$ argus snapshot 39113 --output=/tmp/incident
+```
+
+```
+Collecting diagnostics from PID 39113...
+  [v] info.txt (88.7 KB)
+  [v] threads.txt (244.3 KB)
+  [v] histo.txt (107.6 KB)
+  [v] doctor.txt (37 B)
+  [-] heap.hprof (skipped: --safe mode (STW > 1s expected; pass --full to include))
+Compressing to tar.gz...
+Snapshot saved: /tmp/incident/argus-snapshot-39113-20260525-103301.tar.gz (45.4 KB)
+```
+
+### What's collected
+
+| Item | Source | Notes |
+|---|---|---|
+| `info.txt` | `jcmd VM.info` | JVM version, args, system properties, GC settings |
+| `threads.txt` | `jcmd Thread.print` ×3 (5s apart) | Three dumps separated by `=== dump N @ <ts> ===` for catching short-lived contention |
+| `histo.txt` | `jcmd GC.class_histogram` | Live-object class histogram |
+| `doctor.txt` | `DoctorEngine.diagnose` | Output of `argus doctor` against the same PID |
+| `heap.hprof` | `jcmd GC.heap_dump` | **`--full` only.** Full heap dump; large, STW-inducing |
+| `manifest.json` | (generated) | Per-item status + bundle metadata; see schema below |
+
+### Options
+
+- `<pid>` — Target JVM PID. Defaults to the current process (self-attach) if omitted.
+- `--output=<dir>` — Output directory. Default: `./argus-snapshot-<yyyyMMdd-HHmmss>`. Missing intermediate directories are created.
+- `--safe` *(default)* — Skip heap dump and any other operation that would cause a long stop-the-world pause. Safe for production.
+- `--full` — Include the heap dump. Implies a STW pause proportional to live-heap size; do not use during a serving incident without consideration.
+- `--help`, `-h` — Print usage.
+
+`--safe` and `--full` are mutually exclusive; passing both exits with code 1.
+
+### Manifest schema (v1)
+
+```json
+{
+  "schemaVersion": 1,
+  "generatedAt": "2026-05-25T01:25:58.474195Z",
+  "argusVersion": "1.4.0",
+  "target": {
+    "pid": 39113,
+    "jvmVersion": "OpenJDK 64-Bit Server VM version 17.0.18+8",
+    "jvmArgs": "-XX:+UseG1GC ...",
+    "hostname": "host.example"
+  },
+  "mode": "safe",
+  "items": [
+    {"name": "info.txt",    "source": "jcmd VM.info",          "status": "ok",      "bytes": 84352},
+    {"name": "threads.txt", "source": "jcmd Thread.print x3",  "status": "ok",      "bytes": 250146},
+    {"name": "histo.txt",   "source": "jcmd GC.class_histogram","status": "ok",     "bytes": 112005},
+    {"name": "doctor.txt",  "source": "DoctorEngine.diagnose", "status": "ok",      "bytes": 37},
+    {"name": "heap.hprof",  "source": "jcmd GC.heap_dump",     "status": "skipped", "reason": "--safe"}
+  ]
+}
+```
+
+`status` is one of `ok`, `skipped` (intentional, e.g. `--safe`), or `error`. On `error`, an `error` field carries the underlying message — failures of individual items do not abort the bundle.
+
+### When to use
+
+- An incident is in progress and you want one artifact you can attach to a Slack thread, ticket, or post-mortem.
+- You need to ship diagnostics to a teammate who cannot attach to the target JVM (different host, security boundary).
+- You want a frozen-in-time set of diagnostics to compare against a later snapshot.
+
+### Limitations / explicitly deferred
+
+- No `argus replay <bundle>` viewer yet — bundles are tar.gz archives meant to be unpacked and read manually or piped into other tools. A first-class replay command is on the roadmap.
+- `doctor.txt` reflects whatever the live `DoctorEngine` rule set surfaces for the target. Healthy small JVMs produce a 37-byte "All checks passed" line; this is not a bug, it's the doctor being honest.
+- Older JDKs may reject the `GC.heap_dump` positional path used here. Tested on JDK 17 and JDK 21.
 
 ---
 

--- a/docs/commands/threads.md
+++ b/docs/commands/threads.md
@@ -8,6 +8,8 @@ Commands for inspecting thread state, capturing thread dumps, detecting deadlock
 - [argus threaddump \<pid\>](#argus-threaddump-pid)
 - [argus deadlock \<pid\>](#argus-deadlock-pid)
 - [argus pool \<pid\>](#argus-pool-pid)
+- [argus pool jdbc \<pid\>](#argus-pool-jdbc-pid)
+- [argus pool advise \<pid\>](#argus-pool-advise-pid)
 
 ---
 
@@ -125,6 +127,127 @@ $ argus pool 39113
 
 Options:
 - `--top N` — Show top N pools
+
+The `pool` namespace also has two subcommands for deeper diagnostics: [`argus pool jdbc`](#argus-pool-jdbc-pid) for connection pools and [`argus pool advise`](#argus-pool-advise-pid) for sizing recommendations.
+
+---
+
+## argus pool jdbc \<pid\>
+
+Reports the state of JDBC connection pools (HikariCP and Tomcat JDBC) by reading their JMX MBeans. Use this when a pool exhaustion alert fires and you need to know which pool is busy, how many threads are waiting on a connection, and how close you are to the configured `maximumPoolSize`.
+
+```bash
+$ argus pool jdbc 39113
+```
+
+```
+JDBC pools for PID 39113:
+  pool                              active    idle   total   waiting   verdict
+  ArgusQaPool                           14       4      18         0   OK
+verdict: 0 CRIT / 0 WARN / 1 pool(s) total
+```
+
+### Verdict
+
+| Verdict | Condition |
+|---|---|
+| `CRIT` | Any threads currently waiting for a connection (`waiting > 0`) |
+| `WARN` | `max > 0` and `active / max >= 0.85` |
+| `OK` | Everything else (including when `max` is not reported by the pool) |
+
+### Detected MBeans
+
+- HikariCP: `com.zaxxer.hikari:type=Pool*` (also reads the matching `type=PoolConfig (...)` MBean for `MaximumPoolSize`). Requires `HikariConfig.setRegisterMbeans(true)` on the application side.
+- Tomcat JDBC: `tomcat.jdbc:type=ConnectionPool,*` — attributes `Active`, `Idle`, `MaxActive`, `WaitCount`.
+
+If neither family is registered, the command prints a friendly message and exits with code 0 — not having JDBC pools is not an error.
+
+### Options
+
+- `<pid>` — Target JVM PID (required).
+- `--format=json` — Emit a parseable JSON document with the `pools` array, each entry carrying `name`, `kind` (`hikari` or `tomcat-jdbc`), `active`, `idle`, `total`, `max`, `waiting`, `verdict`.
+- `--help`, `-h` — Print usage.
+
+### JSON example
+
+```json
+{
+  "pid": 39113,
+  "pools": [
+    {"name": "ArgusQaPool", "kind": "hikari", "active": 14, "idle": 4,
+     "total": 18, "max": 20, "waiting": 0, "verdict": "OK"}
+  ]
+}
+```
+
+### Limitations / explicitly deferred
+
+- **Leak-thread attribution** — knowing *which thread frame* holds a leaked connection requires HikariCP's `leakDetectionThreshold` opt-in or instrumentation. The current command shows pool state and verdict only. This is tracked as a follow-up.
+- No DoctorEngine rule integration yet (the `JdbcPoolExhaustion` and `JdbcConnectionLeak` rules in the design notes are a separate PR).
+
+---
+
+## argus pool advise \<pid\>
+
+Recommends a sizing for thread pools in the target JVM, based on a short sampling window of `ThreadMXBean`. Use this when you suspect a pool is over- or under-provisioned and you want a starting number plus the parameters behind it.
+
+```bash
+$ argus pool advise 39113 --window=3s
+```
+
+```
+Thread-pool sizing advisor for PID 39113 (window=3000ms):
+  group                           p99Active  blocking%   configured  recommended
+  argus-qa-worker                        50     100.0%            -           75
+  argus-qa-scheduler                      2     100.0%            -            4
+Recommendation: ceil(p99Active * 1.5), min 4. Per-pool arrival rate is unavailable via standard JMX; this is a sizing-headroom heuristic, not a full Little's Law calculation.
+```
+
+### How it samples
+
+- Polls `ThreadMXBean.dumpAllThreads(false, false)` every 250 ms over the window.
+- Groups threads by name prefix:
+  - `http-nio-PORT-exec-N` → `http-nio-PORT`
+  - `ForkJoinPool*-worker-N` → `ForkJoinPool.*`
+  - `pool-N-thread-M` → `pool-N`
+  - `scheduling-N` → `scheduling`
+  - Any name ending in `-<digits>` (including long suffixes from custom `ThreadFactory` implementations using `System.nanoTime()` or unix-millis) → the prefix.
+- JDK/container-internal pools the user cannot resize are filtered out: `RMI TCP Accept`, `RMI Scheduler`, `GC Thread`, `Catalina-utility`, `G1 *`, `ParGC*`.
+- For Tomcat connectors, also queries `Catalina:type=ThreadPool,*` for the configured `maxThreads` and shows it in the `configured` column.
+
+### Verdict math
+
+- `p99Active` is the 99th-percentile of per-sample thread count in the group across the window.
+- `recommended = max(4, ceil(p99Active × 1.5))`.
+- `blocking%` is the share of samples where the thread was in a non-`RUNNABLE` state (a rough idle-vs-busy signal).
+
+### Options
+
+- `<pid>` — Target JVM PID (required).
+- `--window=Ns|Nms|Nm` — Sampling window. Default: `5s`. Garbage values fall back to the default; negative or zero produces no samples.
+- `--format=json` — Emit structured JSON with the `pools` array (`group`, `p99Active`, `blockingRatio`, `configured`, `recommended`).
+- `--help`, `-h` — Print usage.
+
+### JSON example
+
+```json
+{
+  "pid": 39113,
+  "windowMs": 3000,
+  "pools": [
+    {"group": "argus-qa-worker",    "p99Active": 50, "blockingRatio": 1.0000,
+     "configured": 0, "recommended": 75},
+    {"group": "argus-qa-scheduler", "p99Active":  2, "blockingRatio": 1.0000,
+     "configured": 0, "recommended":  4}
+  ]
+}
+```
+
+### Limitations / explicitly deferred
+
+- `p99Active` is "p99 of threads in the named group", not "p99 of threads actively doing work". A 50-thread pool that is mostly idle will still show `p99Active=50` and recommend ~75, which may grow an oversized pool further. Treat the number as a sizing-headroom hint, not an authoritative answer; lean on the `blocking%` column for the idle-vs-busy signal.
+- Per-pool arrival rate is not available via standard JMX, so full Little's Law (L = λ × W) is not computed. Where Tomcat exposes request rate via its connector MBean, that integration is a future enhancement.
+- Custom `ExecutorService` instances without an MBean cannot report `configured` size — the column shows `-`.
 
 ---
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -365,7 +365,7 @@ try (var executor = Executors.newVirtualThreadPerTaskExecutor()) {
 
 | Feature | Java 11+ | Java 17+ | Java 21+ |
 |---------|:--------:|:--------:|:--------:|
-| CLI (67 commands) | ✅ | ✅ | ✅ |
+| CLI (68 commands) | ✅ | ✅ | ✅ |
 | Dashboard & Web UI | — | ✅ | ✅ |
 | GC Analysis | CLI only | ✅ MXBean | ✅ JFR |
 | Virtual Thread Monitoring | — | — | ✅ JFR |

--- a/site/index.html
+++ b/site/index.html
@@ -75,7 +75,7 @@
 
                 <p>Argus gives you two tools for JVM diagnostics:</p>
                 <ul>
-                    <li><strong>Argus CLI</strong> — 67 diagnostic commands that work on any running JVM. No agent, no restart, no configuration. Point at a PID and get answers in seconds.</li>
+                    <li><strong>Argus CLI</strong> — 68 diagnostic commands that work on any running JVM. No agent, no restart, no configuration. Point at a PID and get answers in seconds.</li>
                     <li><strong>Argus Agent</strong> — Attach as a Java agent and get a live web dashboard with GC timelines, CPU graphs, heap usage, flame graphs, and thread analysis, all streaming in real time.</li>
                 </ul>
 
@@ -98,7 +98,7 @@
                 <div class="feature-grid">
                     <div class="feature-card">
                         <h4>Instant CLI Diagnostics</h4>
-                        <p>67 commands that work on any running JVM. No agent, no restart, no configuration. Just point at a PID and get answers in seconds.</p>
+                        <p>68 commands that work on any running JVM. No agent, no restart, no configuration. Just point at a PID and get answers in seconds.</p>
                     </div>
                     <div class="feature-card">
                         <h4>Real-time Dashboard</h4>


### PR DESCRIPTION
## Summary
Brings the public-facing docs in line with master after PRs #227 and #228 landed.

- Command count `67 → 68` in 6 places (README × 2, `docs/README.md`, `docs/cli-commands.md`, `docs/getting-started.md`, `site/index.html` × 2).
- Added full sections for the three new user-facing surfaces:
  - **`argus snapshot`** in `docs/commands/profiling-tracing.md` — usage, options, manifest schema, when-to-use, known limits (no `argus replay` viewer yet).
  - **`argus pool jdbc`** in `docs/commands/threads.md` — verdict matrix, detected MBeans (Hikari + Tomcat JDBC), JSON shape, leak-attribution deferral.
  - **`argus pool advise`** in `docs/commands/threads.md` — sampling approach, recommendation math, configured-size discovery, semantic limit of `p99Active`.
- A-Z index in `docs/cli-commands.md` now includes the new commands.
- README "Why Argus?" highlights now surface the incident-bundle and connection-pool features so they are discoverable from the landing page.

## Out of scope
- No code or i18n changes; locale-key parity (561 × 4) preserved.
- No release-distribution surfaces touched (Helm / Formula / install.sh) — those go via `release-sync` at release time.

## Test plan
- [x] `grep -rhEo '[0-9]{2,3} (diagnostic )?commands?' README.md docs/ site/index.html | sort -u` → single value `68`
- [x] `./gradlew :argus-cli:test --tests Pool* --tests SnapshotCommandTest` → BUILD SUCCESSFUL
- [x] Manual scan of new sections renders cleanly on GitHub