### PR TITLE
docs: sync remaining site/*.html pages to 68 + harden skill scope

### DIFF
--- a/.claude/skills/docs-sync/SKILL.md
+++ b/.claude/skills/docs-sync/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: docs-sync
-description: Audit and update Argus user-facing docs (README, docs/**/*.md, site/index.html) against the code truth. Detects version drift, command-count drift, i18n parity violations, and stale CLI examples. Use before a release, or any time the user asks to "sync docs", "update docs", "fix docs drift", "verify docs".
+description: Audit and update Argus user-facing docs (README, docs/**/*.md, site/*.html) against the code truth. Detects version drift, command-count drift, i18n parity violations, and stale CLI examples. Use before a release, or any time the user asks to "sync docs", "update docs", "fix docs drift", "verify docs".
 argument-hint: "[--check] [--fix]"
 ---
 
@@ -39,7 +39,7 @@ Keep Argus public-facing documentation aligned with the actual codebase.
 | `docs/usage.md` | Spring Boot starter version |
 | `docs/kubernetes.md` | Container image tag |
 | `docs/troubleshooting.md` | Error messages match `messages_en.properties` |
-| `site/index.html` | Version badge, command-count badge + prose + heading, code samples (especially the spring-boot-starter snippet around line 970) |
+| `site/*.html` | Version badge, command-count badge + prose + headings on every page (index.html, commands.html, comparison.html, dashboard.html, scenarios.html, integrations.html, reference.html), code samples |
 
 ## Procedure
 
@@ -77,19 +77,19 @@ For each target file, search for any line that mentions a version or command cou
 Useful greps:
 ```bash
 # Version drift
-grep -rEn 'v?[0-9]+\.[0-9]+\.[0-9]+' README.md docs/ site/index.html \
+grep -rEn 'v?[0-9]+\.[0-9]+\.[0-9]+' README.md docs/ site/*.html \
   | grep -v -E '(java|jdk|jvm|netty|micrometer|junit|spring|node|graalvm|grafana|prometheus|3\.[0-9]|11\+|17\+|21\+)' \
   | head -50
 
 # Command-count drift (per-file listing)
-grep -rnE '[0-9]{2}\+? ?(commands|Commands)' README.md docs/ site/index.html
+grep -rnE '[0-9]{2}\+? ?(commands|Commands)' README.md docs/ site/*.html
 
 # Command-count internal consistency (catches the trap where the SAME README
 # says "67 commands" on line 14 and "66 diagnostic commands" on line 64 — listing
 # alone doesn't fail; collapse all occurrences plus the runtime help banner to a
 # unique-value set and fail if there's more than one).
 COUNT_OCCURRENCES=$(grep -rhEo '[0-9]{2,3} (diagnostic )?commands?' \
-    README.md docs/ site/index.html 2>/dev/null \
+    README.md docs/ site/*.html 2>/dev/null \
   | sed -E 's/ diagnostic / /' \
   | awk '{print $1}' \
   | sort -u)
@@ -121,7 +121,7 @@ Compare the A–Z index in `docs/cli-commands.md` against the actual `*Command.j
 
 ### 4. CLI example drift (best effort)
 
-For any code block in `README.md` or `site/index.html` of the form `argus <subcommand> ...`, verify `<subcommand>` exists in the command set computed in step 1. Flag unknowns.
+For any code block in `README.md` or `site/*.html` of the form `argus <subcommand> ...`, verify `<subcommand>` exists in the command set computed in step 1. Flag unknowns.
 
 ### 5. Fix policy
 

--- a/site/commands.html
+++ b/site/commands.html
@@ -91,7 +91,7 @@ argus histo 12345</code></pre>
                 <p class="video-caption">Argus CLI in action — diagnosing a running JVM process</p>
 
                 <span class="section-anchor" id="command-reference"></span>
-                <h3>All 67 Commands</h3>
+                <h3>All 68 Commands</h3>
 
                 <p>Every command follows the same pattern: <code>argus &lt;command&gt; &lt;pid&gt;</code>. All commands support <code>--format=json</code> for scripting and <code>--source=auto|agent|jdk</code> to control the data source.</p>
 

--- a/site/reference.html
+++ b/site/reference.html
@@ -65,7 +65,7 @@
                             <tr><th>Feature</th><th>Java 11+</th><th>Java 17+</th><th>Java 21+</th></tr>
                         </thead>
                         <tbody>
-                            <tr><td>CLI (67 commands)</td><td>Yes</td><td>Yes</td><td>Yes</td></tr>
+                            <tr><td>CLI (68 commands)</td><td>Yes</td><td>Yes</td><td>Yes</td></tr>
                             <tr><td>Dashboard &amp; Web UI</td><td>—</td><td>Yes (MXBean)</td><td>Yes (JFR)</td></tr>
                             <tr><td>GC / CPU / Memory</td><td>CLI only</td><td>Yes</td><td>Yes</td></tr>
                             <tr><td>Allocation Tracking</td><td>—</td><td>—</td><td>Yes</td></tr>
@@ -100,7 +100,7 @@
                             <tr><td><code>argus-agent</code></td><td>Java agent entry point, JFR streaming engine, MXBean polling engine</td></tr>
                             <tr><td><code>argus-server</code></td><td>Netty HTTP/WebSocket server, 10 analyzers, metrics export</td></tr>
                             <tr><td><code>argus-frontend</code></td><td>Dashboard web UI (vanilla JS, Chart.js, D3 flame graph)</td></tr>
-                            <tr><td><code>argus-cli</code></td><td>67 diagnostic commands using jcmd/jstat</td></tr>
+                            <tr><td><code>argus-cli</code></td><td>68 diagnostic commands using jcmd/jstat</td></tr>
                             <tr><td><code>argus-micrometer</code></td><td>Framework-agnostic Micrometer MeterBinder</td></tr>
                             <tr><td><code>argus-spring-boot-starter</code></td><td>Spring Boot auto-configuration</td></tr>
                         </tbody>


### PR DESCRIPTION
## Summary

PR #235 only fixed `site/index.html`. Three other site pages still said "67". Reason: the docs-sync skill's Targets table hard-coded `site/index.html` as the only site target, so every drift-scan grep was scoped there.

This PR fixes the remaining three occurrences **and** widens the skill scope so the same gap cannot recur.

## Drift fixed

| File | Line | Was | Now |
|---|---|---|---|
| `site/commands.html` | 94 | All 67 Commands | All 68 Commands |
| `site/reference.html` | 68 | CLI (67 commands) | CLI (68 commands) |
| `site/reference.html` | 103 | 67 diagnostic commands | 68 diagnostic commands |

## Skill hardened

`.claude/skills/docs-sync/SKILL.md` — switched every consumer-side reference from `site/index.html` to `site/*.html`:

- L3 (description)
- L42 (Targets table row)
- L80, L85, L92, L124 (drift-scan grep snippets)

One historical example line in the report-format section is left as-is.

## Verification

```
grep -rhEo '[0-9]{2,3} (diagnostic )?[cC]ommands?' README.md docs/ site/ \
  | sed -E 's/ diagnostic / /' | awk '{print $1}' | sort -u
68
```

## Companion release-sync result

Ran release-sync in the same session — all 11 channels OK, install/release deep-verified (Formula sha256 matches the actual v1.4.0 release asset). No release-side drift to fix.