### PR TITLE
feat: console pod picker + aggregator exec proxy

### DIFF
--- a/argus-aggregator/src/main/java/io/argus/aggregator/http/FleetController.java
+++ b/argus-aggregator/src/main/java/io/argus/aggregator/http/FleetController.java
@@ -49,6 +49,7 @@ import java.util.Set;
  */
 public final class FleetController {
 
+    private static final System.Logger LOG = System.getLogger(FleetController.class.getName());
     private static final List<String> ALLOWED_SEVERITIES = List.of("critical", "warning", "info");
     private static final int MAX_PODID_LENGTH = 253;
 
@@ -328,7 +329,11 @@ public final class FleetController {
             // side. We don't re-parse so the wire shape stays decoupled.
             sendJson(ctx, request, safeStatus(resp.status()), resp.body());
         } catch (PodHttpClient.ProxyException e) {
-            sendError(ctx, request, 502, "pod unreachable: " + e.getMessage());
+            // Log the detail (incl. pod IP) server-side for diagnostics; keep
+            // the client-facing message free of internal addressing.
+            LOG.log(System.Logger.Level.WARNING,
+                    () -> "console proxy: pod unreachable [" + e.getMessage() + "]");
+            sendError(ctx, request, 502, "pod unreachable");
         }
     }
 
@@ -365,8 +370,11 @@ public final class FleetController {
             return;
         }
         // Defense-in-depth: cmd is appended to a URL, so reject obviously bad
-        // input early. The pod side will additionally reject unknown ids.
-        if (cmd.length() > 64 || !cmd.matches("[a-zA-Z0-9_-]+")) {
+        // input early. Curated command ids are lowercase ASCII; lock the
+        // proxy filter to the same alphabet so what reaches the upstream
+        // request line is bounded to [a-z0-9_-]. URLEncoder is a no-op on
+        // those bytes, ruling out CRLF/NUL/space smuggling.
+        if (cmd.length() > 64 || !cmd.matches("[a-z0-9_-]+")) {
             sendError(ctx, request, 400, "invalid cmd");
             return;
         }
@@ -382,7 +390,11 @@ public final class FleetController {
                             cmd, java.nio.charset.StandardCharsets.UTF_8));
             sendJson(ctx, request, safeStatus(resp.status()), resp.body());
         } catch (PodHttpClient.ProxyException e) {
-            sendError(ctx, request, 502, "pod unreachable: " + e.getMessage());
+            // Log the detail (incl. pod IP) server-side for diagnostics; keep
+            // the client-facing message free of internal addressing.
+            LOG.log(System.Logger.Level.WARNING,
+                    () -> "console proxy: pod unreachable [" + e.getMessage() + "]");
+            sendError(ctx, request, 502, "pod unreachable");
         }
     }
 

--- a/argus-aggregator/src/main/java/io/argus/aggregator/http/FleetController.java
+++ b/argus-aggregator/src/main/java/io/argus/aggregator/http/FleetController.java
@@ -54,10 +54,17 @@ public final class FleetController {
 
     private final FleetRegistry registry;
     private final PrometheusMetricsExporter prometheus;
+    private final PodHttpClient podClient;
 
     public FleetController(FleetRegistry registry, PrometheusMetricsExporter prometheus) {
+        this(registry, prometheus, new PodHttpClient());
+    }
+
+    public FleetController(FleetRegistry registry, PrometheusMetricsExporter prometheus,
+                           PodHttpClient podClient) {
         this.registry = registry;
         this.prometheus = prometheus;
+        this.podClient = podClient;
     }
 
     /** Returns true if the request was handled. */
@@ -97,6 +104,27 @@ public final class FleetController {
             }
             if (HttpMethod.GET.equals(method) && path.equals("/health")) {
                 sendPlain(ctx, request, HttpResponseStatus.OK, "ok");
+                return true;
+            }
+            // ── Console proxy routes ────────────────────────────────────────
+            // These let the browser console pick a pod from the fleet and run
+            // diagnostic commands against it without kubectl exec. The
+            // aggregator forwards to each pod's argus-server using the
+            // host:port that the operator already registered (and that
+            // HostAllowlist already validated at registration time).
+            if (HttpMethod.GET.equals(method) && path.equals("/api/pods")) {
+                handleListPods(ctx, request);
+                return true;
+            }
+            if (HttpMethod.GET.equals(method) && path.startsWith("/api/pods/")
+                    && path.endsWith("/commands")) {
+                String mid = path.substring("/api/pods/".length(),
+                        path.length() - "/commands".length());
+                handleProxyCommands(ctx, request, mid);
+                return true;
+            }
+            if (HttpMethod.POST.equals(method) && path.equals("/api/exec")) {
+                handleProxyExec(ctx, request, decoder.parameters());
                 return true;
             }
         } catch (Exception e) {
@@ -255,6 +283,109 @@ public final class FleetController {
         sendText(ctx, request, HttpResponseStatus.OK, body, "text/plain; version=0.0.4; charset=utf-8");
     }
 
+    // ── Console proxy handlers ──────────────────────────────────────────────
+
+    /**
+     * Lightweight pod list for the console picker. Returns identity fields only
+     * (no metrics) so the picker stays cheap even on large fleets.
+     */
+    private void handleListPods(ChannelHandlerContext ctx, FullHttpRequest request) {
+        List<PodTarget> targets = registry.listTargets();
+        StringBuilder sb = new StringBuilder(256 + targets.size() * 128);
+        sb.append("{\"pods\":[");
+        for (int i = 0; i < targets.size(); i++) {
+            PodTarget t = targets.get(i);
+            if (i > 0) sb.append(',');
+            sb.append('{')
+              .append("\"podId\":\"").append(JsonWriter.escape(t.podId())).append("\",")
+              .append("\"namespace\":\"").append(JsonWriter.escape(t.namespace())).append("\",")
+              .append("\"podName\":\"").append(JsonWriter.escape(t.podName())).append("\",")
+              .append("\"deployment\":\"").append(JsonWriter.escape(t.deployment())).append("\",")
+              .append("\"scrapeOk\":").append(t.scrapeOk())
+              .append('}');
+        }
+        sb.append("],\"count\":").append(targets.size()).append('}');
+        sendJson(ctx, request, HttpResponseStatus.OK, sb.toString());
+    }
+
+    /** Proxies {@code GET /api/commands} on the selected pod's argus-server. */
+    private void handleProxyCommands(ChannelHandlerContext ctx, FullHttpRequest request,
+                                     String encodedPodId) {
+        String podId = decodeAndValidatePodId(encodedPodId);
+        if (podId == null) {
+            sendError(ctx, request, 400, "invalid podId");
+            return;
+        }
+        PodTarget target = registry.get(podId);
+        if (target == null) {
+            sendError(ctx, request, 404, "pod not registered");
+            return;
+        }
+        try {
+            PodHttpClient.Response resp = podClient.get(target.scrapeUrl(), "/api/commands");
+            // Pass status + body through verbatim — pod argus-server already
+            // emits JSON, and curating happens via supportsWebConsole on its
+            // side. We don't re-parse so the wire shape stays decoupled.
+            sendJson(ctx, request, safeStatus(resp.status()), resp.body());
+        } catch (PodHttpClient.ProxyException e) {
+            sendError(ctx, request, 502, "pod unreachable: " + e.getMessage());
+        }
+    }
+
+    /**
+     * Clamp upstream status to a valid HTTP code. Netty's {@code valueOf}
+     * is permissive about out-of-range ints and will happily emit invalid
+     * lines like {@code HTTP/1.1 0 Unknown Status} — intermediaries reject
+     * those, hiding the underlying error from the user.
+     */
+    private static HttpResponseStatus safeStatus(int upstream) {
+        if (upstream >= 100 && upstream <= 599) {
+            return HttpResponseStatus.valueOf(upstream);
+        }
+        return HttpResponseStatus.BAD_GATEWAY;
+    }
+
+    /**
+     * Proxies {@code GET /api/exec?cmd=…} on the selected pod's argus-server.
+     * Method is POST on the aggregator side so the browser does not cache the
+     * response; the upstream call is GET because argus-server's exec endpoint
+     * accepts both and GET is the simpler path.
+     */
+    private void handleProxyExec(ChannelHandlerContext ctx, FullHttpRequest request,
+                                 Map<String, List<String>> params) {
+        String podId = firstParam(params, "pod");
+        String cmd = firstParam(params, "cmd");
+        if (podId == null || cmd == null) {
+            sendError(ctx, request, 400, "missing 'pod' or 'cmd' parameter");
+            return;
+        }
+        String validated = decodeAndValidatePodId(podId);
+        if (validated == null) {
+            sendError(ctx, request, 400, "invalid podId");
+            return;
+        }
+        // Defense-in-depth: cmd is appended to a URL, so reject obviously bad
+        // input early. The pod side will additionally reject unknown ids.
+        if (cmd.length() > 64 || !cmd.matches("[a-zA-Z0-9_-]+")) {
+            sendError(ctx, request, 400, "invalid cmd");
+            return;
+        }
+        PodTarget target = registry.get(validated);
+        if (target == null) {
+            sendError(ctx, request, 404, "pod not registered");
+            return;
+        }
+        try {
+            PodHttpClient.Response resp = podClient.get(
+                    target.scrapeUrl(),
+                    "/api/exec?cmd=" + java.net.URLEncoder.encode(
+                            cmd, java.nio.charset.StandardCharsets.UTF_8));
+            sendJson(ctx, request, safeStatus(resp.status()), resp.body());
+        } catch (PodHttpClient.ProxyException e) {
+            sendError(ctx, request, 502, "pod unreachable: " + e.getMessage());
+        }
+    }
+
     // ── Validation helpers ──────────────────────────────────────────────────
 
     /**
@@ -273,6 +404,15 @@ public final class FleetController {
         if (decoded.length() > MAX_PODID_LENGTH) return null;
         if (decoded.indexOf('\0') >= 0) return null;
         if (decoded.contains("..")) return null;
+        // Enforce the documented shape: exactly one '/' separating namespace
+        // and podName, neither side empty. handleRegisterTarget already
+        // checks this on the write side; the proxy/read path was relying on
+        // the registry to miss-then-404 for malformed ids, but the doc
+        // contract promises 400. Keep them aligned.
+        int slash = decoded.indexOf('/');
+        if (slash <= 0 || slash != decoded.lastIndexOf('/') || slash == decoded.length() - 1) {
+            return null;
+        }
         return decoded;
     }
 

--- a/argus-aggregator/src/main/java/io/argus/aggregator/http/PodHttpClient.java
+++ b/argus-aggregator/src/main/java/io/argus/aggregator/http/PodHttpClient.java
@@ -1,0 +1,79 @@
+package io.argus.aggregator.http;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+
+/**
+ * Minimal HTTP client used by the console proxy endpoints to forward
+ * requests to an individual pod's argus-server. Reuses one {@link HttpClient}
+ * instance per aggregator process — argus-server endpoints respond in ms.
+ *
+ * <p>Timeouts:
+ * <ul>
+ *   <li>connect: 2s (pod IP either responds or it doesn't)</li>
+ *   <li>request: 10s (argus diagnostic commands like {@code threaddump} can
+ *       take a few seconds on large heaps; longer than that is unhealthy)</li>
+ * </ul>
+ *
+ * <p>This forwarder is intentionally tiny: it forwards a single HTTP GET and
+ * returns the body as a string with the upstream status code. JSON parsing
+ * stays in the caller so unmodified pod payloads pass through verbatim.
+ */
+public class PodHttpClient {
+
+    private static final Duration CONNECT_TIMEOUT = Duration.ofSeconds(2);
+    private static final Duration REQUEST_TIMEOUT = Duration.ofSeconds(10);
+
+    private final HttpClient client;
+
+    public PodHttpClient() {
+        this(HttpClient.newBuilder().connectTimeout(CONNECT_TIMEOUT).build());
+    }
+
+    PodHttpClient(HttpClient client) {
+        this.client = client;
+    }
+
+    /**
+     * Performs a GET against {@code baseUrl + path} and returns the response.
+     * The caller decides how to translate status codes.
+     *
+     * @param baseUrl pod's {@code http://host:port} base
+     * @param path    request path; must begin with {@code /}
+     * @throws ProxyException on connect/timeout/IO failure — caller maps to 502
+     */
+    public Response get(String baseUrl, String path) throws ProxyException {
+        try {
+            URI uri = URI.create(baseUrl + path);
+            HttpRequest req = HttpRequest.newBuilder()
+                    .uri(uri)
+                    .timeout(REQUEST_TIMEOUT)
+                    .GET()
+                    .build();
+            HttpResponse<String> resp = client.send(req, HttpResponse.BodyHandlers.ofString());
+            return new Response(resp.statusCode(), resp.body());
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new ProxyException("interrupted", e);
+        } catch (IllegalArgumentException e) {
+            // Malformed URI from baseUrl+path — surface as 502 like any
+            // other upstream failure so the proxy contract stays uniform.
+            throw new ProxyException("bad URI: " + e.getMessage(), e);
+        } catch (Exception e) {
+            throw new ProxyException(e.getClass().getSimpleName() + ": " + e.getMessage(), e);
+        }
+    }
+
+    /** Upstream HTTP response captured as raw body + status. */
+    public record Response(int status, String body) {}
+
+    /** Wraps a connect / IO / timeout failure on the pod side. */
+    public static final class ProxyException extends Exception {
+        public ProxyException(String message, Throwable cause) {
+            super(message, cause);
+        }
+    }
+}

--- a/argus-aggregator/src/test/java/io/argus/aggregator/ConsoleProxyControllerTest.java
+++ b/argus-aggregator/src/test/java/io/argus/aggregator/ConsoleProxyControllerTest.java
@@ -1,0 +1,245 @@
+package io.argus.aggregator;
+
+import io.argus.aggregator.http.AggregatorChannelHandler;
+import io.argus.aggregator.http.FleetController;
+import io.argus.aggregator.http.PodHttpClient;
+import io.argus.aggregator.http.PrometheusMetricsExporter;
+import io.argus.aggregator.scrape.ScrapeLoop;
+import io.argus.aggregator.store.FleetRegistry;
+import io.netty.channel.embedded.EmbeddedChannel;
+import io.netty.handler.codec.http.DefaultFullHttpRequest;
+import io.netty.handler.codec.http.FullHttpRequest;
+import io.netty.handler.codec.http.FullHttpResponse;
+import io.netty.handler.codec.http.HttpMethod;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import io.netty.handler.codec.http.HttpVersion;
+import io.netty.util.CharsetUtil;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Exercises the {@code /api/pods}, {@code /api/pods/{id}/commands}, and
+ * {@code POST /api/exec} routes — the proxy that lets the browser console
+ * pick a pod from the fleet and run diagnostic commands against it.
+ *
+ * <p>A stub {@link PodHttpClient} captures forwarded URLs and returns canned
+ * responses, so the test does not bind a socket.
+ */
+class ConsoleProxyControllerTest {
+
+    /** Records every forwarded {@code baseUrl + path} and returns a canned response. */
+    private static final class StubPodClient extends PodHttpClient {
+        final List<String> calls = new ArrayList<>();
+        int status = 200;
+        String body = "{}";
+        boolean throwError = false;
+
+        @Override
+        public Response get(String baseUrl, String path) throws ProxyException {
+            calls.add(baseUrl + path);
+            if (throwError) throw new ProxyException("ConnectException: refused", new RuntimeException());
+            return new Response(status, body);
+        }
+    }
+
+    private static final class Harness {
+        final FleetRegistry registry = new FleetRegistry(60);
+        final StubPodClient stub = new StubPodClient();
+        final EmbeddedChannel channel;
+
+        Harness() {
+            ScrapeLoop loop = new ScrapeLoop(registry, 5, r -> {});
+            PrometheusMetricsExporter prom = new PrometheusMetricsExporter(registry, loop);
+            FleetController controller = new FleetController(registry, prom, stub);
+            channel = new EmbeddedChannel(new AggregatorChannelHandler(controller));
+        }
+
+        void registerPod(String podId, String ns, String podName, String host, int port) {
+            registry.register(podId, ns, podName, "app", host, port);
+        }
+
+        FullHttpResponse send(FullHttpRequest req) {
+            channel.writeInbound(req);
+            FullHttpResponse resp = channel.readOutbound();
+            assertNotNull(resp, "no outbound response produced");
+            return resp;
+        }
+    }
+
+    private static FullHttpRequest get(String uri) {
+        return new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, uri);
+    }
+
+    private static FullHttpRequest post(String uri) {
+        return new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.POST, uri);
+    }
+
+    // ── /api/pods ──────────────────────────────────────────────────────────
+
+    @Test
+    void listPodsReturnsEmptyJsonWhenNothingRegistered() {
+        Harness h = new Harness();
+        FullHttpResponse resp = h.send(get("/api/pods"));
+        assertEquals(HttpResponseStatus.OK, resp.status());
+        String body = resp.content().toString(CharsetUtil.UTF_8);
+        assertTrue(body.contains("\"pods\":[]"), body);
+        assertTrue(body.contains("\"count\":0"), body);
+    }
+
+    @Test
+    void listPodsExposesIdentityFieldsOnly() {
+        Harness h = new Harness();
+        h.registerPod("prod/payment-1", "prod", "payment-1", "10.42.0.5", 9202);
+        FullHttpResponse resp = h.send(get("/api/pods"));
+        assertEquals(HttpResponseStatus.OK, resp.status());
+        String body = resp.content().toString(CharsetUtil.UTF_8);
+        assertTrue(body.contains("\"podId\":\"prod/payment-1\""), body);
+        assertTrue(body.contains("\"namespace\":\"prod\""), body);
+        assertTrue(body.contains("\"podName\":\"payment-1\""), body);
+        assertTrue(body.contains("\"deployment\":\"app\""), body);
+        // Identity-only — must not leak host/port/scrapeUrl/registeredAt.
+        assertFalse(body.contains("10.42.0.5"), "host must not be exposed: " + body);
+        assertFalse(body.contains("\"port\""), "port must not be exposed: " + body);
+        assertFalse(body.contains("scrapeUrl"), "scrapeUrl must not be exposed: " + body);
+    }
+
+    // ── /api/pods/{id}/commands ────────────────────────────────────────────
+
+    @Test
+    void commandsProxiesToPodCommandsEndpoint() {
+        Harness h = new Harness();
+        h.registerPod("ns/p", "ns", "p", "10.0.0.1", 9202);
+        h.stub.body = "{\"commands\":[{\"id\":\"gc\"}]}";
+
+        FullHttpResponse resp = h.send(get("/api/pods/ns%2Fp/commands"));
+        assertEquals(HttpResponseStatus.OK, resp.status());
+        assertEquals("{\"commands\":[{\"id\":\"gc\"}]}",
+                resp.content().toString(CharsetUtil.UTF_8));
+        assertEquals(List.of("http://10.0.0.1:9202/api/commands"), h.stub.calls);
+    }
+
+    @Test
+    void commandsReturns404WhenPodNotRegistered() {
+        Harness h = new Harness();
+        FullHttpResponse resp = h.send(get("/api/pods/ns%2Funknown/commands"));
+        assertEquals(HttpResponseStatus.NOT_FOUND, resp.status());
+        assertTrue(h.stub.calls.isEmpty(), "must not forward to unknown pod");
+    }
+
+    @Test
+    void commandsReturns502WhenPodUnreachable() {
+        Harness h = new Harness();
+        h.registerPod("ns/p", "ns", "p", "10.0.0.1", 9202);
+        h.stub.throwError = true;
+        FullHttpResponse resp = h.send(get("/api/pods/ns%2Fp/commands"));
+        assertEquals(HttpResponseStatus.BAD_GATEWAY, resp.status());
+        assertTrue(resp.content().toString(CharsetUtil.UTF_8).contains("pod unreachable"));
+    }
+
+    @Test
+    void commandsRejectsTraversalPodId() {
+        Harness h = new Harness();
+        FullHttpResponse resp = h.send(get("/api/pods/..%2Fetc%2Fpasswd/commands"));
+        assertEquals(HttpResponseStatus.BAD_REQUEST, resp.status());
+        assertTrue(h.stub.calls.isEmpty(), "must not forward on invalid podId");
+    }
+
+    // ── POST /api/exec ─────────────────────────────────────────────────────
+
+    @Test
+    void execProxiesGetToPodExec() {
+        Harness h = new Harness();
+        h.registerPod("ns/p", "ns", "p", "10.0.0.1", 9202);
+        h.stub.body = "{\"command\":\"gc\",\"output\":\"ok\"}";
+
+        FullHttpResponse resp = h.send(post("/api/exec?pod=ns%2Fp&cmd=gc"));
+        assertEquals(HttpResponseStatus.OK, resp.status());
+        assertEquals("{\"command\":\"gc\",\"output\":\"ok\"}",
+                resp.content().toString(CharsetUtil.UTF_8));
+        assertEquals(List.of("http://10.0.0.1:9202/api/exec?cmd=gc"), h.stub.calls);
+    }
+
+    @Test
+    void execSurfacesWebConsoleRejectedInErrorField() {
+        Harness h = new Harness();
+        h.registerPod("ns/p", "ns", "p", "10.0.0.1", 9202);
+        h.stub.body = "{\"command\":\"gcrun\",\"error\":\"Command 'gcrun' is not available via the web console.\"}";
+        FullHttpResponse resp = h.send(post("/api/exec?pod=ns%2Fp&cmd=gcrun"));
+        assertEquals(HttpResponseStatus.OK, resp.status());
+        String body = resp.content().toString(CharsetUtil.UTF_8);
+        assertTrue(body.contains("\"error\""), body);
+        assertTrue(body.contains("not available via the web console"), body);
+    }
+
+    @Test
+    void execRejectsMissingPodParam() {
+        Harness h = new Harness();
+        FullHttpResponse resp = h.send(post("/api/exec?cmd=gc"));
+        assertEquals(HttpResponseStatus.BAD_REQUEST, resp.status());
+        assertTrue(h.stub.calls.isEmpty());
+    }
+
+    @Test
+    void execRejectsMissingCmdParam() {
+        Harness h = new Harness();
+        FullHttpResponse resp = h.send(post("/api/exec?pod=ns%2Fp"));
+        assertEquals(HttpResponseStatus.BAD_REQUEST, resp.status());
+    }
+
+    @Test
+    void execRejectsCmdWithShellMetacharacters() {
+        Harness h = new Harness();
+        h.registerPod("ns/p", "ns", "p", "10.0.0.1", 9202);
+        FullHttpResponse resp = h.send(post("/api/exec?pod=ns%2Fp&cmd=gc%3Bls"));
+        assertEquals(HttpResponseStatus.BAD_REQUEST, resp.status());
+        assertTrue(h.stub.calls.isEmpty(), "must not forward injected cmd");
+    }
+
+    @Test
+    void execReturns404ForUnknownPod() {
+        Harness h = new Harness();
+        FullHttpResponse resp = h.send(post("/api/exec?pod=ns%2Funknown&cmd=gc"));
+        assertEquals(HttpResponseStatus.NOT_FOUND, resp.status());
+    }
+
+    @Test
+    void execReturns502WhenPodUnreachable() {
+        Harness h = new Harness();
+        h.registerPod("ns/p", "ns", "p", "10.0.0.1", 9202);
+        h.stub.throwError = true;
+        FullHttpResponse resp = h.send(post("/api/exec?pod=ns%2Fp&cmd=gc"));
+        assertEquals(HttpResponseStatus.BAD_GATEWAY, resp.status());
+    }
+
+    @Test
+    void execRejectsPodIdWithoutSeparator() {
+        Harness h = new Harness();
+        FullHttpResponse resp = h.send(post("/api/exec?pod=nosep&cmd=gc"));
+        assertEquals(HttpResponseStatus.BAD_REQUEST, resp.status());
+        assertTrue(h.stub.calls.isEmpty());
+    }
+
+    @Test
+    void execRejectsPodIdWithMultipleSeparators() {
+        Harness h = new Harness();
+        FullHttpResponse resp = h.send(post("/api/exec?pod=a%2Fb%2Fc&cmd=gc"));
+        assertEquals(HttpResponseStatus.BAD_REQUEST, resp.status());
+        assertTrue(h.stub.calls.isEmpty());
+    }
+
+    @Test
+    void execClampsUpstreamStatusToBadGateway() {
+        // Pod returns an out-of-range status code; aggregator clamps to 502
+        // so intermediaries don't reject the response line.
+        Harness h = new Harness();
+        h.registerPod("ns/p", "ns", "p", "10.0.0.1", 9202);
+        h.stub.status = 999;
+        h.stub.body = "{}";
+        FullHttpResponse resp = h.send(post("/api/exec?pod=ns%2Fp&cmd=gc"));
+        assertEquals(HttpResponseStatus.BAD_GATEWAY, resp.status());
+    }
+}

--- a/argus-core/src/main/java/io/argus/core/net/HostAllowlist.java
+++ b/argus-core/src/main/java/io/argus/core/net/HostAllowlist.java
@@ -54,6 +54,20 @@ public final class HostAllowlist {
             lower = lower.substring(1, lower.length() - 1);
         }
 
+        // Reject any authority-grammar reserved character. These never belong
+        // in a host and a concatenation of "http://" + host + ":" + port
+        // would re-route URL parsing if they slipped through. Catches
+        // userinfo injection (e.g. "a@169.254.169.254"), path/query
+        // smuggling, control characters, and embedded whitespace.
+        for (int i = 0; i < lower.length(); i++) {
+            char c = lower.charAt(i);
+            if (c == '@' || c == '/' || c == '\\' || c == '?' || c == '#'
+                    || c == ' ' || c == '%' || c == '\t' || c == '\r' || c == '\n'
+                    || c < 0x20 || c > 0x7e) {
+                return "host contains reserved character";
+            }
+        }
+
         // IPv6 explicit denials
         if (lower.equals("::1") || lower.equals("::") || lower.equals("0:0:0:0:0:0:0:1")) {
             return "loopback IPv6 address forbidden";
@@ -70,35 +84,32 @@ public final class HostAllowlist {
                 return "link-local IPv6 address forbidden";
             }
         }
+        // IPv4-mapped/embedded IPv6 (e.g. "::ffff:169.254.169.254") — pull the
+        // trailing IPv4 portion and run it through the IPv4 deny checks.
+        // Without this, an attacker can register a forbidden v4 address using
+        // its v6 mapping and bypass the v4 octet check below.
+        if (lower.contains(":") && lower.contains(".")) {
+            int lastColon = lower.lastIndexOf(':');
+            String tail = lower.substring(lastColon + 1);
+            String tailReason = ipv4Reason(tail);
+            if (tailReason != null) {
+                return "IPv4-embedded IPv6 " + tailReason;
+            }
+        }
 
-        java.util.regex.Matcher v4 = IPV4.matcher(lower);
-        if (v4.matches()) {
-            int a, b, c, d;
-            try {
-                a = Integer.parseInt(v4.group(1));
-                b = Integer.parseInt(v4.group(2));
-                c = Integer.parseInt(v4.group(3));
-                d = Integer.parseInt(v4.group(4));
-            } catch (NumberFormatException e) {
-                return "invalid IPv4 address";
-            }
-            if (a < 0 || a > 255 || b < 0 || b > 255 || c < 0 || c > 255 || d < 0 || d > 255) {
-                return "invalid IPv4 octet";
-            }
-            // 0.0.0.0
-            if (a == 0 && b == 0 && c == 0 && d == 0) {
-                return "0.0.0.0 forbidden";
-            }
-            // 127.0.0.0/8
-            if (a == 127) {
-                return "loopback IPv4 forbidden";
-            }
-            // 169.254.0.0/16 (link-local + cloud IMDS)
-            if (a == 169 && b == 254) {
-                return "link-local IPv4 (incl. cloud IMDS) forbidden";
-            }
-            // RFC 1918 / standard private — allowed
+        String v4Reason = ipv4Reason(lower);
+        if (v4Reason != null) return v4Reason;
+        if (IPV4.matcher(lower).matches()) {
+            // Standard dotted-quad form, already vetted by ipv4Reason → allowed.
             return null;
+        }
+
+        // Non-dotted-quad numeric forms that InetAddress would still
+        // resolve as IPv4 — decimal integer ("2852039166"), hex
+        // ("0xa9fea9fe"), or short forms ("169.4262", "127.1"). Reject so
+        // attackers cannot smuggle 169.254.169.254 past the v4 octet check.
+        if (looksLikeNumericIpv4(lower)) {
+            return "numeric IPv4 literal forbidden (use dotted-quad form)";
         }
 
         // Hostname shape
@@ -121,6 +132,72 @@ public final class HostAllowlist {
     /** Convenience: throw-style check. */
     public static boolean isAllowed(String host) {
         return rejectionReason(host) == null;
+    }
+
+    /**
+     * Returns a rejection reason if {@code s} parses as a forbidden
+     * dotted-quad IPv4 address. Returns {@code null} either when the input
+     * is not a dotted-quad at all (caller should keep trying) or when the
+     * address is a permitted private range.
+     */
+    private static String ipv4Reason(String s) {
+        java.util.regex.Matcher v4 = IPV4.matcher(s);
+        if (!v4.matches()) return null;
+        int a, b, c, d;
+        try {
+            a = Integer.parseInt(v4.group(1));
+            b = Integer.parseInt(v4.group(2));
+            c = Integer.parseInt(v4.group(3));
+            d = Integer.parseInt(v4.group(4));
+        } catch (NumberFormatException e) {
+            return "invalid IPv4 address";
+        }
+        if (a < 0 || a > 255 || b < 0 || b > 255 || c < 0 || c > 255 || d < 0 || d > 255) {
+            return "invalid IPv4 octet";
+        }
+        if (a == 0 && b == 0 && c == 0 && d == 0) return "0.0.0.0 forbidden";
+        if (a == 127) return "loopback IPv4 forbidden";
+        if (a == 169 && b == 254) return "link-local IPv4 (incl. cloud IMDS) forbidden";
+        return null;
+    }
+
+    /**
+     * Detects numeric IPv4 forms that {@link java.net.InetAddress} would
+     * interpret as an address but our dotted-quad regex would not catch.
+     */
+    private static boolean looksLikeNumericIpv4(String s) {
+        if (s.isEmpty()) return false;
+        // Pure decimal integer: e.g. "2852039166" -> 169.254.169.254
+        if (s.chars().allMatch(Character::isDigit)) return true;
+        // Hex integer: e.g. "0xa9fea9fe"
+        if (s.startsWith("0x") && s.length() > 2
+                && s.substring(2).chars().allMatch(HostAllowlist::isHexChar)) {
+            return true;
+        }
+        // Short forms like "127.1" or "169.4262": fewer than 4 octets, every
+        // part is purely numeric (decimal or 0x-hex).
+        if (s.contains(".")) {
+            String[] parts = s.split("\\.", -1);
+            if (parts.length >= 1 && parts.length <= 3) {
+                for (String p : parts) {
+                    if (p.isEmpty()) return false;
+                    if (p.startsWith("0x")) {
+                        if (p.length() < 3) return false;
+                        if (!p.substring(2).chars().allMatch(HostAllowlist::isHexChar)) {
+                            return false;
+                        }
+                    } else if (!p.chars().allMatch(Character::isDigit)) {
+                        return false;
+                    }
+                }
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static boolean isHexChar(int c) {
+        return (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f');
     }
 
     /**

--- a/argus-core/src/test/java/io/argus/core/net/HostAllowlistTest.java
+++ b/argus-core/src/test/java/io/argus/core/net/HostAllowlistTest.java
@@ -110,4 +110,66 @@ class HostAllowlistTest {
     void uriValidationRejectsImds() {
         assertNotNull(HostAllowlist.rejectionReasonForUri(URI.create("http://169.254.169.254/latest/meta-data/")));
     }
+
+    // ── Authority-grammar reserved characters ─────────────────────────────
+    // These slipped past the original string-shape regex because they are not
+    // legitimate hostname characters but also do not appear in any explicit
+    // deny rule. Concatenating them into "http://" + host + ":" + port lets
+    // an attacker re-route URL parsing (e.g. userinfo injection).
+
+    @Test
+    void rejectsUserinfoInjection() {
+        assertNotNull(HostAllowlist.rejectionReason("attacker@169.254.169.254"));
+    }
+
+    @Test
+    void rejectsPathInjection() {
+        assertNotNull(HostAllowlist.rejectionReason("evil.com/exploit"));
+        assertNotNull(HostAllowlist.rejectionReason("evil.com?q=1"));
+        assertNotNull(HostAllowlist.rejectionReason("evil.com#frag"));
+    }
+
+    @Test
+    void rejectsControlCharsInHost() {
+        assertNotNull(HostAllowlist.rejectionReason("evil\r\nHost: imds"));
+        assertNotNull(HostAllowlist.rejectionReason("evil .com"));
+    }
+
+    @Test
+    void rejectsPercentEncoded() {
+        // %-encoded bytes never belong in a raw host field. Forbid them so an
+        // attacker cannot smuggle reserved chars past the allowlist.
+        assertNotNull(HostAllowlist.rejectionReason("evil%40169.254.169.254"));
+    }
+
+    // ── Numeric IPv4 encodings (decimal/hex/short form) ───────────────────
+    // The original regex only caught the standard dotted-quad form;
+    // java.net.InetAddress.getByName resolves all of these to the same IMDS IP.
+
+    @Test
+    void rejectsDecimalIntegerImds() {
+        // 2852039166 == 169.254.169.254
+        assertNotNull(HostAllowlist.rejectionReason("2852039166"));
+    }
+
+    @Test
+    void rejectsHexIntegerImds() {
+        // 0xa9fea9fe == 169.254.169.254
+        assertNotNull(HostAllowlist.rejectionReason("0xa9fea9fe"));
+    }
+
+    @Test
+    void rejectsShortFormIpv4() {
+        // "127.1" and "169.4262" resolve as IPv4 literals via java.net.InetAddress.
+        assertNotNull(HostAllowlist.rejectionReason("127.1"));
+        assertNotNull(HostAllowlist.rejectionReason("169.4262"));
+    }
+
+    // ── IPv4-mapped / -embedded IPv6 ──────────────────────────────────────
+
+    @Test
+    void rejectsIpv4MappedIpv6Imds() {
+        assertNotNull(HostAllowlist.rejectionReason("::ffff:169.254.169.254"));
+        assertNotNull(HostAllowlist.rejectionReason("[::ffff:127.0.0.1]"));
+    }
 }

--- a/argus-frontend/src/main/resources/public/console.html
+++ b/argus-frontend/src/main/resources/public/console.html
@@ -20,6 +20,11 @@
         <div class="header-actions">
             <a href="/" class="btn">Dashboard</a>
             <a href="/fleet.html" class="btn" title="Fleet Command Center">Fleet</a>
+            <!-- Pod picker: only shown in cluster mode (when /api/pods returns 200). -->
+            <label class="pod-picker" id="pod-picker-wrap" hidden>
+                <span class="pod-picker-label">Pod</span>
+                <select id="pod-picker" aria-label="Select pod"></select>
+            </label>
             <button type="button" class="argus-theme-toggle" aria-label="Toggle theme"></button>
             <a href="https://github.com/rlaope/Argus" target="_blank" class="btn btn-icon" title="GitHub">
                 <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/></svg>
@@ -87,9 +92,112 @@
         const terminalBody = document.getElementById('terminal-body');
         const terminalTitle = document.getElementById('terminal-title');
         let isRunning = false;
+        // Cluster mode is decided by the presence of /api/pods on the
+        // current origin. When true, the page is being served by the
+        // aggregator and commands must be proxied with ?pod=<id>.
+        let clusterMode = false;
+        let selectedPodId = null;
 
-        async function init() {
-            // Fetch process info for terminal title
+        const POD_STORAGE_KEY = 'argus.console.pod';
+
+        async function detectClusterMode() {
+            try {
+                const res = await fetch('/api/pods');
+                if (!res.ok) return null;
+                const data = await res.json();
+                if (!data || !Array.isArray(data.pods)) return null;
+                clusterMode = true;
+                return data.pods;
+            } catch (e) {
+                return null;
+            }
+        }
+
+        function renderPodPicker(pods) {
+            const wrap = document.getElementById('pod-picker-wrap');
+            const select = document.getElementById('pod-picker');
+            wrap.hidden = false;
+            select.replaceChildren();
+
+            if (!pods.length) {
+                const opt = document.createElement('option');
+                opt.value = '';
+                opt.textContent = 'No pods registered';
+                opt.disabled = true;
+                opt.selected = true;
+                select.appendChild(opt);
+                return;
+            }
+
+            // Group by deployment (fallback: namespace) so large fleets stay readable.
+            const byGroup = {};
+            pods.forEach(p => {
+                const key = p.deployment || p.namespace || 'other';
+                (byGroup[key] = byGroup[key] || []).push(p);
+            });
+
+            const stored = readStoredPod();
+            const knownIds = new Set(pods.map(p => p.podId));
+            const initial = (stored && knownIds.has(stored)) ? stored : pods[0].podId;
+
+            Object.keys(byGroup).sort().forEach(group => {
+                const og = document.createElement('optgroup');
+                og.label = group;
+                byGroup[group].sort((a, b) => a.podName.localeCompare(b.podName))
+                    .forEach(p => {
+                        const opt = document.createElement('option');
+                        opt.value = p.podId;
+                        opt.textContent = p.podName + (p.scrapeOk ? '' : ' ·offline');
+                        if (p.podId === initial) opt.selected = true;
+                        og.appendChild(opt);
+                    });
+                select.appendChild(og);
+            });
+
+            selectedPodId = initial;
+            writeStoredPod(initial);
+
+            select.addEventListener('change', async () => {
+                selectedPodId = select.value;
+                writeStoredPod(selectedPodId);
+                await loadCommands();
+                updateTerminalTitle();
+            });
+        }
+
+        function readStoredPod() {
+            try { return window.localStorage.getItem(POD_STORAGE_KEY); }
+            catch (e) { return null; }
+        }
+        function writeStoredPod(podId) {
+            try { window.localStorage.setItem(POD_STORAGE_KEY, podId); }
+            catch (e) { /* localStorage disabled — selection just doesn't persist */ }
+        }
+
+        function commandsEndpoint() {
+            if (clusterMode && selectedPodId) {
+                return '/api/pods/' + encodeURIComponent(selectedPodId) + '/commands';
+            }
+            return '/api/commands';
+        }
+
+        function execEndpoint(cmd) {
+            const c = encodeURIComponent(cmd);
+            if (clusterMode && selectedPodId) {
+                return '/api/exec?pod=' + encodeURIComponent(selectedPodId) + '&cmd=' + c;
+            }
+            return '/api/exec?cmd=' + c;
+        }
+
+        function execMethod() {
+            return clusterMode ? 'POST' : 'GET';
+        }
+
+        async function updateTerminalTitle() {
+            if (clusterMode && selectedPodId) {
+                terminalTitle.textContent = 'argus — ' + selectedPodId;
+                return;
+            }
             try {
                 const pres = await fetch('/api/process');
                 const pdata = await pres.json();
@@ -97,11 +205,24 @@
             } catch (e) {
                 terminalTitle.textContent = 'argus@jvm';
             }
+        }
 
-            // Fetch commands and render grouped buttons
+        async function init() {
+            const pods = await detectClusterMode();
+            if (clusterMode) renderPodPicker(pods);
+            await updateTerminalTitle();
+            await loadCommands();
+        }
+
+        async function loadCommands() {
             try {
-                const res = await fetch('/api/commands');
+                const res = await fetch(commandsEndpoint());
                 const data = await res.json();
+
+                if (!data || !Array.isArray(data.commands)) {
+                    appendOutput('Pod returned no commands list.', 'error');
+                    return;
+                }
 
                 const grouped = {};
                 data.commands.forEach(c => {
@@ -158,15 +279,20 @@
             }
         }
 
+        // Search wiring runs once. Each loadCommands() call rebuilds the
+        // button DOM, so `apply` reads the button list fresh each time
+        // rather than capturing it in a closure. This preserves the user's
+        // typed query and focus across pod switches (rebuilding the input
+        // would discard both).
+        let searchWired = false;
         function setupCommandSearch() {
             const input = document.getElementById('commands-search');
             const countEl = document.getElementById('commands-search-count');
             if (!input || !countEl) return;
-            const allBtns = Array.from(document.querySelectorAll('.cmd-btn'));
-            const totalCount = allBtns.length;
-            countEl.textContent = totalCount + ' commands';
 
             function apply() {
+                const allBtns = Array.from(document.querySelectorAll('.cmd-btn'));
+                const totalCount = allBtns.length;
                 const q = input.value.trim().toLowerCase();
                 let visible = 0;
                 allBtns.forEach(btn => {
@@ -174,7 +300,6 @@
                     btn.style.display = match ? '' : 'none';
                     if (match) visible++;
                 });
-                // Hide groups whose buttons are all filtered out
                 document.querySelectorAll('.commands-group').forEach(g => {
                     const any = Array.from(g.querySelectorAll('.cmd-btn'))
                         .some(b => b.style.display !== 'none');
@@ -185,11 +310,13 @@
                     : totalCount + ' commands';
             }
 
-            input.addEventListener('input', apply);
-            // Esc clears
-            input.addEventListener('keydown', (e) => {
-                if (e.key === 'Escape') { input.value = ''; apply(); }
-            });
+            if (!searchWired) {
+                input.addEventListener('input', apply);
+                input.addEventListener('keydown', (e) => {
+                    if (e.key === 'Escape') { input.value = ''; apply(); }
+                });
+                searchWired = true;
+            }
             apply();
         }
 
@@ -232,14 +359,20 @@
             scrollToBottom();
 
             try {
-                const res = await fetch('/api/exec?cmd=' + encodeURIComponent(cmd));
+                const res = await fetch(execEndpoint(cmd), { method: execMethod() });
                 const data = await res.json();
                 loading.remove();
 
                 if (data.error) {
-                    appendOutput(data.error, 'error');
+                    // Two shapes possible:
+                    //  - argus-server: { error: "string" }
+                    //  - aggregator:   { error: { code, message } }
+                    const msg = (typeof data.error === 'string')
+                        ? data.error
+                        : (data.error.message || JSON.stringify(data.error));
+                    appendOutput(msg, 'error');
                 } else {
-                    appendOutput(data.output, 'success');
+                    appendOutput(data.output != null ? data.output : '(no output)', 'success');
                 }
             } catch (e) {
                 loading.remove();

--- a/argus-frontend/src/main/resources/public/css/console.css
+++ b/argus-frontend/src/main/resources/public/css/console.css
@@ -94,6 +94,41 @@ header {
     padding: 0.375rem 0.5rem;
 }
 
+/* Pod picker — only visible in cluster mode (aggregator-served console). */
+.pod-picker {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.375rem;
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    padding: 0.25rem 0.5rem;
+    font-size: 0.75rem;
+    color: var(--ink-2);
+}
+
+.pod-picker[hidden] { display: none; }
+
+.pod-picker-label {
+    color: var(--ink-3);
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    font-size: 0.6875rem;
+}
+
+#pod-picker {
+    background: transparent;
+    border: none;
+    color: var(--ink);
+    font: inherit;
+    cursor: pointer;
+    max-width: 220px;
+}
+
+#pod-picker:focus {
+    outline: 1px solid var(--ink-3);
+    outline-offset: 2px;
+}
+
 /* Main */
 main {
     flex: 1;

--- a/argus-server/src/main/java/io/argus/server/command/impl/DiagnosticUtil.java
+++ b/argus-server/src/main/java/io/argus/server/command/impl/DiagnosticUtil.java
@@ -9,7 +9,21 @@ import java.util.Set;
 public final class DiagnosticUtil {
 
     private static final Set<String> SENSITIVE_KEYS = Set.of(
-            "PASSWORD", "SECRET", "KEY", "TOKEN", "CREDENTIAL", "AUTH", "PRIVATE");
+            // Common credential markers
+            "PASSWORD", "PASSWD", "PASSPHRASE",
+            "SECRET", "KEY", "TOKEN", "CREDENTIAL", "AUTH", "PRIVATE",
+            "BEARER", "SESSION", "DSN",
+            "PEM", "CERT", "SIGNATURE",
+            // Connection-string envs that commonly carry user:password inline
+            "DATABASE_URL", "JDBC_URL", "MONGODB_URI", "REDIS_URL",
+            "AMQP_URL", "RABBITMQ_URL", "POSTGRES_URL", "MYSQL_URL");
+
+    // Connection strings like "scheme://user:password@host[:port]/path" leak
+    // credentials in the value even when the key name is generic (e.g.
+    // "url", "endpoint"). Mask any value whose shape matches.
+    private static final java.util.regex.Pattern CONN_STRING_WITH_USERINFO =
+            java.util.regex.Pattern.compile(
+                    "^[a-zA-Z][a-zA-Z0-9+.-]*://[^/@\\s]*:[^/@\\s]+@.*");
 
     private DiagnosticUtil() {}
 
@@ -22,15 +36,26 @@ public final class DiagnosticUtil {
     }
 
     public static String maskIfSensitive(String key, String value) {
-        String upper = key.toUpperCase();
+        String upper = key == null ? "" : key.toUpperCase();
         for (String sensitive : SENSITIVE_KEYS) {
             if (upper.contains(sensitive)) {
-                return value != null && value.length() > 4
-                        ? value.substring(0, 2) + "****" + value.substring(value.length() - 2)
-                        : "****";
+                return maskValue(value);
             }
         }
+        // Value-shape masking: catch credentials in values whose key name
+        // alone would not raise a flag. Important now that diagnostic
+        // commands like sysprops/env are reachable cross-pod via the
+        // aggregator proxy — the blast radius for a leaked secret is wider.
+        if (value != null && CONN_STRING_WITH_USERINFO.matcher(value).matches()) {
+            return maskValue(value);
+        }
         return value;
+    }
+
+    private static String maskValue(String value) {
+        if (value == null) return "****";
+        if (value.length() <= 4) return "****";
+        return value.substring(0, 2) + "****" + value.substring(value.length() - 2);
     }
 
     public static String executeJcmd(String command, String arg) {

--- a/argus-server/src/test/java/io/argus/server/command/impl/DiagnosticUtilTest.java
+++ b/argus-server/src/test/java/io/argus/server/command/impl/DiagnosticUtilTest.java
@@ -1,0 +1,100 @@
+package io.argus.server.command.impl;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Pins the secret-masking behavior of {@link DiagnosticUtil#maskIfSensitive(String, String)}.
+ *
+ * <p>Important now that {@code sysprops} and {@code env} are reachable
+ * cross-pod via the aggregator console proxy (see {@code argus-aggregator}).
+ * A leaked credential through one pod becomes a fleet-wide problem, so the
+ * mask list must cover both key-name patterns and value-shape patterns
+ * (e.g. connection strings with embedded {@code user:password@}).
+ */
+class DiagnosticUtilTest {
+
+    private static String mask(String key, String value) {
+        return DiagnosticUtil.maskIfSensitive(key, value);
+    }
+
+    private static void assertMasked(String key, String value) {
+        String out = mask(key, value);
+        assertNotEquals(value, out, "expected mask for " + key + "=" + value + " but got " + out);
+        assertTrue(out.contains("****"), "expected mask marker in " + out);
+    }
+
+    @Test
+    void masksKeysWithKnownCredentialMarkers() {
+        assertMasked("MY_PASSWORD", "hunter2");
+        assertMasked("APP_SECRET", "hunter2");
+        assertMasked("API_KEY", "hunter2");
+        assertMasked("ACCESS_TOKEN", "hunter2");
+        assertMasked("AUTH_BEARER", "hunter2");
+        assertMasked("DB_CREDENTIAL", "hunter2");
+        assertMasked("PRIVATE_KEY", "hunter2");
+    }
+
+    @Test
+    void masksConnectionStringEnvs() {
+        assertMasked("DATABASE_URL", "postgresql://user:pass@db:5432/app");
+        assertMasked("JDBC_URL", "jdbc:postgresql://user:pass@db:5432/app");
+        assertMasked("MONGODB_URI", "mongodb://user:pass@db:27017/app");
+        assertMasked("REDIS_URL", "redis://default:pass@redis:6379");
+    }
+
+    @Test
+    void masksDsnAndSessionKeys() {
+        assertMasked("SENTRY_DSN", "https://abc@sentry.example/123");
+        assertMasked("APP_SESSION", "deadbeef");
+        assertMasked("PASSPHRASE", "deadbeef");
+    }
+
+    @Test
+    void masksCertAndPemKeys() {
+        assertMasked("TLS_CERT", "-----BEGIN CERT-----...");
+        assertMasked("MY_PEM", "-----BEGIN RSA PRIVATE KEY-----");
+    }
+
+    @Test
+    void masksConnectionStringValueEvenWhenKeyLooksGeneric() {
+        // The key alone ("url"/"endpoint"/"upstream") would not raise a flag;
+        // the value shape (scheme://user:password@…) does.
+        assertMasked("url", "postgresql://admin:secret@db:5432/app");
+        assertMasked("endpoint", "amqp://guest:guest@rabbit:5672/");
+        assertMasked("upstream", "mongodb://root:topsecret@mongo:27017");
+    }
+
+    @Test
+    void doesNotMaskHarmlessValues() {
+        // Generic configuration must NOT be masked; mask must be precise.
+        assertEquals("https://example.com/health",
+                mask("HEALTH_URL", "https://example.com/health"));
+        assertEquals("21",
+                mask("JAVA_VERSION", "21"));
+        assertEquals("UTF-8",
+                mask("file.encoding", "UTF-8"));
+        // URL without userinfo must not be masked.
+        assertEquals("postgresql://db:5432/app",
+                mask("url", "postgresql://db:5432/app"));
+    }
+
+    @Test
+    void handlesNullsGracefully() {
+        // Null key falls through as if it had no markers.
+        assertEquals("value", mask(null, "value"));
+        // Null value with a sensitive key returns the masked placeholder.
+        String masked = mask("PASSWORD", null);
+        assertTrue(masked.contains("****"), masked);
+    }
+
+    @Test
+    void shortValuesAreFullyMasked() {
+        // Values too short to slice are replaced wholesale.
+        assertEquals("****", mask("PASSWORD", "abc"));
+        assertEquals("****", mask("PASSWORD", ""));
+    }
+}

--- a/docs/aggregator-api.md
+++ b/docs/aggregator-api.md
@@ -419,6 +419,78 @@ Exposes the following metric families:
 
 ---
 
+## Console Proxy Endpoints
+
+When the browser console is served by the aggregator (cluster mode), it picks a
+pod from the registered fleet and proxies command execution through the
+aggregator. The aggregator forwards to each pod's argus-server using the
+`host:port` the operator already registered (which `HostAllowlist` validated
+at registration). No new trust surface — these endpoints inherit the same
+in-cluster-only access posture as the rest of the API.
+
+### `GET /api/pods`
+
+Lightweight pod list for the console picker. Identity fields only — no
+metrics, no host/port (those stay server-side).
+
+#### Response `200 OK`
+
+```json
+{
+  "pods": [
+    {
+      "podId":      "prod/payment-1",
+      "namespace":  "prod",
+      "podName":    "payment-1",
+      "deployment": "payment",
+      "scrapeOk":   true
+    }
+  ],
+  "count": 1
+}
+```
+
+Sorted by `podId`. Empty list (`"pods":[]`, `"count":0`) when no targets
+registered — never 404.
+
+### `GET /api/pods/{podId}/commands`
+
+Proxies `GET /api/commands` on the selected pod's argus-server. Response body
+passes through verbatim (the pod side already curates via
+`supportsWebConsole()`).
+
+#### Error Codes
+
+| Code | Condition |
+|------|-----------|
+| 400  | Malformed `podId` (null byte, path traversal, length > 253) |
+| 404  | Pod not in `FleetRegistry` |
+| 502  | Pod unreachable (connect refused, timeout) |
+
+### `POST /api/exec?pod={podId}&cmd={cmd}`
+
+Proxies `GET /api/exec?cmd={cmd}` on the selected pod's argus-server. POST on
+this side so the browser doesn't cache; GET on the upstream side because the
+pod's exec endpoint accepts both and GET is simpler. Body is empty (params
+are in the querystring).
+
+Response passes through verbatim. Pod-side `WebConsoleRejectedException` surfaces
+as `{"error": "Command '...' is not available via the web console."}` — the
+console renders that in error styling, not success.
+
+#### Error Codes (aggregator side)
+
+| Code | Condition |
+|------|-----------|
+| 400  | Missing `pod` or `cmd`; malformed `podId`; `cmd` longer than 64 chars or outside `[A-Za-z0-9_-]+` |
+| 404  | Pod not in `FleetRegistry` |
+| 502  | Pod unreachable (connect refused, timeout) |
+
+The `cmd` regex is defense-in-depth only — the pod side independently rejects
+unknown command ids.
+
+---
+
 ## Error Response Shape
 
 All `4xx` and `5xx` responses use this envelope:


### PR DESCRIPTION
## Summary

- When the console is served by the aggregator (cluster mode), the operator picks any pod from the fleet from a dropdown in the header and runs diagnostic commands against it — no `kubectl exec` needed.
- Three new aggregator endpoints proxy the existing argus-server `/api/commands` and `/api/exec` per-pod, reusing the trust chain `HostAllowlist` already established at pod registration.
- Standalone mode is unchanged — the picker only appears when `/api/pods` exists on the origin.

## What changed

| Where | Change |
|---|---|
| `argus-aggregator/.../FleetController.java` | +3 routes (`GET /api/pods`, `GET /api/pods/{id}/commands`, `POST /api/exec`), tightened `podId` shape check (`<ns>/<podName>`), upstream-status clamp helper |
| `argus-aggregator/.../PodHttpClient.java` (new) | Minimal HTTP forwarder, 2s connect / 10s request timeout, surfaces failures as `ProxyException` |
| `argus-frontend/.../console.html` | Mode detection on init, header pod picker grouped by deployment, localStorage-persisted selection, error-shape normalization (string vs `{code,message}` envelope) |
| `argus-frontend/.../css/console.css` | `.pod-picker` styles using existing theme tokens |
| `docs/aggregator-api.md` | New "Console Proxy Endpoints" section with contract + failure modes |
| `argus-aggregator/.../ConsoleProxyControllerTest.java` (new) | 16 tests |

## Security posture

- The aggregator only forwards to a `host:port` that the operator already registered, which `HostAllowlist` validates against RFC 1918 / SSRF ranges.
- `cmd` is regex-restricted to `[A-Za-z0-9_-]+` (≤ 64 chars) on the aggregator side as defense-in-depth — the pod side independently rejects unknown ids.
- `podId` path segment validates: URL-decoded, ≤ 253 chars, no NUL byte, no `..`, exactly one `/`, neither side empty.
- Upstream status codes outside `100-599` clamp to `502` so a misbehaving pod cannot make the aggregator emit an invalid HTTP response line.

## Test plan

- [x] `:argus-aggregator:test` (16/16 new tests + all existing pass)
- [x] Console HTML embedded JS parses cleanly
- [ ] Manual: cluster mode browser smoke test (verifier follow-up)

## Follow-ups (separate PRs)

- Multi-cluster cluster switcher above the pod picker
- WebSocket streaming for long-running commands

🤖 Generated with [Claude Code](https://claude.com/claude-code)