### PR TITLE
chore(release): sync SDKMAN candidate description to 68 commands

### DIFF
--- a/deploy/sdkman/argus-candidate.json
+++ b/deploy/sdkman/argus-candidate.json
@@ -1,7 +1,7 @@
 {
   "candidate": "argus",
   "name": "Argus JVM Diagnostic Toolkit",
-  "description": "56 CLI commands for JVM diagnostics — health diagnosis, GC analysis, flame graphs, interactive TUI",
+  "description": "68 CLI commands for JVM diagnostics — health diagnosis, GC analysis, flame graphs, interactive TUI",
   "websiteUrl": "https://github.com/rlaope/Argus",
   "distribution": "PLATFORM_SPECIFIC",
   "platform": {


### PR DESCRIPTION
## Summary
SDKMAN's \`deploy/sdkman/argus-candidate.json\` still advertised "56 CLI commands" in its description. After PRs #227 and #228 landed on master, the true command count is 68. This bumps the SDKMAN description to match.

## Other channels verified clean
Per the release-sync skill, all eleven distribution channels were checked and only the SDKMAN description was drifted:

| Channel | Status |
|---|---|
| Helm chart (Chart.yaml, values.yaml, templates) | version + appVersion 1.4.0, kubeVersion >=1.23.0-0, no deprecated K8s APIs |
| docker-compose | \`prom/prometheus:v2.55.0\`, \`grafana/grafana:11.3.0\` — both pinned, no \`:latest\` |
| Dockerfiles | all on \`eclipse-temurin:21-{jdk,jre}-alpine\` |
| install.sh / install.ps1 | fallback \`v1.4.0\`, ASPROF_VERSION 4.4 |
| async-profiler 3-way version check | install.sh / AsProfDownloader / AsProfCapabilities all \`4.4\` |
| Homebrew Formula | url + sha256 already point at v1.4.0 release |
| GitHub Action | \`version\` input default \`latest\` (intentional) |
| CI workflows | actions SHA-pinned; \`actions/checkout@v6\`, \`actions/setup-java@v5\`, java 21 |
| Spring Boot starter | Spring Boot 3.2.0, Spring Context 6.1.0, Micrometer 1.12.0, slf4j 2.0.9 — baselines met |
| gradle.properties | netty 4.1.115.Final (CVE patched), junit 5.11.4 |
| Released v1.4.0 artifacts | GHCR both images HTTP 200; release.yml + docker.yml + native-image.yml all success; 6 release assets present |

## Test plan
- [x] \`./gradlew compileJava\` → exit 0
- [x] No \`:latest\` in compose
- [x] No deprecated K8s APIs in Helm templates
- [x] async-profiler 3-source consistency check
- [x] \`gh release view v1.4.0\` shows all expected assets