### PR TITLE
fix: address MEDIUM/LOW review findings from #232 (ultrawork batch)

### DIFF
--- a/argus-frontend/src/main/resources/public/console.html
+++ b/argus-frontend/src/main/resources/public/console.html
@@ -6,7 +6,7 @@
     <title>Argus Console</title>
     <link rel="stylesheet" href="/css/console.css">
     <link rel="stylesheet" href="/css/theme.css">
-    <script>(function(){try{var t=localStorage.getItem('argus-theme');if(t==='dark'||t==='light')document.documentElement.dataset.theme=t;}catch(e){}})();</script>
+    <script src="/js/theme-preboot.js"></script>
     <script src="/js/theme.js"></script>
 </head>
 <body>
@@ -151,9 +151,10 @@
                     group.appendChild(row);
                     panel.appendChild(group);
                 }
-                setupCommandSearch();
             } catch (e) {
                 appendOutput('Failed to load commands: ' + e.message, 'error');
+            } finally {
+                setupCommandSearch();
             }
         }
 
@@ -169,7 +170,7 @@
                 const q = input.value.trim().toLowerCase();
                 let visible = 0;
                 allBtns.forEach(btn => {
-                    const match = !q || btn.dataset.searchKey.includes(q);
+                    const match = !q || (btn.dataset.searchKey || '').includes(q);
                     btn.style.display = match ? '' : 'none';
                     if (match) visible++;
                 });
@@ -197,7 +198,9 @@
             isRunning = true;
 
             document.querySelectorAll('.cmd-btn').forEach(b => b.classList.remove('active'));
-            const activeBtn = [...document.querySelectorAll('.cmd-btn')].find(b => b.textContent === cmd);
+            const buttons = [...document.querySelectorAll('.cmd-btn')];
+            const activeBtn = buttons.find(b => b.textContent === cmd && b.style.display !== 'none')
+                               || buttons.find(b => b.textContent === cmd);
             if (activeBtn) activeBtn.classList.add('active');
 
             // Type command animation

--- a/argus-frontend/src/main/resources/public/fleet.html
+++ b/argus-frontend/src/main/resources/public/fleet.html
@@ -7,7 +7,7 @@
     <link rel="stylesheet" href="/css/style.css">
     <link rel="stylesheet" href="/css/fleet.css">
     <link rel="stylesheet" href="/css/theme.css">
-    <script>(function(){try{var t=localStorage.getItem('argus-theme');if(t==='dark'||t==='light')document.documentElement.dataset.theme=t;}catch(e){}})();</script>
+    <script src="/js/theme-preboot.js"></script>
     <script src="/js/theme.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.min.js"></script>
 </head>

--- a/argus-frontend/src/main/resources/public/index.html
+++ b/argus-frontend/src/main/resources/public/index.html
@@ -10,7 +10,7 @@
     <script src="https://cdn.jsdelivr.net/npm/d3-flame-graph@4/dist/d3-flamegraph.min.js"></script>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/d3-flame-graph@4/dist/d3-flamegraph.css">
     <link rel="stylesheet" href="/css/theme.css">
-    <script>(function(){try{var t=localStorage.getItem('argus-theme');if(t==='dark'||t==='light')document.documentElement.dataset.theme=t;}catch(e){}})();</script>
+    <script src="/js/theme-preboot.js"></script>
     <script src="/js/theme.js"></script>
 </head>
 <body>

--- a/argus-frontend/src/main/resources/public/js/theme-preboot.js
+++ b/argus-frontend/src/main/resources/public/js/theme-preboot.js
@@ -1,0 +1,1 @@
+(function(){try{var t=localStorage.getItem('argus-theme');if(t==='dark'||t==='light')document.documentElement.dataset.theme=t;}catch(e){}})();

--- a/argus-frontend/src/main/resources/public/js/theme.js
+++ b/argus-frontend/src/main/resources/public/js/theme.js
@@ -1,6 +1,11 @@
 /* Argus theme toggle — persists across pages via localStorage.
    Load this BEFORE the first paint via inline include at the top of <head>. */
 (function() {
+    // Idempotency guard: if this script is accidentally loaded twice (e.g. bundler
+    // includes it twice or a future page has two <script> tags), the second invocation
+    // must not attach a second set of click listeners that would toggle theme twice per click.
+    if (window.__argusTheme) return;
+
     const STORAGE_KEY = 'argus-theme';
     const valid = ['light', 'dark'];
 
@@ -67,5 +72,16 @@
         init();
     }
 
-    window.__argusTheme = { toggle, apply, read };
+    // Cross-tab synchronization: when localStorage changes in another tab, apply the
+    // new theme and re-render buttons so all tabs stay consistent without a reload.
+    window.addEventListener('storage', function(e) {
+        if (e.key === STORAGE_KEY && valid.includes(e.newValue)) {
+            apply(e.newValue);
+            renderButton();
+        }
+    });
+
+    // Object.freeze prevents any same-origin third-party script (e.g. a compromised CDN
+    // dependency) from reassigning toggle/apply/read and silently breaking theme control.
+    window.__argusTheme = Object.freeze({ toggle, apply, read });
 })();

--- a/argus-server/src/main/java/io/argus/server/command/ServerCommandExecutor.java
+++ b/argus-server/src/main/java/io/argus/server/command/ServerCommandExecutor.java
@@ -6,6 +6,7 @@ import io.argus.core.command.DiagnosticCommand;
 import java.lang.management.ManagementFactory;
 import java.lang.management.RuntimeMXBean;
 import java.util.LinkedHashMap;
+import java.util.Locale;
 import java.util.Map;
 
 /**
@@ -37,7 +38,7 @@ public final class ServerCommandExecutor {
             if (!cmd.supportsWebConsole()) continue;
             result.put(cmd.id(), new CommandInfo(
                     cmd.id(),
-                    cmd.group().displayName().toLowerCase(),
+                    cmd.group().displayName().toLowerCase(Locale.ROOT),
                     cmd.description()));
         }
         return result;


### PR DESCRIPTION
Batches the MEDIUM/LOW review findings from PR #232 into a single follow-up. Built via /ultrawork with 3 parallel agents on disjoint files.

## Commits

- **8b4ac9b** `fix(server): use Locale.ROOT in toLowerCase to avoid Turkish-locale dotless-i bug`
  ServerCommandExecutor.getAvailableCommands() previously used the JVM default Locale for case folding, so a tr_TR JVM produced `runtıme` instead of `runtime` and the frontend dropped entire command groups. Now uses `Locale.ROOT`.

- **e75c0d8** `fix(frontend): harden theme.js — idempotency guard, cross-tab sync, freeze API`
  Three hardening passes on theme.js:
  - Idempotency guard at top of IIFE — returns early if `window.__argusTheme` already exists. Future accidental double-load no longer doubles listeners.
  - `storage` event listener — toggling theme in one tab now syncs the icon + palette in other open tabs without a reload.
  - `Object.freeze({ toggle, apply, read })` on the exposed API so a same-origin script (CDN compromise on Chart.js / d3 / d3-flame-graph) can't replace it.

- **281ccaf** `fix(frontend): extract duplicated theme preboot inline script to shared file`
  Despite the commit title, bundles four console/HTML defenses:
  - New `/js/theme-preboot.js` — the previously triple-duplicated inline pre-paint snippet across console.html / fleet.html / index.html is now a single shared file. Future storage-key renames need to change one place.
  - `setupCommandSearch()` moved into `finally` block of init's try/catch — the search input is always wired even when /api/commands fetch fails (no more silently-dead input).
  - `(btn.dataset.searchKey || '').includes(q)` — prevents TypeError if a static `.cmd-btn` ever exists outside the dynamic render path.
  - Two-pass `find` in executeCommand — prefers visible matching buttons, so clicking a command during search filtering gives accurate active-state feedback.

## Verification

- `./gradlew :argus-core:test :argus-server:test :argus-cli:test` — PASS
- `ServerCommandExecutorTest` (the pinning test from PR #232) — PASS
- `node --check argus-frontend/.../js/theme.js` — PASS (syntax-only validation; runtime needs `window` which is browser-only)
- All three HTML files load `/js/theme-preboot.js` before `/js/theme.js`

## What's NOT in this PR

- HIGH findings (5): all addressed in commit bd40240 on PR #232 before merge
- Pod picker / per-pod execution / aggregator exec proxy: separate graduate, big surface
- Multi-cluster cluster switcher: separate graduate, big surface
- Render-blocking head script perf: defer/async script tags are a deliberate trade-off here (preboot must run before first paint to avoid FOUC); leaving as-is

🤖 Generated with [Claude Code](https://claude.com/claude-code)