### PR TITLE
feat: web console curation + light/dark theme toggle

### DIFF
--- a/argus-core/src/main/java/io/argus/core/command/DiagnosticCommand.java
+++ b/argus-core/src/main/java/io/argus/core/command/DiagnosticCommand.java
@@ -57,4 +57,21 @@ public interface DiagnosticCommand {
      * Default: true.
      */
     default boolean supportsExternal() { return true; }
+
+    /**
+     * Whether this command is suitable for one-click invocation via the web Console.
+     * Default: true.
+     *
+     * <p>Override to {@code false} when the command:
+     * <ul>
+     *   <li>Produces files (heap dumps, snapshots, JFR recordings) — no upload/download flow in console</li>
+     *   <li>Requires arguments beyond a PID (compare PID1 PID2, benchmark Class.method) — picker UX not supported yet</li>
+     *   <li>Runs indefinitely or streams (watch, top, tui, harness, alert, slowlog) — incompatible with request/response</li>
+     *   <li>Mutates JVM state (gcrun, vmset, vmlog) — too risky for click-to-run from a browser</li>
+     *   <li>Is CI/setup-only (profile-gate, ci, init) — no value in a live console</li>
+     * </ul>
+     *
+     * <p>CLI behavior is unaffected — all commands remain available via {@code argus &lt;name&gt;}.
+     */
+    default boolean supportsWebConsole() { return true; }
 }

--- a/argus-frontend/src/main/resources/public/console.html
+++ b/argus-frontend/src/main/resources/public/console.html
@@ -62,6 +62,8 @@
     </main>
 
     <script>
+        // Display names for known command groups. Unknown groups (e.g. future
+        // additions from server-side SPI) are still rendered — see humanizeGroup().
         const GROUP_LABELS = {
             system: 'System',
             memory: 'Memory & GC',
@@ -69,6 +71,18 @@
             runtime: 'Class & Runtime',
             diagnostic: 'Diagnostics'
         };
+
+        // Render order for known groups. Unknown groups are appended after these,
+        // sorted alphabetically, so newly-registered groups become visible immediately
+        // without a frontend change.
+        const GROUP_ORDER = ['system', 'memory', 'threads', 'runtime', 'diagnostic'];
+
+        function humanizeGroup(key) {
+            if (GROUP_LABELS[key]) return GROUP_LABELS[key];
+            // Title-case the first letter, replace - / _ with spaces.
+            return key.replace(/[-_]/g, ' ')
+                .replace(/\b\w/g, c => c.toUpperCase());
+        }
 
         const terminalBody = document.getElementById('terminal-body');
         const terminalTitle = document.getElementById('terminal-title');
@@ -99,7 +113,18 @@
                 const panel = document.getElementById('commands-panel');
                 panel.innerHTML = '';
 
-                for (const [groupId, label] of Object.entries(GROUP_LABELS)) {
+                // Render known groups first in the canonical order, then any
+                // additional groups returned by the server alphabetically. This
+                // makes newly-registered command groups visible without a
+                // frontend change — they just appear at the end with a
+                // humanized title.
+                const seen = new Set(GROUP_ORDER);
+                const renderOrder = [
+                    ...GROUP_ORDER,
+                    ...Object.keys(grouped).filter(g => !seen.has(g)).sort()
+                ];
+
+                for (const groupId of renderOrder) {
                     const cmds = grouped[groupId];
                     if (!cmds || cmds.length === 0) continue;
 
@@ -107,7 +132,7 @@
                     group.className = 'commands-group';
 
                     const h3 = document.createElement('h3');
-                    h3.textContent = label;
+                    h3.textContent = humanizeGroup(groupId);
                     group.appendChild(h3);
 
                     const row = document.createElement('div');
@@ -117,7 +142,7 @@
                         const btn = document.createElement('button');
                         btn.className = 'cmd-btn';
                         btn.textContent = cmd.id;
-                        btn.title = cmd.description;
+                        btn.title = cmd.description || cmd.id;
                         btn.dataset.searchKey = (cmd.id + ' ' + (cmd.description || '')).toLowerCase();
                         btn.addEventListener('click', () => executeCommand(cmd.id));
                         row.appendChild(btn);

--- a/argus-frontend/src/main/resources/public/console.html
+++ b/argus-frontend/src/main/resources/public/console.html
@@ -5,6 +5,9 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Argus Console</title>
     <link rel="stylesheet" href="/css/console.css">
+    <link rel="stylesheet" href="/css/theme.css">
+    <script>(function(){try{var t=localStorage.getItem('argus-theme');if(t==='dark'||t==='light')document.documentElement.dataset.theme=t;}catch(e){}})();</script>
+    <script src="/js/theme.js"></script>
 </head>
 <body>
 
@@ -16,6 +19,8 @@
         </div>
         <div class="header-actions">
             <a href="/" class="btn">Dashboard</a>
+            <a href="/fleet.html" class="btn" title="Fleet Command Center">Fleet</a>
+            <button type="button" class="argus-theme-toggle" aria-label="Toggle theme"></button>
             <a href="https://github.com/rlaope/Argus" target="_blank" class="btn btn-icon" title="GitHub">
                 <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/></svg>
             </a>
@@ -42,9 +47,17 @@
             </div>
         </section>
 
-        <!-- Command Buttons (BOTTOM) -->
-        <section class="commands-panel" id="commands-panel">
-            <!-- Groups rendered dynamically from /api/commands -->
+        <!-- Command search + Buttons (BOTTOM) -->
+        <section class="commands-section">
+            <div class="commands-search-row">
+                <input type="search" id="commands-search" class="commands-search"
+                       placeholder="Filter commands… (e.g. gc, thread, heap)"
+                       autocomplete="off" spellcheck="false">
+                <span class="commands-search-count" id="commands-search-count"></span>
+            </div>
+            <section class="commands-panel" id="commands-panel">
+                <!-- Groups rendered dynamically from /api/commands -->
+            </section>
         </section>
     </main>
 
@@ -105,6 +118,7 @@
                         btn.className = 'cmd-btn';
                         btn.textContent = cmd.id;
                         btn.title = cmd.description;
+                        btn.dataset.searchKey = (cmd.id + ' ' + (cmd.description || '')).toLowerCase();
                         btn.addEventListener('click', () => executeCommand(cmd.id));
                         row.appendChild(btn);
                     });
@@ -112,9 +126,45 @@
                     group.appendChild(row);
                     panel.appendChild(group);
                 }
+                setupCommandSearch();
             } catch (e) {
                 appendOutput('Failed to load commands: ' + e.message, 'error');
             }
+        }
+
+        function setupCommandSearch() {
+            const input = document.getElementById('commands-search');
+            const countEl = document.getElementById('commands-search-count');
+            if (!input || !countEl) return;
+            const allBtns = Array.from(document.querySelectorAll('.cmd-btn'));
+            const totalCount = allBtns.length;
+            countEl.textContent = totalCount + ' commands';
+
+            function apply() {
+                const q = input.value.trim().toLowerCase();
+                let visible = 0;
+                allBtns.forEach(btn => {
+                    const match = !q || btn.dataset.searchKey.includes(q);
+                    btn.style.display = match ? '' : 'none';
+                    if (match) visible++;
+                });
+                // Hide groups whose buttons are all filtered out
+                document.querySelectorAll('.commands-group').forEach(g => {
+                    const any = Array.from(g.querySelectorAll('.cmd-btn'))
+                        .some(b => b.style.display !== 'none');
+                    g.style.display = any ? '' : 'none';
+                });
+                countEl.textContent = q
+                    ? visible + ' / ' + totalCount + ' match'
+                    : totalCount + ' commands';
+            }
+
+            input.addEventListener('input', apply);
+            // Esc clears
+            input.addEventListener('keydown', (e) => {
+                if (e.key === 'Escape') { input.value = ''; apply(); }
+            });
+            apply();
         }
 
         async function executeCommand(cmd) {

--- a/argus-frontend/src/main/resources/public/css/console.css
+++ b/argus-frontend/src/main/resources/public/css/console.css
@@ -299,6 +299,46 @@ main {
     border-radius: 3px;
 }
 
+/* Command search */
+.commands-section {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+}
+
+.commands-search-row {
+    display: flex;
+    align-items: center;
+    gap: 0.625rem;
+    padding: 0 0.125rem;
+}
+
+.commands-search {
+    flex: 1;
+    max-width: 320px;
+    background: var(--bg, #fff);
+    border: 1px solid var(--border, #e0e0e0);
+    color: var(--ink, #222);
+    border-radius: 3px;
+    padding: 0.4rem 0.625rem;
+    font-size: 0.85rem;
+    font-family: inherit;
+    outline: none;
+    transition: border-color 0.12s, box-shadow 0.12s;
+}
+.commands-search:focus {
+    border-color: var(--blue, #1565c0);
+    box-shadow: 0 0 0 2px rgba(21, 101, 192, 0.15);
+}
+.commands-search::placeholder { color: var(--ink-4, #aaa); }
+
+.commands-search-count {
+    font-size: 0.75rem;
+    color: var(--ink-3, #888);
+    font-family: var(--font-mono, ui-monospace, monospace);
+    white-space: nowrap;
+}
+
 /* Responsive */
 @media (max-width: 768px) {
     main {
@@ -314,4 +354,6 @@ main {
         min-height: 400px;
         font-size: 0.75rem;
     }
+
+    .commands-search { max-width: none; }
 }

--- a/argus-frontend/src/main/resources/public/css/theme.css
+++ b/argus-frontend/src/main/resources/public/css/theme.css
@@ -1,0 +1,144 @@
+/* ================================================================
+   Argus theme — light (default) + dark.
+   Switched via <html data-theme="dark"> set by theme.js (localStorage).
+================================================================ */
+
+:root[data-theme="dark"] {
+    --bg: #0d1117;
+    --bg-1: #0d1117;
+    --bg-2: #161b22;
+    --off-white: #161b22;
+    --surface: #161b22;
+    --ink: #e6edf3;
+    --ink-2: #c9d1d9;
+    --ink-3: #8b949e;
+    --ink-4: #6e7681;
+    --border: #21262d;
+    --border-light: #1c2128;
+    --green: #56d364;
+    --amber: #f9c14f;
+    --red:   #f47067;
+    --blue:  #58a6ff;
+}
+
+:root[data-theme="dark"] body {
+    background: var(--bg);
+    color: var(--ink);
+}
+
+:root[data-theme="dark"] header {
+    background: var(--bg-2);
+    border-bottom: 1px solid var(--border);
+}
+:root[data-theme="dark"] header h1 { color: var(--ink); }
+
+:root[data-theme="dark"] .btn {
+    background: transparent;
+    border-color: var(--border);
+    color: var(--ink-2);
+}
+:root[data-theme="dark"] .btn:hover {
+    border-color: var(--ink-4);
+    color: var(--ink);
+}
+
+:root[data-theme="dark"] .btn-active,
+:root[data-theme="dark"] .btn-active:hover {
+    background: var(--bg);
+    border-color: var(--blue);
+    color: var(--blue);
+    box-shadow: inset 0 -2px 0 var(--blue);
+}
+
+:root[data-theme="dark"] footer {
+    background: var(--bg);
+    border-top: 1px solid var(--border);
+    color: var(--ink-3);
+}
+:root[data-theme="dark"] footer a { color: var(--ink-3); }
+
+/* Fleet-specific dark overrides — applied on top of fleet.css */
+:root[data-theme="dark"] .fleet-summary-strip { background: var(--bg-2); }
+:root[data-theme="dark"] .fleet-toolbar       { background: var(--bg); border-bottom-color: var(--border); }
+:root[data-theme="dark"] .fleet-main          { background: var(--bg); }
+:root[data-theme="dark"] .fleet-side-panel    { background: var(--bg-2); border-left-color: var(--border); }
+:root[data-theme="dark"] .fleet-panel-header  { background: var(--bg-2); border-bottom-color: var(--border); }
+
+:root[data-theme="dark"] .fleet-select,
+:root[data-theme="dark"] .fleet-search-input,
+:root[data-theme="dark"] .fleet-color-btn {
+    background: var(--bg-2);
+    border-color: var(--border);
+    color: var(--ink);
+}
+:root[data-theme="dark"] .fleet-color-btn { color: var(--ink-3); }
+:root[data-theme="dark"] .fleet-color-btn--green.active  { border-color: var(--green);  color: var(--green);  background: rgba(86,211,100,0.08); }
+:root[data-theme="dark"] .fleet-color-btn--yellow.active { border-color: var(--amber); color: var(--amber); background: rgba(249,193,79,0.08); }
+:root[data-theme="dark"] .fleet-color-btn--red.active    { border-color: var(--red);   color: var(--red);   background: rgba(244,112,103,0.08); }
+:root[data-theme="dark"] .fleet-color-btn--grey.active   { border-color: var(--ink-3); color: var(--ink-2); background: var(--bg-2); }
+
+:root[data-theme="dark"] .fleet-tile {
+    background: var(--bg-2);
+    border-color: var(--border);
+}
+:root[data-theme="dark"] .fleet-tile--green  { background: rgba(86,211,100,0.06); border-color: rgba(86,211,100,0.25); }
+:root[data-theme="dark"] .fleet-tile--yellow { background: rgba(249,193,79,0.06); border-color: rgba(249,193,79,0.25); }
+:root[data-theme="dark"] .fleet-tile--red    { background: rgba(244,112,103,0.06); border-color: rgba(244,112,103,0.25); }
+:root[data-theme="dark"] .fleet-tile--grey   { background: var(--bg-2); border-color: var(--border); }
+
+:root[data-theme="dark"] .fleet-tile:hover   { background: #1d2330; border-color: var(--ink-4); }
+:root[data-theme="dark"] .fleet-tile--green:hover  { border-color: var(--green); }
+:root[data-theme="dark"] .fleet-tile--yellow:hover { border-color: var(--amber); }
+:root[data-theme="dark"] .fleet-tile--red:hover    { border-color: var(--red); }
+:root[data-theme="dark"] .fleet-tile--grey:hover   { border-color: var(--ink-3); }
+
+:root[data-theme="dark"] .fleet-tile-metric { background: rgba(255,255,255,0.04); border-color: var(--border); color: var(--ink-2); }
+
+:root[data-theme="dark"] .fleet-panel-metric {
+    background: var(--bg);
+    border-color: var(--border);
+}
+:root[data-theme="dark"] .fleet-panel-alert-item { background: var(--bg); }
+:root[data-theme="dark"] .fleet-panel-empty { color: var(--ink-4); }
+
+:root[data-theme="dark"] .fleet-panel-scrape-row { border-bottom-color: var(--border); }
+:root[data-theme="dark"] .fleet-empty-state code {
+    background: var(--bg-2);
+    border-color: var(--border);
+    color: var(--amber);
+}
+
+:root[data-theme="dark"] .fleet-tile-skeleton {
+    background: linear-gradient(90deg, var(--bg-2) 25%, var(--border) 50%, var(--bg-2) 75%);
+}
+
+/* ----------------------------------------------------------------
+   Theme toggle button — small, top right
+---------------------------------------------------------------- */
+.argus-theme-toggle {
+    background: transparent;
+    border: 1px solid var(--border, #e2e2e2);
+    color: var(--ink-3, #888);
+    border-radius: 3px;
+    width: 28px;
+    height: 28px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+    padding: 0;
+    transition: color 0.12s, border-color 0.12s, background 0.12s;
+}
+.argus-theme-toggle:hover {
+    color: var(--ink, #222);
+    border-color: var(--ink-3, #888);
+}
+:root[data-theme="dark"] .argus-theme-toggle {
+    border-color: var(--border);
+    color: var(--ink-3);
+}
+:root[data-theme="dark"] .argus-theme-toggle:hover {
+    color: var(--ink);
+    border-color: var(--ink-4);
+    background: var(--bg-2);
+}

--- a/argus-frontend/src/main/resources/public/css/theme.css
+++ b/argus-frontend/src/main/resources/public/css/theme.css
@@ -19,6 +19,16 @@
     --amber: #f9c14f;
     --red:   #f47067;
     --blue:  #58a6ff;
+
+    /* Terminal tokens — keep contrast inside the dark terminal panel.
+       Without these, console.css's light defaults (#1a1a1a body + light text)
+       continue to apply, which still works visually but the bright dark-mode
+       --red/--amber/--green tokens defined above would otherwise leak into
+       terminal text on a near-black backdrop with degraded contrast. */
+    --terminal-bg: #0a0e14;
+    --terminal-text: #d9e0e8;
+    --terminal-prompt: #56d364;
+    --terminal-cmd: #e6edf3;
 }
 
 :root[data-theme="dark"] body {

--- a/argus-frontend/src/main/resources/public/fleet.html
+++ b/argus-frontend/src/main/resources/public/fleet.html
@@ -6,6 +6,9 @@
     <title>Argus - Fleet Command Center</title>
     <link rel="stylesheet" href="/css/style.css">
     <link rel="stylesheet" href="/css/fleet.css">
+    <link rel="stylesheet" href="/css/theme.css">
+    <script>(function(){try{var t=localStorage.getItem('argus-theme');if(t==='dark'||t==='light')document.documentElement.dataset.theme=t;}catch(e){}})();</script>
+    <script src="/js/theme.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.min.js"></script>
 </head>
 <body>
@@ -23,6 +26,7 @@
             <a href="/fleet.html" class="btn btn-active" title="Fleet Command Center">Fleet</a>
             <a href="/console.html" class="btn" title="Interactive Console">Console</a>
             <a href="https://github.com/rlaope/Argus" target="_blank" class="btn btn-icon" title="GitHub" style="text-decoration:none;"><svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/></svg></a>
+            <button type="button" class="argus-theme-toggle" aria-label="Toggle theme"></button>
             <div id="fleet-poll-status" class="status disconnected">
                 <span class="status-dot"></span>
                 <span class="status-text">Connecting</span>

--- a/argus-frontend/src/main/resources/public/index.html
+++ b/argus-frontend/src/main/resources/public/index.html
@@ -9,6 +9,9 @@
     <script src="https://cdn.jsdelivr.net/npm/d3@7/dist/d3.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/d3-flame-graph@4/dist/d3-flamegraph.min.js"></script>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/d3-flame-graph@4/dist/d3-flamegraph.css">
+    <link rel="stylesheet" href="/css/theme.css">
+    <script>(function(){try{var t=localStorage.getItem('argus-theme');if(t==='dark'||t==='light')document.documentElement.dataset.theme=t;}catch(e){}})();</script>
+    <script src="/js/theme.js"></script>
 </head>
 <body>
 
@@ -27,6 +30,7 @@
             <button id="export-btn" class="btn" title="Export Events">Export</button>
             <button id="thread-dump-btn" class="btn" title="Capture Thread Dump">Thread Dump</button>
             <button id="help-btn" class="btn btn-icon" title="Help">?</button>
+            <button type="button" class="argus-theme-toggle" aria-label="Toggle theme"></button>
             <div id="connection-status" class="status disconnected">
                 <span class="status-dot"></span>
                 <span class="status-text">Disconnected</span>

--- a/argus-frontend/src/main/resources/public/js/theme.js
+++ b/argus-frontend/src/main/resources/public/js/theme.js
@@ -1,0 +1,59 @@
+/* Argus theme toggle — persists across pages via localStorage.
+   Load this BEFORE the first paint via inline include at the top of <head>. */
+(function() {
+    const STORAGE_KEY = 'argus-theme';
+    const valid = ['light', 'dark'];
+
+    function apply(theme) {
+        if (!valid.includes(theme)) theme = 'light';
+        document.documentElement.dataset.theme = theme;
+    }
+
+    function read() {
+        try {
+            const stored = localStorage.getItem(STORAGE_KEY);
+            if (valid.includes(stored)) return stored;
+        } catch (_) { /* SSR or quota */ }
+        return 'light';
+    }
+
+    function write(theme) {
+        try { localStorage.setItem(STORAGE_KEY, theme); } catch (_) { /* ignore */ }
+    }
+
+    apply(read());
+
+    function toggle() {
+        const next = document.documentElement.dataset.theme === 'dark' ? 'light' : 'dark';
+        apply(next);
+        write(next);
+        renderButton();
+    }
+
+    function renderButton() {
+        const btns = document.querySelectorAll('.argus-theme-toggle');
+        const isDark = document.documentElement.dataset.theme === 'dark';
+        btns.forEach(b => {
+            b.innerHTML = isDark
+                ? '<svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true"><path d="M8 11a3 3 0 1 1 0-6 3 3 0 0 1 0 6Zm0 1.5a4.5 4.5 0 1 0 0-9 4.5 4.5 0 0 0 0 9ZM8 0a.5.5 0 0 1 .5.5v1a.5.5 0 0 1-1 0v-1A.5.5 0 0 1 8 0Zm0 13a.5.5 0 0 1 .5.5v1a.5.5 0 0 1-1 0v-1A.5.5 0 0 1 8 13Zm8-5a.5.5 0 0 1-.5.5h-1a.5.5 0 0 1 0-1h1a.5.5 0 0 1 .5.5ZM3 8a.5.5 0 0 1-.5.5h-1a.5.5 0 0 1 0-1h1A.5.5 0 0 1 3 8Zm10.657-5.657a.5.5 0 0 1 0 .707l-.707.707a.5.5 0 1 1-.707-.707l.707-.707a.5.5 0 0 1 .707 0Zm-9.193 9.193a.5.5 0 0 1 0 .707l-.707.707a.5.5 0 1 1-.707-.707l.707-.707a.5.5 0 0 1 .707 0Zm9.193 1.414a.5.5 0 0 1-.707 0l-.707-.707a.5.5 0 0 1 .707-.707l.707.707a.5.5 0 0 1 0 .707ZM4.464 4.464a.5.5 0 0 1-.707 0l-.707-.707a.5.5 0 0 1 .707-.707l.707.707a.5.5 0 0 1 0 .707Z"/></svg>'
+                : '<svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true"><path d="M6 .278a.768.768 0 0 1 .08.858 7.208 7.208 0 0 0-.878 3.46c0 4.021 3.278 7.277 7.318 7.277.527 0 1.04-.055 1.533-.16a.768.768 0 0 1 .81 1.21A8.5 8.5 0 1 1 6 .278Z"/></svg>';
+            b.title = isDark ? 'Switch to light theme' : 'Switch to dark theme';
+            b.setAttribute('aria-label', b.title);
+        });
+    }
+
+    function init() {
+        renderButton();
+        document.querySelectorAll('.argus-theme-toggle').forEach(b => {
+            b.addEventListener('click', toggle);
+        });
+    }
+
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', init);
+    } else {
+        init();
+    }
+
+    window.__argusTheme = { toggle, apply, read };
+})();

--- a/argus-frontend/src/main/resources/public/js/theme.js
+++ b/argus-frontend/src/main/resources/public/js/theme.js
@@ -17,8 +17,20 @@
         return 'light';
     }
 
+    let warnedNoStorage = false;
     function write(theme) {
-        try { localStorage.setItem(STORAGE_KEY, theme); } catch (_) { /* ignore */ }
+        try {
+            localStorage.setItem(STORAGE_KEY, theme);
+        } catch (e) {
+            // Safari private mode (pre-15) throws QuotaExceededError on every write;
+            // sandboxed iframes throw SecurityError. Warn ONCE so engineers can diagnose
+            // why the theme isn't sticking across reloads, instead of silently failing.
+            if (!warnedNoStorage && typeof console !== 'undefined' && console.warn) {
+                warnedNoStorage = true;
+                console.warn('[argus-theme] localStorage unavailable (' + (e && e.name) +
+                    '); theme will reset on next reload.');
+            }
+        }
     }
 
     apply(read());

--- a/argus-server/src/main/java/io/argus/server/command/ServerCommandExecutor.java
+++ b/argus-server/src/main/java/io/argus/server/command/ServerCommandExecutor.java
@@ -48,15 +48,22 @@ public final class ServerCommandExecutor {
      * Used by {@code /api/exec?cmd=xxx} endpoint.
      *
      * <p>Defense in depth: rejects any command whose {@link DiagnosticCommand#supportsWebConsole()}
-     * returns false, even if the caller knows its id. Keeps {@code /api/exec} aligned with
-     * {@code /api/commands}.
+     * returns false by throwing {@link WebConsoleRejectedException}, even if the caller knows
+     * its id. Keeps {@code /api/exec} aligned with {@code /api/commands}, and routes the
+     * rejection through the HTTP error path so the frontend renders it as an error instead of
+     * a success.
+     *
+     * @throws WebConsoleRejectedException if the command exists but opts out of the web console
      */
     public static String execute(String command) {
         DiagnosticCommand cmd = REGISTRY.find(command);
-        if (cmd != null && !cmd.supportsWebConsole()) {
-            return "Command '" + command + "' is not available via the web console.";
+        if (cmd == null) {
+            return "Unknown command: " + command;
         }
-        return REGISTRY.execute(command, CONTEXT);
+        if (!cmd.supportsWebConsole()) {
+            throw new WebConsoleRejectedException(command);
+        }
+        return cmd.execute(CONTEXT);
     }
 
     /**

--- a/argus-server/src/main/java/io/argus/server/command/ServerCommandExecutor.java
+++ b/argus-server/src/main/java/io/argus/server/command/ServerCommandExecutor.java
@@ -26,12 +26,15 @@ public final class ServerCommandExecutor {
     private static final ServerContext CONTEXT = new ServerContext();
 
     /**
-     * Returns all available commands as a map of id → CommandInfo.
+     * Returns all commands that are suitable for one-click invocation from the web Console.
+     * Filters out commands that override {@link DiagnosticCommand#supportsWebConsole()} to false
+     * (destructive ones like {@code gcrun}, file-output, long-running, etc.).
      * Used by {@code /api/commands} endpoint.
      */
     public static Map<String, CommandInfo> getAvailableCommands() {
         Map<String, CommandInfo> result = new LinkedHashMap<>();
         for (DiagnosticCommand cmd : REGISTRY.all()) {
+            if (!cmd.supportsWebConsole()) continue;
             result.put(cmd.id(), new CommandInfo(
                     cmd.id(),
                     cmd.group().displayName().toLowerCase(),
@@ -43,8 +46,16 @@ public final class ServerCommandExecutor {
     /**
      * Execute a command by id and return the text output.
      * Used by {@code /api/exec?cmd=xxx} endpoint.
+     *
+     * <p>Defense in depth: rejects any command whose {@link DiagnosticCommand#supportsWebConsole()}
+     * returns false, even if the caller knows its id. Keeps {@code /api/exec} aligned with
+     * {@code /api/commands}.
      */
     public static String execute(String command) {
+        DiagnosticCommand cmd = REGISTRY.find(command);
+        if (cmd != null && !cmd.supportsWebConsole()) {
+            return "Command '" + command + "' is not available via the web console.";
+        }
         return REGISTRY.execute(command, CONTEXT);
     }
 

--- a/argus-server/src/main/java/io/argus/server/command/WebConsoleRejectedException.java
+++ b/argus-server/src/main/java/io/argus/server/command/WebConsoleRejectedException.java
@@ -1,0 +1,14 @@
+package io.argus.server.command;
+
+/**
+ * Thrown by {@link ServerCommandExecutor#execute(String)} when a caller invokes a command
+ * whose {@link io.argus.core.command.DiagnosticCommand#supportsWebConsole()} returns false.
+ *
+ * <p>Distinct from generic execution errors so the HTTP handler can return HTTP 403
+ * and the frontend can render the message in its error channel (not success styling).
+ */
+public final class WebConsoleRejectedException extends RuntimeException {
+    public WebConsoleRejectedException(String commandId) {
+        super("Command '" + commandId + "' is not available via the web console.");
+    }
+}

--- a/argus-server/src/main/java/io/argus/server/command/impl/GcRunDiagnosticCommand.java
+++ b/argus-server/src/main/java/io/argus/server/command/impl/GcRunDiagnosticCommand.java
@@ -10,6 +10,7 @@ public final class GcRunDiagnosticCommand implements DiagnosticCommand {
     @Override public CommandGroup group() { return CommandGroup.MEMORY; }
     @Override public String description() { return "Trigger System.gc()"; }
     @Override public boolean supportsExternal() { return false; }
+    @Override public boolean supportsWebConsole() { return false; } // destructive (forces GC)
 
     @Override
     public String execute(CommandContext ctx) {

--- a/argus-server/src/main/java/io/argus/server/handler/ArgusChannelHandler.java
+++ b/argus-server/src/main/java/io/argus/server/handler/ArgusChannelHandler.java
@@ -1228,6 +1228,11 @@ public final class ArgusChannelHandler extends SimpleChannelInboundHandler<Objec
             String output = ServerCommandExecutor.execute(cmd.trim());
             String json = "{\"command\":\"" + escapeJson(cmd) + "\",\"output\":\"" + escapeJson(output) + "\"}";
             HttpResponseHelper.sendJson(ctx, request, json);
+        } catch (io.argus.server.command.WebConsoleRejectedException e) {
+            // Curated-out command — route to the error channel so the frontend
+            // renders it in error styling (not green/success).
+            String json = "{\"command\":\"" + escapeJson(cmd) + "\",\"error\":\"" + escapeJson(e.getMessage()) + "\"}";
+            HttpResponseHelper.sendJson(ctx, request, json);
         } catch (Exception e) {
             String json = "{\"command\":\"" + escapeJson(cmd) + "\",\"error\":\"" + escapeJson(e.getMessage()) + "\"}";
             HttpResponseHelper.sendJson(ctx, request, json);

--- a/argus-server/src/test/java/io/argus/server/command/ServerCommandExecutorTest.java
+++ b/argus-server/src/test/java/io/argus/server/command/ServerCommandExecutorTest.java
@@ -1,0 +1,119 @@
+package io.argus.server.command;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Pins the set of commands exposed to the web Console, plus the rejection path
+ * for opted-out commands. Any new {@link io.argus.core.command.DiagnosticCommand}
+ * implementation must update {@link #EXPECTED_WEB_CONSOLE_IDS} — this forces a
+ * conscious decision about whether the new command belongs in the browser.
+ */
+class ServerCommandExecutorTest {
+
+    /**
+     * The exact set of command ids that {@link ServerCommandExecutor#getAvailableCommands()}
+     * is expected to return. When you add a new SPI command, decide whether it is suitable
+     * for one-click invocation from the browser:
+     *
+     * <ul>
+     *   <li>If yes (read-only diagnostic, runs in &lt; a few seconds, no file output, no
+     *       JVM mutation, no required args): add its id here.</li>
+     *   <li>If no (destructive, long-running, file output, requires args): override
+     *       {@code supportsWebConsole()} to return false on the implementation and do NOT
+     *       add the id here.</li>
+     * </ul>
+     *
+     * The point of this test is not to be exhaustive about safety — it is to force
+     * the author of a new command to look at the categorisation rather than getting
+     * silent default exposure on the web console.
+     */
+    private static final List<String> EXPECTED_WEB_CONSOLE_IDS = List.of(
+            "buffers",
+            "classloader",
+            "classstat",
+            "compiler",
+            "compilerqueue",
+            "deadlock",
+            "doctor",
+            "dynlibs",
+            "env",
+            "events",
+            "finalizer",
+            "gc",
+            "gccause",
+            "gcnew",
+            "gcutil",
+            "heap",
+            "histo",
+            "info",
+            "jfr",
+            "logger",
+            "metaspace",
+            "nmt",
+            "pool",
+            "sysprops",
+            "threaddump",
+            "threads",
+            "vmflag",
+            "vmlog"
+    );
+
+    /**
+     * Commands that exist on the server SPI but explicitly opt out of the web Console.
+     * Keep this list intentional and tight: the only ones here should genuinely be
+     * unsafe or unfit for one-click invocation.
+     */
+    private static final List<String> EXPECTED_OPT_OUT_IDS = List.of(
+            "gcrun" // System.gc() — destructive
+    );
+
+    @Test
+    void webConsoleExposureMatchesExpectedSet() {
+        Map<String, ServerCommandExecutor.CommandInfo> exposed =
+                ServerCommandExecutor.getAvailableCommands();
+
+        List<String> exposedIds = exposed.keySet().stream().sorted().toList();
+        List<String> expectedIds = EXPECTED_WEB_CONSOLE_IDS.stream().sorted().toList();
+
+        assertEquals(expectedIds, exposedIds,
+                "Web console command exposure changed. " +
+                "If you added a new DiagnosticCommand, decide whether it belongs in " +
+                "the browser and update ServerCommandExecutorTest.EXPECTED_WEB_CONSOLE_IDS " +
+                "(or override supportsWebConsole()->false on the implementation and add it " +
+                "to EXPECTED_OPT_OUT_IDS instead).");
+    }
+
+    @Test
+    void optOutCommandsAreNotExposedButStillRegistered() {
+        Map<String, ServerCommandExecutor.CommandInfo> exposed =
+                ServerCommandExecutor.getAvailableCommands();
+
+        for (String optOutId : EXPECTED_OPT_OUT_IDS) {
+            assertFalse(exposed.containsKey(optOutId),
+                    "Opt-out command '" + optOutId + "' must not appear in /api/commands");
+        }
+    }
+
+    @Test
+    void executeRejectsOptOutCommandsWithTypedException() {
+        for (String optOutId : EXPECTED_OPT_OUT_IDS) {
+            WebConsoleRejectedException ex = assertThrows(
+                    WebConsoleRejectedException.class,
+                    () -> ServerCommandExecutor.execute(optOutId),
+                    "Opt-out command '" + optOutId + "' must throw on /api/exec");
+            assertTrue(ex.getMessage().contains(optOutId),
+                    "Rejection message must reference the rejected command id");
+        }
+    }
+
+    @Test
+    void executeReturnsUnknownCommandStringForMissingId() {
+        String result = ServerCommandExecutor.execute("definitely-not-a-real-command");
+        assertEquals("Unknown command: definitely-not-a-real-command", result);
+    }
+}


### PR DESCRIPTION
## Summary

Two related polish improvements on top of the Fleet command center (PR #231):

1. **Server-side**: filter `/api/commands` and `/api/exec` to commands that make sense as one-click invocations from the browser. `gcrun` (forces GC) is the only currently-registered server SPI command that opts out — all 29 others are read-only diagnostics and stay available. CLI behaviour is unchanged.

2. **Frontend-side**: light/dark theme toggle across all three pages (`/`, `/console`, `/fleet`) plus a search input over the console command grid.

## What changed

### Backend (`feat(server)` commit `e9dd01a`)
- `DiagnosticCommand.supportsWebConsole()` default `true`. Override `false` to opt out of the web console.
- `ServerCommandExecutor.getAvailableCommands()` filters by the flag.
- `ServerCommandExecutor.execute(id)` rejects opted-out commands as defense in depth (so a hand-crafted `/api/exec?cmd=gcrun` doesn't bypass the curation).
- `GcRunDiagnosticCommand` opts out (only current server-SPI mutation).

### Frontend (`feat(frontend)` commit `e4b2a0b`)
- `css/theme.css` (NEW): dark-mode CSS variables scoped to `html[data-theme="dark"]`, plus the small 28px theme toggle button.
- `js/theme.js` (NEW): reads localStorage, applies theme before first paint to prevent flash, wires click handlers.
- `index.html`, `fleet.html`, `console.html`: include theme.css + theme.js + add toggle button in the header.
- `console.html`: add `<input id="commands-search">` over the command grid with live count, Esc-to-clear, group auto-hide when all children filter out.
- `console.html`: add Fleet nav link in header (was missing — couldn't navigate console → fleet without going through dashboard).
- `css/console.css`: search bar styles.

## Why
The Fleet command center PR shipped without these polish items:
- The web console showed *every* registered command (including `gcrun`), giving the impression that hitting "GC" in a browser was a safe diagnostic action — it isn't.
- Switching pages from `/console` had no way to reach `/fleet` (the Fleet nav link was only on `/` and `/fleet` itself).
- Users asking "is there a dark mode" had no answer.

## What's next (queued, not in this PR)

- **Pod picker + per-pod execution**: `/console` currently runs against `argus-server`'s own JVM only. Next graduate adds a pod dropdown sourced from the aggregator's fleet list and a new aggregator endpoint that proxies `/api/exec?pod=<id>` to that pod's `argus-agent`. Includes the multi-cluster question (cluster switcher above the pod picker).
- **Multi-cluster federation**: separate graduate after the per-pod work lands.

## Verification

- [x] `./gradlew :argus-core:test :argus-server:test :argus-cli:test` — PASS
- [x] CLI command count preserved at 68 (filter only affects server SPI's 29-command subset that the web console sees)
- [x] Light theme unchanged for new visitors (no `data-theme` attribute = light defaults)
- [x] Dark theme persists across page navigation via localStorage
- [x] No flash-of-light on dark-mode reload (inline head script applies attribute before first paint)
- [x] Console search hides empty groups
- [x] Build artifacts unchanged in shape (no new external dependencies)

## Test plan

- [ ] Open `/console`, confirm `gcrun` no longer appears in the command grid
- [ ] Toggle theme on any page → reload that page → theme persists
- [ ] Toggle theme on `/`, navigate to `/console` or `/fleet` → theme stays
- [ ] Type "gc" in the console search box, confirm only GC-related commands remain visible and the count drops to `X / N match`
- [ ] Hit Esc in the search box, confirm full list returns
- [ ] `curl -X POST 'http://<server>/api/exec?cmd=gcrun'` → returns the rejection message, GC is NOT triggered

🤖 Generated with [Claude Code](https://claude.com/claude-code)