### PR TITLE
docs: sync site command-count badge to 68

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -67,7 +67,7 @@
                         <span class="badge green">Java 11+ CLI</span>
                         <span class="badge green">Java 17+ Dashboard</span>
                         <span class="badge green">Java 21+ Full Features</span>
-                        <span class="badge">67 Commands</span>
+                        <span class="badge">68 Commands</span>
                         <span class="badge">Zero Dependencies</span>
                         <span class="badge green">v1.4.0</span>
                     </div>


### PR DESCRIPTION
## Summary

Drift fix only — site/index.html line 70 badge still read "67 Commands" while every other docs surface (README, cli-commands.md, getting-started.md, docs/README.md, and site/index.html line 101 prose) already says "68 commands".

## TRUTH

| | |
|---|---|
| `argusVersion` | `1.4.0` |
| Source commands | 68 (`*Command.java` files minus the `Command` interface) |
| Docs A–Z index | 68 entries in `docs/cli-commands.md` (perfect parity with source) |
| i18n keys | 598 × 4 locales (en/ko/ja/zh in parity, zero diff) |

## Drift fixed

- `site/index.html:70` — `67 Commands` → `68 Commands`

## Verification

```
grep -rhEo '[0-9]{2,3} (diagnostic )?[cC]ommands?' README.md docs/ site/index.html \
  | sed -E 's/ diagnostic / /' | awk '{print $1}' | sort -u
68
```

`./gradlew :argus-cli:test --quiet` → exit 0

## Test plan

- [x] Single unique command-count across docs+site after fix
- [x] CLI tests green