### PR TITLE
feat(g1): G1 parity-with-ZGC graduate (argus g1 + diagnostics/g1 + 3 doctor rules + score branch)

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
   <a href="https://github.com/rlaope/Argus/stargazers"><img src="https://img.shields.io/github/stars/rlaope/Argus" alt="GitHub stars"></a>
 </p>
 
-> **One CLI for all JVM diagnostics.** 68 commands, zero agent required, works on Java 11+.
+> **One CLI for all JVM diagnostics.** 69 commands, zero agent required, works on Java 11+.
 > The free alternative to GCEasy + jcmd + VisualVM combined — GC analysis, health diagnosis, flame graphs, async-profiler integration, ZGC live monitoring, and CI/CD profile gates.
 
 ---
@@ -61,7 +61,7 @@ Full reference: [docs/harness.md](docs/harness.md)
 
 ## Why Argus?
 
-- **68 diagnostic commands** — heap, GC, threads, profiling, flame graphs, NMT, class loaders, and more. No agent required.
+- **69 diagnostic commands** — heap, GC, threads, profiling, flame graphs, NMT, class loaders, and more. No agent required.
 - **Incident forensic bundle** — `argus snapshot <pid>` collects threads, histogram, doctor, JFR, and (optionally) a heap dump into one tar.gz for offline analysis.
 - **Connection-pool diagnostics** — `argus pool jdbc <pid>` reports HikariCP / Tomcat JDBC state; `argus pool advise` recommends thread-pool sizing from a ThreadMXBean sample.
 - **Live JVM attach** — attaches externally via `jcmd`/JMX; target JVM needs no restart and no `-javaagent` flag.

--- a/argus-cli/src/main/java/io/argus/cli/command/G1Command.java
+++ b/argus-cli/src/main/java/io/argus/cli/command/G1Command.java
@@ -28,6 +28,7 @@ import java.time.Instant;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
+import java.util.Locale;
 import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -288,7 +289,7 @@ public final class G1Command implements Command {
                 + current.concurrentCycles + "c";
 
         String pauseColor = reset;
-        String pauseStr = String.format("%.1fms", current.maxPauseMs);
+        String pauseStr = String.format(Locale.ROOT, "%.1fms", current.maxPauseMs);
         if (previous != null && previous.maxPauseMs > 0
                 && current.maxPauseMs / previous.maxPauseMs > 1.5) {
             pauseColor = yellow;
@@ -328,7 +329,7 @@ public final class G1Command implements Command {
         Instant now = Instant.now();
         long elapsedMinutes = Duration.between(baseline.capturedAt, now).toMinutes();
         String elapsedLabel = elapsedMinutes >= 60
-                ? String.format("%.1f hr", elapsedMinutes / 60.0)
+                ? String.format(Locale.ROOT, "%.1f hr", elapsedMinutes / 60.0)
                 : elapsedMinutes + " min";
         System.out.println(bold + messages.get("cli.g1.diff.header",
                 ISO_FMT.format(baseline.capturedAt),
@@ -537,9 +538,9 @@ public final class G1Command implements Command {
         System.out.println("  " + bold + messages.get("cli.g1.cycles.label") + reset
                 + "       " + d.youngCycles + " young, " + d.mixedCycles + " mixed, "
                 + d.concurrentCycles + " concurrent, " + d.fullGcCycles + " full"
-                + " (avg young " + String.format("%.2fms", d.avgYoungPauseMs)
-                + (d.mixedCycles > 0 ? ", avg mixed " + String.format("%.2fms", d.avgMixedPauseMs) : "")
-                + ", max " + String.format("%.2fms", d.maxPauseMs) + ")");
+                + " (avg young " + String.format(Locale.ROOT, "%.2fms", d.avgYoungPauseMs)
+                + (d.mixedCycles > 0 ? ", avg mixed " + String.format(Locale.ROOT, "%.2fms", d.avgMixedPauseMs) : "")
+                + ", max " + String.format(Locale.ROOT, "%.2fms", d.maxPauseMs) + ")");
 
         // Evacuation
         System.out.println("  " + bold + messages.get("cli.g1.evac.label") + reset
@@ -553,8 +554,8 @@ public final class G1Command implements Command {
         // MMU
         if (d.avgMmuPercent > 0) {
             System.out.println("  " + bold + messages.get("cli.g1.mmu.label") + reset
-                    + "         min " + String.format("%.1f%%", d.minMmuPercent)
-                    + ", avg " + String.format("%.1f%%", d.avgMmuPercent));
+                    + "         min " + String.format(Locale.ROOT, "%.1f%%", d.minMmuPercent)
+                    + ", avg " + String.format(Locale.ROOT, "%.1f%%", d.avgMmuPercent));
         }
 
         // IHOP
@@ -562,8 +563,8 @@ public final class G1Command implements Command {
             String ihopMark = d.ihopMistimed ? yel + "⚠" + reset + " " : "";
             System.out.println("  " + bold + messages.get("cli.g1.ihop.label") + reset
                     + "        " + ihopMark
-                    + "predicted " + String.format("%.1f%%", d.predictedIhopPercent)
-                    + " / actual " + String.format("%.1f%%", d.actualIhopPercent));
+                    + "predicted " + String.format(Locale.ROOT, "%.1f%%", d.predictedIhopPercent)
+                    + " / actual " + String.format(Locale.ROOT, "%.1f%%", d.actualIhopPercent));
         }
 
         // Humongous
@@ -575,7 +576,7 @@ public final class G1Command implements Command {
             if (!d.humongousHotspots.isEmpty()) {
                 System.out.println("               "
                         + messages.get("cli.g1.humongous.alloc.header",
-                                String.format("%,d", d.totalHumongousAllocEvents)));
+                                String.format(Locale.ROOT, "%,d", d.totalHumongousAllocEvents)));
                 for (int i = 0; i < d.humongousHotspots.size(); i++) {
                     G1Diagnosis.HumongousHotspot h = d.humongousHotspots.get(i);
                     System.out.printf("               %2d. %-60s %s%n",

--- a/argus-cli/src/main/java/io/argus/cli/command/G1Command.java
+++ b/argus-cli/src/main/java/io/argus/cli/command/G1Command.java
@@ -1,0 +1,684 @@
+package io.argus.cli.command;
+
+import io.argus.cli.config.CliConfig;
+import io.argus.cli.config.Messages;
+import io.argus.cli.jfr.JfrCaptureFailed;
+import io.argus.cli.jfr.JfrCaptureSession;
+import io.argus.cli.jmx.JmxAttachment;
+import io.argus.cli.jmx.JmxAttachmentException;
+import io.argus.cli.provider.ProviderRegistry;
+import io.argus.diagnostics.jcmd.JcmdExecutor;
+import io.argus.cli.render.AnsiStyle;
+import io.argus.cli.render.RichRenderer;
+import io.argus.diagnostics.g1.G1Baseline;
+import io.argus.diagnostics.g1.G1Diagnosis;
+import io.argus.diagnostics.g1.G1JfrCollector;
+import io.argus.core.command.CommandGroup;
+
+import javax.management.MBeanServerConnection;
+import javax.management.ObjectName;
+import javax.management.openmbean.CompositeData;
+import javax.management.remote.JMXConnector;
+import javax.management.remote.JMXConnectorFactory;
+import javax.management.remote.JMXServiceURL;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * One-shot G1GC health verdict from a single live JFR capture, with optional
+ * {@code --save}, {@code --diff}, and {@code --watch} modes for trend tracking.
+ *
+ * <p>Mirrors {@link ZgcCommand}: same modes, same JFR-capture path, same diff
+ * rendering shape — but G1-specific signals (region mix, mixed-cycle effectiveness,
+ * humongous, IHOP timing, evacuation failure).
+ *
+ * <p>Usage:
+ * <pre>
+ *   argus g1 &lt;PID&gt; [--duration=N]
+ *   argus g1 &lt;PID&gt; --save=PATH
+ *   argus g1 &lt;PID&gt; --diff=PATH
+ *   argus g1 &lt;PID&gt; --watch[=N] [--interval=N]
+ * </pre>
+ */
+public final class G1Command implements Command {
+
+    private static final int WIDTH = RichRenderer.DEFAULT_WIDTH;
+    private static final int DEFAULT_DURATION_SEC = 30;
+    private static final int MIN_DURATION_SEC = 5;
+    private static final int MAX_DURATION_SEC = 120;
+    private static final int MIN_INTERVAL_SEC = 10;
+    private static final int MAX_INTERVAL_SEC = 300;
+    private static final String JFR_RECORDING_NAME = "argus-g1";
+
+    private static final DateTimeFormatter TIME_FMT =
+            DateTimeFormatter.ofPattern("HH:mm:ss").withZone(ZoneId.systemDefault());
+    private static final DateTimeFormatter ISO_FMT = DateTimeFormatter.ISO_INSTANT;
+
+    private static final Pattern REGION_SIZE_FLAG =
+            Pattern.compile("-XX:G1HeapRegionSize=(\\d+)([KMG]?)", Pattern.CASE_INSENSITIVE);
+    private static final Pattern MAX_PAUSE_FLAG =
+            Pattern.compile("-XX:MaxGCPauseMillis=(\\d+)", Pattern.CASE_INSENSITIVE);
+    private static final Pattern IHOP_FLAG =
+            Pattern.compile("-XX:InitiatingHeapOccupancyPercent=(\\d+)", Pattern.CASE_INSENSITIVE);
+    private static final Pattern ADAPTIVE_IHOP_FLAG =
+            Pattern.compile("-XX:([+-])G1UseAdaptiveIHOP", Pattern.CASE_INSENSITIVE);
+
+    @Override public String name() { return "g1"; }
+    @Override public CommandGroup group() { return CommandGroup.MEMORY; }
+    @Override public CommandMode mode() { return CommandMode.READ; }
+    @Override public boolean supportsTui() { return false; }
+
+    @Override
+    public String description(Messages messages) {
+        return messages.get("cmd.g1.desc");
+    }
+
+    @Override
+    public void execute(String[] args, CliConfig config, ProviderRegistry registry, Messages messages) {
+        if (args.length == 0 || !isPid(args[0])) {
+            System.err.println("Usage: argus g1 <PID> [--duration=N] [--save=PATH] [--diff=PATH] [--watch[=N]] [--interval=N]");
+            throw new CommandExitException(1);
+        }
+
+        long pid = Long.parseLong(args[0]);
+        int  duration = DEFAULT_DURATION_SEC;
+        Path saveTo   = null;
+        Path diffWith = null;
+        int  watchIterations = -1;
+        int  interval = DEFAULT_DURATION_SEC;
+
+        for (int i = 1; i < args.length; i++) {
+            String a = args[i];
+            if (a.startsWith("--duration=")) {
+                try { duration = Integer.parseInt(a.substring(11)); }
+                catch (NumberFormatException ignored) {}
+            } else if (a.startsWith("--save=")) {
+                saveTo = Path.of(a.substring("--save=".length()));
+            } else if (a.equals("--save") && i + 1 < args.length) {
+                saveTo = Path.of(args[++i]);
+            } else if (a.startsWith("--diff=")) {
+                diffWith = Path.of(a.substring("--diff=".length()));
+            } else if (a.equals("--diff") && i + 1 < args.length) {
+                diffWith = Path.of(args[++i]);
+            } else if (a.equals("--watch")) {
+                watchIterations = 0;
+            } else if (a.startsWith("--watch=")) {
+                try {
+                    watchIterations = Integer.parseInt(a.substring("--watch=".length()));
+                    if (watchIterations < 1) watchIterations = 0;
+                } catch (NumberFormatException ignored) {
+                    watchIterations = 0;
+                }
+            } else if (a.startsWith("--interval=")) {
+                try { interval = Integer.parseInt(a.substring("--interval=".length())); }
+                catch (NumberFormatException ignored) {}
+            }
+        }
+
+        if (duration < MIN_DURATION_SEC) duration = MIN_DURATION_SEC;
+        if (duration > MAX_DURATION_SEC) duration = MAX_DURATION_SEC;
+        if (interval < MIN_INTERVAL_SEC) interval = MIN_INTERVAL_SEC;
+        if (interval > MAX_INTERVAL_SEC) interval = MAX_INTERVAL_SEC;
+
+        boolean useColor = config.color();
+
+        // ── Pre-check: is the target using G1? ──────────────────────────────
+        TargetInfo info = inspectTarget(pid);
+        if (!info.usingG1) {
+            System.out.println(messages.get("cli.g1.not.using.g1",
+                    String.valueOf(pid),
+                    info.gcAlgo.isEmpty() ? "unknown" : info.gcAlgo,
+                    String.valueOf(pid)));
+            throw new CommandExitException(1);
+        }
+
+        if (watchIterations >= 0) {
+            runWatch(pid, info, watchIterations, interval, useColor, messages);
+            return;
+        }
+
+        G1Diagnosis d = captureOnce(pid, info, duration, messages);
+
+        if (saveTo != null) {
+            try {
+                G1Baseline.save(saveTo, d, (int) pid);
+                System.out.println(messages.get("cli.g1.save.success", saveTo.toAbsolutePath()));
+            } catch (IOException e) {
+                System.err.println(messages.get("cli.g1.save.failed", e.getMessage()));
+            }
+        }
+
+        if (diffWith != null) {
+            try {
+                G1Baseline baseline = G1Baseline.load(diffWith);
+                List<G1Baseline.DiffRow> rows = G1Baseline.diff(baseline, d);
+                printDiff(baseline, d, rows, useColor, messages);
+            } catch (IOException e) {
+                System.err.println(messages.get("cli.g1.diff.failed", e.getMessage()));
+                throw new CommandExitException(1);
+            }
+            return;
+        }
+
+        printReport(pid, d, useColor, messages);
+    }
+
+    // ── Capture ──────────────────────────────────────────────────────────────
+
+    private static G1Diagnosis captureOnce(long pid, TargetInfo info, int durationSec, Messages messages) {
+        G1Diagnosis d = new G1Diagnosis();
+        d.usingG1            = true;
+        d.jvmVersion         = info.jvmVersion;
+        d.regionSizeMb       = info.regionSizeMb;
+        d.targetPauseMs      = info.targetPauseMs;
+        d.ihopPercent        = info.ihopPercent;
+        d.adaptiveIhop       = info.adaptiveIhop;
+        d.maxHeapBytes       = info.maxHeapBytes;
+        d.heapCommittedBytes = info.heapCommittedBytes;
+
+        System.out.println(messages.get("cli.g1.capturing", String.valueOf(durationSec)));
+
+        try (JfrCaptureSession.Capture capture = JfrCaptureSession.capture(
+                pid, JFR_RECORDING_NAME, "profile", durationSec, "argus-g1-")) {
+            G1JfrCollector.collect(capture.file(), d);
+        } catch (JfrCaptureFailed e) {
+            System.err.println(e.getMessage());
+            throw new CommandExitException(2);
+        } catch (IOException e) {
+            System.err.println("Failed to capture live G1 data for PID " + pid + ": " + e.getMessage());
+            throw new CommandExitException(2);
+        }
+        return d;
+    }
+
+    private static void stopExistingRecording(long pid) {
+        JcmdExecutor.runJcmd(pid, "JFR.stop", "name=" + JFR_RECORDING_NAME);
+    }
+
+    // ── Watch mode ───────────────────────────────────────────────────────────
+
+    private static void runWatch(long pid, TargetInfo info, int maxIterations,
+                                 int intervalSec, boolean useColor, Messages messages) {
+        System.out.println(messages.get("cli.g1.watch.banner", String.valueOf(intervalSec)));
+
+        int totalFull = 0; int totalEvacFail = 0; int totalHumCycles = 0;
+        int iterationCount = 0;
+        G1Diagnosis previous = null;
+
+        final int[] finalCount    = {0};
+        final int[] finalFull     = {0};
+        final int[] finalEvacFail = {0};
+        final int[] finalHumCycles = {0};
+
+        Thread shutdownHook = new Thread(() -> {
+            stopExistingRecording(pid);
+            System.out.println();
+            System.out.println(messages.get("cli.g1.watch.summary",
+                    String.valueOf(finalCount[0]),
+                    String.valueOf(finalFull[0]),
+                    String.valueOf(finalEvacFail[0]),
+                    String.valueOf(finalHumCycles[0])));
+        }, "argus-g1-watch-cleanup");
+        Runtime.getRuntime().addShutdownHook(shutdownHook);
+
+        try {
+            while (maxIterations == 0 || iterationCount < maxIterations) {
+                G1Diagnosis current;
+                try {
+                    current = captureOnce(pid, info, intervalSec, messages);
+                } catch (CommandExitException e) {
+                    System.err.println("  [warn] JFR capture failed for iteration "
+                            + (iterationCount + 1) + ", skipping.");
+                    try { Thread.sleep(intervalSec * 1000L); }
+                    catch (InterruptedException ie) { Thread.currentThread().interrupt(); break; }
+                    continue;
+                }
+
+                iterationCount++;
+                if (current.fullGcSeen) totalFull++;
+                if (current.evacuationFailureSeen) totalEvacFail++;
+                totalHumCycles += current.humongousAllocationCycles;
+
+                printWatchLine(current, previous, intervalSec, useColor, messages);
+
+                if (iterationCount % 5 == 0) {
+                    System.out.println();
+                    printReport(pid, current, useColor, messages);
+                    System.out.println();
+                }
+
+                previous = current;
+                finalCount[0]     = iterationCount;
+                finalFull[0]      = totalFull;
+                finalEvacFail[0]  = totalEvacFail;
+                finalHumCycles[0] = totalHumCycles;
+            }
+        } finally {
+            try { Runtime.getRuntime().removeShutdownHook(shutdownHook); }
+            catch (IllegalStateException ignored) {}
+            stopExistingRecording(pid);
+            System.out.println();
+            System.out.println(messages.get("cli.g1.watch.summary",
+                    String.valueOf(iterationCount),
+                    String.valueOf(totalFull),
+                    String.valueOf(totalEvacFail),
+                    String.valueOf(totalHumCycles)));
+        }
+    }
+
+    private static void printWatchLine(G1Diagnosis current, G1Diagnosis previous,
+                                       int intervalSec, boolean useColor, Messages messages) {
+        String reset  = AnsiStyle.style(useColor, AnsiStyle.RESET);
+        String dim    = AnsiStyle.style(useColor, AnsiStyle.DIM);
+        String yellow = AnsiStyle.style(useColor, AnsiStyle.YELLOW);
+        String red    = AnsiStyle.style(useColor, AnsiStyle.RED);
+        String green  = AnsiStyle.style(useColor, AnsiStyle.GREEN);
+
+        String timestamp = TIME_FMT.format(Instant.now());
+
+        String cyclesStr = current.youngCycles + "y/" + current.mixedCycles + "m/"
+                + current.concurrentCycles + "c";
+
+        String pauseColor = reset;
+        String pauseStr = String.format("%.1fms", current.maxPauseMs);
+        if (previous != null && previous.maxPauseMs > 0
+                && current.maxPauseMs / previous.maxPauseMs > 1.5) {
+            pauseColor = yellow;
+        }
+
+        String evacColor = current.evacuationFailureSeen ? red : reset;
+        String evacStr   = current.evacuationFailureSeen ? "✘" : "✓";
+
+        String fullColor = current.fullGcSeen ? red : (current.humongousAllocationCycles > 0 ? yellow : green);
+        String fullStr   = current.fullGcSeen
+                ? "Full GC"
+                : (current.humongousAllocationCycles > 0
+                        ? "humongous " + current.humongousAllocationCycles
+                        : "ok");
+
+        StringBuilder sb = new StringBuilder();
+        sb.append(dim).append('[').append(timestamp).append(']').append(reset);
+        sb.append(" G1 | cycles ").append(dim).append(cyclesStr).append(reset);
+        sb.append(" | max-pause ").append(pauseColor).append(pauseStr).append(reset);
+        sb.append(" | evac ").append(evacColor).append(evacStr).append(reset);
+        sb.append(" | ").append(fullColor).append(fullStr).append(reset);
+
+        System.out.println(sb);
+    }
+
+    // ── Diff rendering ───────────────────────────────────────────────────────
+
+    private static void printDiff(G1Baseline baseline, G1Diagnosis current,
+                                   List<G1Baseline.DiffRow> rows,
+                                   boolean useColor, Messages messages) {
+        String reset  = AnsiStyle.style(useColor, AnsiStyle.RESET);
+        String dim    = AnsiStyle.style(useColor, AnsiStyle.DIM);
+        String bold   = AnsiStyle.style(useColor, AnsiStyle.BOLD);
+        String yellow = AnsiStyle.style(useColor, AnsiStyle.YELLOW, AnsiStyle.BOLD);
+        String red    = AnsiStyle.style(useColor, AnsiStyle.RED, AnsiStyle.BOLD);
+
+        Instant now = Instant.now();
+        long elapsedMinutes = Duration.between(baseline.capturedAt, now).toMinutes();
+        String elapsedLabel = elapsedMinutes >= 60
+                ? String.format("%.1f hr", elapsedMinutes / 60.0)
+                : elapsedMinutes + " min";
+        System.out.println(bold + messages.get("cli.g1.diff.header",
+                ISO_FMT.format(baseline.capturedAt),
+                ISO_FMT.format(now),
+                "+" + elapsedLabel) + reset);
+        System.out.println(dim + "═".repeat(63) + reset);
+
+        for (G1Baseline.DiffRow row : rows) {
+            String label = rowLabel(row.label(), messages);
+            String marker; String color;
+            switch (row.severity()) {
+                case REGRESSION: marker = " ✘"; color = red;    break;
+                case WARN:       marker = " ⚠"; color = yellow; break;
+                default:         marker = "";   color = reset;   break;
+            }
+            String deltaDisplay = row.delta();
+            if ("NEW".equals(deltaDisplay)) {
+                deltaDisplay = "(" + messages.get("cli.g1.diff.regression.new") + ")";
+            }
+            String line = String.format("  %-22s %14s → %-14s  %s%s",
+                    label, row.baselineValue(), row.currentValue(), deltaDisplay, marker);
+            System.out.println(color + line + reset);
+        }
+        System.out.println();
+    }
+
+    private static String rowLabel(String key, Messages messages) {
+        switch (key) {
+            case "heapCommitted":      return messages.get("cli.g1.diff.row.committed");
+            case "fullGcSeen":         return messages.get("cli.g1.diff.row.fullgc");
+            case "evacuationFailure":  return messages.get("cli.g1.diff.row.evac");
+            case "mixedStarvation":    return messages.get("cli.g1.diff.row.mixed");
+            case "humongousCycles":    return messages.get("cli.g1.diff.row.humongous");
+            case "maxPause":           return messages.get("cli.g1.diff.row.maxpause");
+            case "minMmu":             return messages.get("cli.g1.diff.row.mmu");
+            default:                   return key;
+        }
+    }
+
+    // ── Target inspection (JMX) ─────────────────────────────────────────────
+
+    private static final class TargetInfo {
+        final boolean usingG1;
+        final String  gcAlgo;
+        final String  jvmVersion;
+        final long    heapCommittedBytes;
+        final long    maxHeapBytes;
+        final int     regionSizeMb;
+        final int     targetPauseMs;
+        final int     ihopPercent;
+        final boolean adaptiveIhop;
+        TargetInfo(boolean usingG1, String gcAlgo, String jvmVersion,
+                   long heapCommittedBytes, long maxHeapBytes,
+                   int regionSizeMb, int targetPauseMs, int ihopPercent, boolean adaptiveIhop) {
+            this.usingG1 = usingG1;
+            this.gcAlgo = gcAlgo;
+            this.jvmVersion = jvmVersion;
+            this.heapCommittedBytes = heapCommittedBytes;
+            this.maxHeapBytes = maxHeapBytes;
+            this.regionSizeMb = regionSizeMb;
+            this.targetPauseMs = targetPauseMs;
+            this.ihopPercent = ihopPercent;
+            this.adaptiveIhop = adaptiveIhop;
+        }
+    }
+
+    private static TargetInfo inspectTarget(long pid) {
+        boolean usingG1 = false;
+        String gcAlgo = "";
+        String jvmVersion = "";
+        long heapCommitted = 0;
+        long maxHeap = 0;
+        int regionSizeMb = 0;
+        int targetPauseMs = 200; // JVM default
+        int ihopPercent = 45;    // JVM default
+        boolean adaptiveIhop = true; // JVM default since JDK 15
+
+        String connectorAddr;
+        try {
+            connectorAddr = JmxAttachment.resolveConnectorAddress(pid);
+        } catch (JmxAttachmentException e) {
+            return new TargetInfo(false, "", "", 0, 0, 0, 200, 45, true);
+        }
+
+        try (JMXConnector connector =
+                JMXConnectorFactory.connect(new JMXServiceURL(connectorAddr))) {
+            MBeanServerConnection mbs = connector.getMBeanServerConnection();
+
+            Set<ObjectName> gcs = mbs.queryNames(
+                    new ObjectName("java.lang:type=GarbageCollector,*"), null);
+            StringBuilder algoNames = new StringBuilder();
+            for (ObjectName on : gcs) {
+                String n = on.getKeyProperty("name");
+                if (n == null) continue;
+                if (algoNames.length() > 0) algoNames.append(", ");
+                algoNames.append(n);
+                if (n.contains("G1")) usingG1 = true;
+            }
+            gcAlgo = algoNames.toString();
+
+            try {
+                ObjectName runtime = new ObjectName("java.lang:type=Runtime");
+                Object spec = mbs.getAttribute(runtime, "SpecVersion");
+                if (spec != null) jvmVersion = spec.toString();
+            } catch (Exception ignored) {}
+
+            try {
+                ObjectName mem = new ObjectName("java.lang:type=Memory");
+                Object usage = mbs.getAttribute(mem, "HeapMemoryUsage");
+                if (usage instanceof CompositeData) {
+                    CompositeData cd = (CompositeData) usage;
+                    Object max = cd.get("max");
+                    Object committed = cd.get("committed");
+                    if (max instanceof Number) maxHeap = ((Number) max).longValue();
+                    if (committed instanceof Number) heapCommitted = ((Number) committed).longValue();
+                }
+            } catch (Exception ignored) {}
+
+            // VM flags (Runtime.InputArguments) to read G1 tunables.
+            try {
+                ObjectName runtime = new ObjectName("java.lang:type=Runtime");
+                Object args = mbs.getAttribute(runtime, "InputArguments");
+                if (args instanceof String[]) {
+                    for (String flag : (String[]) args) {
+                        Matcher rm = REGION_SIZE_FLAG.matcher(flag);
+                        if (rm.find()) {
+                            long v = Long.parseLong(rm.group(1));
+                            String unit = rm.group(2);
+                            if ("K".equalsIgnoreCase(unit)) regionSizeMb = (int) Math.max(1, v / 1024);
+                            else if ("G".equalsIgnoreCase(unit)) regionSizeMb = (int) (v * 1024);
+                            else if ("M".equalsIgnoreCase(unit)) regionSizeMb = (int) v;
+                            else regionSizeMb = (int) Math.max(1, v / (1024 * 1024)); // bytes
+                        }
+                        Matcher pm = MAX_PAUSE_FLAG.matcher(flag);
+                        if (pm.find()) {
+                            try { targetPauseMs = Integer.parseInt(pm.group(1)); }
+                            catch (NumberFormatException ignored2) {}
+                        }
+                        Matcher im = IHOP_FLAG.matcher(flag);
+                        if (im.find()) {
+                            try { ihopPercent = Integer.parseInt(im.group(1)); }
+                            catch (NumberFormatException ignored2) {}
+                        }
+                        Matcher am = ADAPTIVE_IHOP_FLAG.matcher(flag);
+                        if (am.find()) {
+                            adaptiveIhop = "+".equals(am.group(1));
+                        }
+                    }
+                }
+            } catch (Exception ignored) {}
+
+        } catch (Exception e) {
+            // JMX path failed — fall through with whatever we collected.
+        }
+
+        return new TargetInfo(usingG1, gcAlgo, jvmVersion, heapCommitted, maxHeap,
+                regionSizeMb, targetPauseMs, ihopPercent, adaptiveIhop);
+    }
+
+    // ── Render ──────────────────────────────────────────────────────────────
+
+    static void printReport(long pid, G1Diagnosis d, boolean c, Messages messages) {
+        G1Diagnosis.Verdict verdict = d.compute();
+
+        String bold  = AnsiStyle.style(c, AnsiStyle.BOLD);
+        String reset = AnsiStyle.style(c, AnsiStyle.RESET);
+        String dim   = AnsiStyle.style(c, AnsiStyle.DIM);
+        String red   = AnsiStyle.style(c, AnsiStyle.RED);
+        String yel   = AnsiStyle.style(c, AnsiStyle.YELLOW);
+        String grn   = AnsiStyle.style(c, AnsiStyle.GREEN);
+
+        String jdkLabel = d.jvmVersion.isEmpty() ? "JDK ?" : "JDK " + d.jvmVersion;
+        String adaptiveLabel = d.adaptiveIhop
+                ? messages.get("cli.g1.adaptive.on")
+                : messages.get("cli.g1.adaptive.off");
+        String title = messages.get("cli.g1.title", String.valueOf(pid), jdkLabel, adaptiveLabel);
+        System.out.println(bold + title + reset);
+        System.out.println(dim + "═".repeat(Math.min(WIDTH, Math.max(40, title.length()))) + reset);
+
+        // Identity
+        String identityLine = "  " + bold + messages.get("cli.g1.identity.label") + reset
+                + "     target " + d.targetPauseMs + "ms"
+                + " · region " + (d.regionSizeMb > 0 ? d.regionSizeMb + "MB" : "default")
+                + " · IHOP " + d.ihopPercent + "%";
+        System.out.println(identityLine);
+
+        // Heap
+        String heapLine = "  " + bold + messages.get("cli.g1.heap.label") + reset
+                + "         committed " + RichRenderer.formatBytes(d.heapCommittedBytes)
+                + " / max " + RichRenderer.formatBytes(d.maxHeapBytes);
+        System.out.println(heapLine);
+
+        // Regions
+        if (d.totalRegions > 0) {
+            System.out.println("  " + bold + messages.get("cli.g1.regions.label") + reset
+                    + "      eden " + d.edenRegions + " · survivor " + d.survivorRegions
+                    + " · old " + d.oldRegions
+                    + (d.humongousRegions > 0
+                            ? " · " + yel + "humongous " + d.humongousRegions + reset
+                            : " · humongous 0")
+                    + " / total " + d.totalRegions);
+        }
+
+        // Cycles
+        System.out.println("  " + bold + messages.get("cli.g1.cycles.label") + reset
+                + "       " + d.youngCycles + " young, " + d.mixedCycles + " mixed, "
+                + d.concurrentCycles + " concurrent, " + d.fullGcCycles + " full"
+                + " (avg young " + String.format("%.2fms", d.avgYoungPauseMs)
+                + (d.mixedCycles > 0 ? ", avg mixed " + String.format("%.2fms", d.avgMixedPauseMs) : "")
+                + ", max " + String.format("%.2fms", d.maxPauseMs) + ")");
+
+        // Evacuation
+        System.out.println("  " + bold + messages.get("cli.g1.evac.label") + reset
+                + "   " + (d.evacuationFailureSeen
+                        ? red + "✘" + reset + " " + messages.get("cli.g1.evac.failed",
+                                String.valueOf(d.evacuationFailures))
+                        : grn + "✓" + reset + " " + messages.get("cli.g1.evac.ok"))
+                + dim + " · young " + RichRenderer.formatBytes(d.bytesCopiedYoung)
+                + " · old " + RichRenderer.formatBytes(d.bytesCopiedOld) + reset);
+
+        // MMU
+        if (d.avgMmuPercent > 0) {
+            System.out.println("  " + bold + messages.get("cli.g1.mmu.label") + reset
+                    + "         min " + String.format("%.1f%%", d.minMmuPercent)
+                    + ", avg " + String.format("%.1f%%", d.avgMmuPercent));
+        }
+
+        // IHOP
+        if (d.predictedIhopPercent > 0 || d.actualIhopPercent > 0) {
+            String ihopMark = d.ihopMistimed ? yel + "⚠" + reset + " " : "";
+            System.out.println("  " + bold + messages.get("cli.g1.ihop.label") + reset
+                    + "        " + ihopMark
+                    + "predicted " + String.format("%.1f%%", d.predictedIhopPercent)
+                    + " / actual " + String.format("%.1f%%", d.actualIhopPercent));
+        }
+
+        // Humongous
+        if (d.humongousAllocationCycles > 0) {
+            System.out.println("  " + bold + messages.get("cli.g1.humongous.label") + reset
+                    + "   " + yel + "⚠" + reset + " "
+                    + messages.get("cli.g1.humongous.cycles",
+                            String.valueOf(d.humongousAllocationCycles)));
+            if (!d.humongousHotspots.isEmpty()) {
+                System.out.println("               "
+                        + messages.get("cli.g1.humongous.alloc.header",
+                                String.format("%,d", d.totalHumongousAllocEvents)));
+                for (int i = 0; i < d.humongousHotspots.size(); i++) {
+                    G1Diagnosis.HumongousHotspot h = d.humongousHotspots.get(i);
+                    System.out.printf("               %2d. %-60s %s%n",
+                            i + 1, h.frame(),
+                            "(" + h.count() + " allocs, max " + RichRenderer.formatBytes(h.maxBytes()) + ")");
+                }
+            }
+        }
+
+        // Mixed starvation
+        if (d.mixedStarvation) {
+            System.out.println("  " + bold + messages.get("cli.g1.mixed.label") + reset
+                    + "      " + yel + "⚠" + reset + " " + messages.get("cli.g1.mixed.starved"));
+        }
+
+        // Full GC
+        if (d.fullGcSeen) {
+            System.out.println("  " + bold + messages.get("cli.g1.full.label") + reset
+                    + "       " + red + "✘" + reset + " "
+                    + messages.get("cli.g1.full.seen", String.valueOf(d.fullGcCycles)));
+        }
+
+        System.out.println();
+
+        // Verdict
+        String verdictColor;
+        switch (verdict) {
+            case HEALTHY:   verdictColor = grn; break;
+            case WARNING:   verdictColor = yel; break;
+            default:        verdictColor = red; break;
+        }
+        String verdictReason = verdictReason(verdict, d, messages);
+        System.out.println(bold + messages.get("cli.g1.verdict.label") + " " + reset
+                + verdictColor + bold + verdict.name() + reset
+                + (verdictReason.isEmpty() ? "" : "  — " + verdictReason));
+
+        if (verdict != G1Diagnosis.Verdict.HEALTHY) {
+            System.out.println(messages.get("cli.g1.recommend.label"));
+            for (String r : recommendations(d, messages)) {
+                System.out.println("  • " + r);
+            }
+        }
+    }
+
+    private static String verdictReason(G1Diagnosis.Verdict v, G1Diagnosis d, Messages messages) {
+        switch (v) {
+            case HEALTHY:
+                return messages.get("cli.g1.verdict.healthy");
+            case WARNING: {
+                if (d.mixedStarvation) return messages.get("cli.g1.verdict.warning.mixed");
+                if (d.ihopMistimed)    return messages.get("cli.g1.verdict.warning.ihop");
+                if (d.humongousAllocationCycles > 0)
+                    return messages.get("cli.g1.verdict.warning.humongous");
+                return messages.get("cli.g1.verdict.warning.pause");
+            }
+            default: {
+                if (d.fullGcSeen && d.evacuationFailureSeen)
+                    return messages.get("cli.g1.verdict.unhealthy.full.evac");
+                if (d.fullGcSeen)
+                    return messages.get("cli.g1.verdict.unhealthy.full");
+                return messages.get("cli.g1.verdict.unhealthy.evac");
+            }
+        }
+    }
+
+    private static List<String> recommendations(G1Diagnosis d, Messages messages) {
+        var out = new java.util.ArrayList<String>();
+        if (d.fullGcSeen) {
+            out.add(messages.get("cli.g1.rec.full",
+                    String.valueOf(suggestedXmxGb(d))));
+        }
+        if (d.evacuationFailureSeen) {
+            out.add(messages.get("cli.g1.rec.evac"));
+        }
+        if (d.humongousAllocationCycles > 0) {
+            int suggestMb = Math.max(8, d.regionSizeMb * 2);
+            if (suggestMb < 8) suggestMb = 8;
+            out.add(messages.get("cli.g1.rec.humongous", String.valueOf(suggestMb)));
+        }
+        if (d.mixedStarvation) {
+            out.add(messages.get("cli.g1.rec.mixed", String.valueOf(Math.max(30, d.ihopPercent - 5))));
+        }
+        if (d.ihopMistimed) {
+            out.add(messages.get("cli.g1.rec.ihop"));
+        }
+        if (out.isEmpty()) {
+            out.add(messages.get("cli.g1.rec.profile"));
+        }
+        return out;
+    }
+
+    private static long suggestedXmxGb(G1Diagnosis d) {
+        long curMaxBytes = d.maxHeapBytes > 0 ? d.maxHeapBytes : d.heapCommittedBytes;
+        long curGb = Math.max(1, (curMaxBytes + (1L << 30) - 1) / (1L << 30));
+        return Math.max(curGb + 1, (long) Math.ceil(curGb * 1.25));
+    }
+
+    // ── Helpers ─────────────────────────────────────────────────────────────
+
+    private static boolean isPid(String arg) {
+        if (arg == null || arg.isEmpty()) return false;
+        for (int i = 0; i < arg.length(); i++) {
+            if (!Character.isDigit(arg.charAt(i))) return false;
+        }
+        return true;
+    }
+}

--- a/argus-cli/src/main/java/io/argus/cli/command/G1Command.java
+++ b/argus-cli/src/main/java/io/argus/cli/command/G1Command.java
@@ -364,6 +364,7 @@ public final class G1Command implements Command {
             case "humongousCycles":    return messages.get("cli.g1.diff.row.humongous");
             case "maxPause":           return messages.get("cli.g1.diff.row.maxpause");
             case "minMmu":             return messages.get("cli.g1.diff.row.mmu");
+            case "ihopMistimed":       return messages.get("cli.g1.diff.row.ihop");
             default:                   return key;
         }
     }

--- a/argus-cli/src/main/resources/META-INF/services/io.argus.cli.command.Command
+++ b/argus-cli/src/main/resources/META-INF/services/io.argus.cli.command.Command
@@ -18,6 +18,7 @@ io.argus.cli.command.EventsCommand
 io.argus.cli.command.ExplainCommand
 io.argus.cli.command.FinalizerCommand
 io.argus.cli.command.FlameCommand
+io.argus.cli.command.G1Command
 io.argus.cli.command.GcCauseCommand
 io.argus.cli.command.GcCommand
 io.argus.cli.command.GcLogCommand

--- a/argus-cli/src/main/resources/messages_en.properties
+++ b/argus-cli/src/main/resources/messages_en.properties
@@ -708,3 +708,57 @@ fleet.poll.live=Live
 fleet.poll.error=Error
 fleet.poll.connecting=Connecting
 fleet.pods.count=%s pods
+
+# G1 Command
+cmd.g1.desc=G1GC live health verdict from a 30s JFR capture
+cli.g1.not.using.g1=Target JVM (PID %s) is not using G1GC. Current GC: %s. Use 'argus gc %s' instead.
+cli.g1.capturing=Capturing G1 JFR for %ss…
+cli.g1.adaptive.on=Adaptive IHOP
+cli.g1.adaptive.off=Manual IHOP
+cli.g1.title=G1 Diagnosis (PID %s, %s, %s)
+cli.g1.identity.label=Config
+cli.g1.heap.label=Heap
+cli.g1.regions.label=Regions
+cli.g1.cycles.label=Cycles
+cli.g1.evac.label=Evacuation
+cli.g1.evac.failed=%s failure(s) during window
+cli.g1.evac.ok=no failures
+cli.g1.mmu.label=MMU
+cli.g1.ihop.label=IHOP
+cli.g1.humongous.label=Humongous
+cli.g1.humongous.cycles=%s cycle(s) triggered by humongous allocation
+cli.g1.humongous.alloc.header=Top humongous-class alloc sites during capture (n=%s events)
+cli.g1.mixed.label=Mixed GC
+cli.g1.mixed.starved=concurrent cycle finished but no Mixed pause followed — mixed-GC starvation
+cli.g1.full.label=Full GC
+cli.g1.full.seen=%s Full GC pause(s) observed — G1 should not Full GC in steady state
+cli.g1.verdict.label=Verdict:
+cli.g1.verdict.healthy=G1 is keeping up.
+cli.g1.verdict.warning.mixed=mixed-GC starvation observed.
+cli.g1.verdict.warning.ihop=IHOP prediction off — mark cycle may start too late.
+cli.g1.verdict.warning.humongous=humongous allocation cycles observed.
+cli.g1.verdict.warning.pause=max pause exceeds 2× target.
+cli.g1.verdict.unhealthy.full=Full GC observed under G1.
+cli.g1.verdict.unhealthy.evac=evacuation failure (to-space exhausted).
+cli.g1.verdict.unhealthy.full.evac=Full GC + evacuation failure.
+cli.g1.recommend.label=Recommend:
+cli.g1.rec.full=Raise -Xmx (e.g. -Xmx%sg) and lower -XX:InitiatingHeapOccupancyPercent
+cli.g1.rec.evac=Raise -Xmx and consider -XX:G1ReservePercent=15 (default 10) for evac headroom
+cli.g1.rec.humongous=Raise -XX:G1HeapRegionSize=%sm so humongous threshold rises above common allocations
+cli.g1.rec.mixed=Lower -XX:InitiatingHeapOccupancyPercent=%s so concurrent cycle finishes before mixed scheduling
+cli.g1.rec.ihop=Disable -XX:-G1UseAdaptiveIHOP and pin -XX:InitiatingHeapOccupancyPercent, or raise heap
+cli.g1.rec.profile=Profile allocations: argus profile <PID> --event=alloc
+cli.g1.save.success=Saved G1 baseline to: %s
+cli.g1.save.failed=Failed to save baseline: %s
+cli.g1.diff.failed=Failed to load baseline: %s
+cli.g1.watch.banner=Watching G1 every %ss (Ctrl-C to stop)
+cli.g1.watch.summary=Watched %s iterations · %s full GCs · %s evac failures · %s humongous cycles
+cli.g1.diff.header=G1 Diff (baseline %s → now %s, %s)
+cli.g1.diff.regression.new=NEW
+cli.g1.diff.row.committed=Heap committed
+cli.g1.diff.row.fullgc=Full GC
+cli.g1.diff.row.evac=Evacuation failure
+cli.g1.diff.row.mixed=Mixed starvation
+cli.g1.diff.row.humongous=Humongous cycles
+cli.g1.diff.row.maxpause=Max pause
+cli.g1.diff.row.mmu=Min MMU

--- a/argus-cli/src/main/resources/messages_en.properties
+++ b/argus-cli/src/main/resources/messages_en.properties
@@ -762,3 +762,4 @@ cli.g1.diff.row.mixed=Mixed starvation
 cli.g1.diff.row.humongous=Humongous cycles
 cli.g1.diff.row.maxpause=Max pause
 cli.g1.diff.row.mmu=Min MMU
+cli.g1.diff.row.ihop=IHOP mistimed

--- a/argus-cli/src/main/resources/messages_ja.properties
+++ b/argus-cli/src/main/resources/messages_ja.properties
@@ -747,4 +747,5 @@ cli.g1.diff.row.mixed=Mixedスターベーション
 cli.g1.diff.row.humongous=Humongousサイクル
 cli.g1.diff.row.maxpause=最大ポーズ
 cli.g1.diff.row.mmu=最小MMU
+cli.g1.diff.row.ihop=IHOPずれ
 

--- a/argus-cli/src/main/resources/messages_ja.properties
+++ b/argus-cli/src/main/resources/messages_ja.properties
@@ -693,3 +693,58 @@ fleet.poll.live=ライブ
 fleet.poll.error=エラー
 fleet.poll.connecting=接続中
 fleet.pods.count=%s Pod
+
+# G1 Command
+cmd.g1.desc=30秒JFRキャプチャによるG1GCライブ診断
+cli.g1.not.using.g1=対象JVM (PID %s) はG1GCを使用していません。現在のGC: %s。代わりに 'argus gc %s' を使用してください。
+cli.g1.capturing=G1 JFRを%s秒間キャプチャ中…
+cli.g1.adaptive.on=適応型IHOP
+cli.g1.adaptive.off=手動IHOP
+cli.g1.title=G1診断 (PID %s, %s, %s)
+cli.g1.identity.label=設定
+cli.g1.heap.label=ヒープ
+cli.g1.regions.label=リージョン
+cli.g1.cycles.label=サイクル
+cli.g1.evac.label=退避
+cli.g1.evac.failed=ウィンドウ内で%s回失敗
+cli.g1.evac.ok=失敗なし
+cli.g1.mmu.label=MMU
+cli.g1.ihop.label=IHOP
+cli.g1.humongous.label=Humongous
+cli.g1.humongous.cycles=%s回のサイクルがHumongous割り当てに起因
+cli.g1.humongous.alloc.header=キャプチャ中の上位Humongous割り当て位置 (n=%s イベント)
+cli.g1.mixed.label=Mixed GC
+cli.g1.mixed.starved=並行サイクル終了後にMixedポーズが発生していない — mixed-GCスターベーション
+cli.g1.full.label=Full GC
+cli.g1.full.seen=%s回のFull GCを観測 — G1は正常状態でFull GCすべきではない
+cli.g1.verdict.label=判定:
+cli.g1.verdict.healthy=G1は正常に追従しています。
+cli.g1.verdict.warning.mixed=mixed-GCスターベーションを検出。
+cli.g1.verdict.warning.ihop=IHOP予測ずれ — マークサイクル開始が遅れる可能性。
+cli.g1.verdict.warning.humongous=Humongous割り当てサイクルを観測。
+cli.g1.verdict.warning.pause=最大ポーズ時間が目標の2倍を超過。
+cli.g1.verdict.unhealthy.full=G1でFull GC発生。
+cli.g1.verdict.unhealthy.evac=退避失敗 (to-space exhausted)。
+cli.g1.verdict.unhealthy.full.evac=Full GC + 退避失敗。
+cli.g1.recommend.label=推奨:
+cli.g1.rec.full=-Xmxを引き上げ (例: -Xmx%sg) し -XX:InitiatingHeapOccupancyPercent を下げる
+cli.g1.rec.evac=-Xmxを引き上げ -XX:G1ReservePercent=15 (デフォルト10) で退避ヘッドルームを確保
+cli.g1.rec.humongous=-XX:G1HeapRegionSize=%sm に引き上げてHumongous閾値を通常割り当て以上にする
+cli.g1.rec.mixed=-XX:InitiatingHeapOccupancyPercent=%s に下げて並行サイクルがmixedスケジューリング前に完了するようにする
+cli.g1.rec.ihop=-XX:-G1UseAdaptiveIHOP を無効化し -XX:InitiatingHeapOccupancyPercent を固定、またはヒープを増やす
+cli.g1.rec.profile=割り当てプロファイリング: argus profile <PID> --event=alloc
+cli.g1.save.success=G1ベースラインを保存: %s
+cli.g1.save.failed=ベースライン保存失敗: %s
+cli.g1.diff.failed=ベースライン読み込み失敗: %s
+cli.g1.watch.banner=G1を%s秒ごとに監視中 (Ctrl-Cで停止)
+cli.g1.watch.summary=%s回反復 · Full GC %s回 · 退避失敗 %s回 · Humongousサイクル %s回
+cli.g1.diff.header=G1 Diff (ベースライン %s → 現在 %s, %s)
+cli.g1.diff.regression.new=新規
+cli.g1.diff.row.committed=ヒープコミット
+cli.g1.diff.row.fullgc=Full GC
+cli.g1.diff.row.evac=退避失敗
+cli.g1.diff.row.mixed=Mixedスターベーション
+cli.g1.diff.row.humongous=Humongousサイクル
+cli.g1.diff.row.maxpause=最大ポーズ
+cli.g1.diff.row.mmu=最小MMU
+

--- a/argus-cli/src/main/resources/messages_ko.properties
+++ b/argus-cli/src/main/resources/messages_ko.properties
@@ -693,3 +693,58 @@ fleet.poll.live=실시간
 fleet.poll.error=오류
 fleet.poll.connecting=연결 중
 fleet.pods.count=%s개 파드
+
+# G1 Command
+cmd.g1.desc=30초 JFR 캡처 기반 G1GC 실시간 상태 진단
+cli.g1.not.using.g1=대상 JVM (PID %s)이 G1GC를 사용하지 않습니다. 현재 GC: %s. 'argus gc %s'를 대신 사용하세요.
+cli.g1.capturing=G1 JFR을 %s초 동안 캡처 중…
+cli.g1.adaptive.on=적응형 IHOP
+cli.g1.adaptive.off=수동 IHOP
+cli.g1.title=G1 진단 (PID %s, %s, %s)
+cli.g1.identity.label=설정
+cli.g1.heap.label=힙
+cli.g1.regions.label=리전
+cli.g1.cycles.label=사이클
+cli.g1.evac.label=대피
+cli.g1.evac.failed=캡처 동안 %s회 실패
+cli.g1.evac.ok=실패 없음
+cli.g1.mmu.label=MMU
+cli.g1.ihop.label=IHOP
+cli.g1.humongous.label=거대 객체
+cli.g1.humongous.cycles=%s개 사이클이 거대 객체 할당으로 인해 시작됨
+cli.g1.humongous.alloc.header=캡처 동안 상위 거대 객체 할당 위치 (n=%s 이벤트)
+cli.g1.mixed.label=Mixed GC
+cli.g1.mixed.starved=동시 사이클이 끝났지만 Mixed 정지가 따르지 않음 — mixed-GC 기근
+cli.g1.full.label=Full GC
+cli.g1.full.seen=%s회 Full GC 관찰됨 — G1은 정상 상태에서 Full GC가 발생하면 안 됨
+cli.g1.verdict.label=판정:
+cli.g1.verdict.healthy=G1이 정상적으로 동작 중입니다.
+cli.g1.verdict.warning.mixed=mixed-GC 기근이 관찰됨.
+cli.g1.verdict.warning.ihop=IHOP 예측 오차 — 마킹 사이클 시작이 너무 늦을 수 있음.
+cli.g1.verdict.warning.humongous=거대 객체 할당 사이클이 관찰됨.
+cli.g1.verdict.warning.pause=최대 정지 시간이 목표의 2배를 초과함.
+cli.g1.verdict.unhealthy.full=G1에서 Full GC가 발생함.
+cli.g1.verdict.unhealthy.evac=대피 실패 (to-space exhausted).
+cli.g1.verdict.unhealthy.full.evac=Full GC + 대피 실패.
+cli.g1.recommend.label=권장:
+cli.g1.rec.full=-Xmx 증가 (예: -Xmx%sg) 및 -XX:InitiatingHeapOccupancyPercent 낮추기
+cli.g1.rec.evac=-Xmx 증가, -XX:G1ReservePercent=15 (기본 10) 고려로 대피 헤드룸 확보
+cli.g1.rec.humongous=-XX:G1HeapRegionSize=%sm으로 증가하여 거대 객체 임계값을 일반 할당 위로 올림
+cli.g1.rec.mixed=-XX:InitiatingHeapOccupancyPercent=%s로 낮춰 동시 사이클이 mixed 스케줄링 전에 완료되도록 함
+cli.g1.rec.ihop=-XX:-G1UseAdaptiveIHOP 비활성화하고 -XX:InitiatingHeapOccupancyPercent 고정, 또는 힙 증가
+cli.g1.rec.profile=할당 프로파일링: argus profile <PID> --event=alloc
+cli.g1.save.success=G1 기준선 저장됨: %s
+cli.g1.save.failed=기준선 저장 실패: %s
+cli.g1.diff.failed=기준선 로드 실패: %s
+cli.g1.watch.banner=G1을 %s초마다 감시 중 (중지하려면 Ctrl-C)
+cli.g1.watch.summary=%s회 반복 · Full GC %s회 · 대피 실패 %s회 · 거대 객체 사이클 %s회
+cli.g1.diff.header=G1 Diff (기준선 %s → 현재 %s, %s)
+cli.g1.diff.regression.new=신규
+cli.g1.diff.row.committed=힙 커밋
+cli.g1.diff.row.fullgc=Full GC
+cli.g1.diff.row.evac=대피 실패
+cli.g1.diff.row.mixed=Mixed 기근
+cli.g1.diff.row.humongous=거대 객체 사이클
+cli.g1.diff.row.maxpause=최대 정지
+cli.g1.diff.row.mmu=최소 MMU
+

--- a/argus-cli/src/main/resources/messages_ko.properties
+++ b/argus-cli/src/main/resources/messages_ko.properties
@@ -747,4 +747,5 @@ cli.g1.diff.row.mixed=Mixed 기근
 cli.g1.diff.row.humongous=거대 객체 사이클
 cli.g1.diff.row.maxpause=최대 정지
 cli.g1.diff.row.mmu=최소 MMU
+cli.g1.diff.row.ihop=IHOP 예측 오차
 

--- a/argus-cli/src/main/resources/messages_zh.properties
+++ b/argus-cli/src/main/resources/messages_zh.properties
@@ -693,3 +693,58 @@ fleet.poll.live=实时
 fleet.poll.error=错误
 fleet.poll.connecting=连接中
 fleet.pods.count=%s个Pod
+
+# G1 Command
+cmd.g1.desc=基于30秒JFR捕获的G1GC实时健康诊断
+cli.g1.not.using.g1=目标JVM (PID %s) 未使用G1GC。当前GC: %s。请改用 'argus gc %s'。
+cli.g1.capturing=正在捕获G1 JFR %s秒…
+cli.g1.adaptive.on=自适应IHOP
+cli.g1.adaptive.off=手动IHOP
+cli.g1.title=G1诊断 (PID %s, %s, %s)
+cli.g1.identity.label=配置
+cli.g1.heap.label=堆
+cli.g1.regions.label=区域
+cli.g1.cycles.label=周期
+cli.g1.evac.label=疏散
+cli.g1.evac.failed=窗口内%s次失败
+cli.g1.evac.ok=无失败
+cli.g1.mmu.label=MMU
+cli.g1.ihop.label=IHOP
+cli.g1.humongous.label=巨型对象
+cli.g1.humongous.cycles=%s个周期由巨型对象分配触发
+cli.g1.humongous.alloc.header=捕获期间巨型对象分配位置Top (n=%s 事件)
+cli.g1.mixed.label=Mixed GC
+cli.g1.mixed.starved=并发周期结束后未出现Mixed停顿 — mixed-GC饥饿
+cli.g1.full.label=Full GC
+cli.g1.full.seen=观察到%s次Full GC — G1在稳态下不应发生Full GC
+cli.g1.verdict.label=诊断结论：
+cli.g1.verdict.healthy=G1运行正常。
+cli.g1.verdict.warning.mixed=观察到mixed-GC饥饿。
+cli.g1.verdict.warning.ihop=IHOP预测偏差 — 标记周期启动可能过晚。
+cli.g1.verdict.warning.humongous=观察到巨型对象分配周期。
+cli.g1.verdict.warning.pause=最大停顿时间超过目标2倍。
+cli.g1.verdict.unhealthy.full=G1中发生Full GC。
+cli.g1.verdict.unhealthy.evac=疏散失败 (to-space exhausted)。
+cli.g1.verdict.unhealthy.full.evac=Full GC + 疏散失败。
+cli.g1.recommend.label=建议：
+cli.g1.rec.full=提升 -Xmx (例如 -Xmx%sg) 并降低 -XX:InitiatingHeapOccupancyPercent
+cli.g1.rec.evac=提升 -Xmx 并考虑 -XX:G1ReservePercent=15 (默认10) 为疏散预留空间
+cli.g1.rec.humongous=提升 -XX:G1HeapRegionSize=%sm 使巨型对象阈值高于常见分配
+cli.g1.rec.mixed=降低 -XX:InitiatingHeapOccupancyPercent=%s 使并发周期在mixed调度前完成
+cli.g1.rec.ihop=禁用 -XX:-G1UseAdaptiveIHOP 并固定 -XX:InitiatingHeapOccupancyPercent，或提升堆
+cli.g1.rec.profile=分配性能分析: argus profile <PID> --event=alloc
+cli.g1.save.success=已保存G1基线: %s
+cli.g1.save.failed=保存基线失败: %s
+cli.g1.diff.failed=加载基线失败: %s
+cli.g1.watch.banner=每%s秒监视G1 (Ctrl-C停止)
+cli.g1.watch.summary=已监视%s次 · Full GC %s次 · 疏散失败 %s次 · 巨型对象周期 %s次
+cli.g1.diff.header=G1 Diff (基线 %s → 现在 %s, %s)
+cli.g1.diff.regression.new=新增
+cli.g1.diff.row.committed=堆提交
+cli.g1.diff.row.fullgc=Full GC
+cli.g1.diff.row.evac=疏散失败
+cli.g1.diff.row.mixed=Mixed饥饿
+cli.g1.diff.row.humongous=巨型对象周期
+cli.g1.diff.row.maxpause=最大停顿
+cli.g1.diff.row.mmu=最小MMU
+

--- a/argus-cli/src/main/resources/messages_zh.properties
+++ b/argus-cli/src/main/resources/messages_zh.properties
@@ -747,4 +747,5 @@ cli.g1.diff.row.mixed=Mixed饥饿
 cli.g1.diff.row.humongous=巨型对象周期
 cli.g1.diff.row.maxpause=最大停顿
 cli.g1.diff.row.mmu=最小MMU
+cli.g1.diff.row.ihop=IHOP预测偏差
 

--- a/argus-diagnostics/src/main/java/io/argus/diagnostics/doctor/DoctorEngine.java
+++ b/argus-diagnostics/src/main/java/io/argus/diagnostics/doctor/DoctorEngine.java
@@ -32,7 +32,10 @@ public final class DoctorEngine {
             new ZgcCycleOverlapRule(),
             new G1FullGcRule(),
             new G1RegionSizeRule(),
-            new G1IhopConfigurationRule()
+            new G1IhopConfigurationRule(),
+            new G1EvacuationFailureRule(),
+            new G1MixedStarvationRule(),
+            new G1HumongousPressureRule()
     );
 
     /**

--- a/argus-diagnostics/src/main/java/io/argus/diagnostics/doctor/DoctorEngine.java
+++ b/argus-diagnostics/src/main/java/io/argus/diagnostics/doctor/DoctorEngine.java
@@ -29,7 +29,10 @@ public final class DoctorEngine {
             new FinalizerQueueRule(),
             new GcAlgorithmRule(),
             new ZgcSoftMaxBreachRule(),
-            new ZgcCycleOverlapRule()
+            new ZgcCycleOverlapRule(),
+            new G1FullGcRule(),
+            new G1RegionSizeRule(),
+            new G1IhopConfigurationRule()
     );
 
     /**

--- a/argus-diagnostics/src/main/java/io/argus/diagnostics/doctor/JvmSnapshot.java
+++ b/argus-diagnostics/src/main/java/io/argus/diagnostics/doctor/JvmSnapshot.java
@@ -1,5 +1,7 @@
 package io.argus.diagnostics.doctor;
 
+import io.argus.diagnostics.gclog.G1Stats;
+
 import java.util.List;
 import java.util.Map;
 
@@ -67,6 +69,11 @@ public final class JvmSnapshot {
     // "Other", "Internal", "Java Heap") so callers must match case-insensitively.
     private final Map<String, Long> nmtCommittedKbByCategory;
 
+    // G1Stats — populated by JvmSnapshotCollector when GC log file is detected
+    // via -Xlog:gc:file=<path>. G1Stats.empty() when no log was readable or the
+    // collector isn't G1.
+    private final G1Stats g1Stats;
+
     public JvmSnapshot(long heapUsed, long heapMax, long heapCommitted, long nonHeapUsed,
                        Map<String, PoolInfo> memoryPools,
                        List<GcInfo> collectors, long totalGcCount, long totalGcTimeMs, long uptimeMs,
@@ -120,6 +127,31 @@ public final class JvmSnapshot {
                        long maxRecentPauseMs,
                        long codeCacheUsedKb, long codeCacheSizeKb,
                        Map<String, Long> nmtCommittedKbByCategory) {
+        this(heapUsed, heapMax, heapCommitted, nonHeapUsed, memoryPools,
+                collectors, totalGcCount, totalGcTimeMs, uptimeMs,
+                processCpuLoad, systemCpuLoad, availableProcessors,
+                threadCount, daemonThreadCount, peakThreadCount,
+                threadStates, deadlockedThreads, bufferPools,
+                loadedClassCount, totalLoadedClassCount, unloadedClassCount,
+                pendingFinalization, vmName, vmVersion, gcAlgorithm, vmFlags,
+                maxRecentPauseMs, codeCacheUsedKb, codeCacheSizeKb,
+                nmtCommittedKbByCategory, null);
+    }
+
+    public JvmSnapshot(long heapUsed, long heapMax, long heapCommitted, long nonHeapUsed,
+                       Map<String, PoolInfo> memoryPools,
+                       List<GcInfo> collectors, long totalGcCount, long totalGcTimeMs, long uptimeMs,
+                       double processCpuLoad, double systemCpuLoad, int availableProcessors,
+                       int threadCount, int daemonThreadCount, int peakThreadCount,
+                       Map<String, Integer> threadStates, int deadlockedThreads,
+                       List<BufferInfo> bufferPools,
+                       int loadedClassCount, long totalLoadedClassCount, long unloadedClassCount,
+                       int pendingFinalization,
+                       String vmName, String vmVersion, String gcAlgorithm, List<String> vmFlags,
+                       long maxRecentPauseMs,
+                       long codeCacheUsedKb, long codeCacheSizeKb,
+                       Map<String, Long> nmtCommittedKbByCategory,
+                       G1Stats g1Stats) {
         this.heapUsed = heapUsed;
         this.heapMax = heapMax;
         this.heapCommitted = heapCommitted;
@@ -150,6 +182,7 @@ public final class JvmSnapshot {
         this.codeCacheUsedKb = codeCacheUsedKb;
         this.codeCacheSizeKb = codeCacheSizeKb;
         this.nmtCommittedKbByCategory = nmtCommittedKbByCategory;
+        this.g1Stats = g1Stats == null ? G1Stats.empty() : g1Stats;
     }
 
     // Accessors
@@ -192,6 +225,8 @@ public final class JvmSnapshot {
     public long codeCacheSizeKb() { return codeCacheSizeKb; }
     /** NMT committed KB per category (verbatim jcmd names). Empty when NMT is off or unreadable. */
     public Map<String, Long> nmtCommittedKbByCategory() { return nmtCommittedKbByCategory; }
+    /** G1-specific stats extracted from the GC log; always non-null, may be {@code G1Stats.empty()}. */
+    public G1Stats g1Stats() { return g1Stats; }
 
     public static final class PoolInfo {
         private final String name;

--- a/argus-diagnostics/src/main/java/io/argus/diagnostics/doctor/JvmSnapshotCollector.java
+++ b/argus-diagnostics/src/main/java/io/argus/diagnostics/doctor/JvmSnapshotCollector.java
@@ -1,5 +1,7 @@
 package io.argus.diagnostics.doctor;
 
+import io.argus.diagnostics.gclog.G1Stats;
+import io.argus.diagnostics.gclog.GcLogParser;
 import io.argus.diagnostics.model.CompilerResult;
 import io.argus.diagnostics.model.GcUtilResult;
 import io.argus.diagnostics.model.NmtResult;
@@ -9,6 +11,8 @@ import io.argus.diagnostics.jcmd.JdkGcUtilProvider;
 import io.argus.diagnostics.jcmd.JdkNmtProvider;
 
 import java.lang.management.*;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -23,6 +27,13 @@ public final class JvmSnapshotCollector {
 
     private static final Pattern JCMD_HEAP_TOTAL_USED_KB = Pattern.compile("total\\s+(\\d+)K.*used\\s+(\\d+)K");
     private static final Pattern JCMD_HEAP_POOL_PARSE = Pattern.compile("(\\w[\\w\\s-]*)\\s+(?:total\\s+)?(\\d+)K.*used\\s+(\\d+)K");
+
+    /** Extracts the GC log file path from -Xlog:gc*:file=<path> style flags. Captures only the file= portion. */
+    private static final Pattern GC_LOG_FILE_FLAG = Pattern.compile(
+            "-Xlog:gc[^:\\s]*:(?:file=)?([^:\\s,]+)", Pattern.CASE_INSENSITIVE);
+
+    /** Maximum GC log size we'll re-parse in the snapshot path (10 MB). */
+    private static final long MAX_LOG_BYTES = 10L * 1024 * 1024;
 
     /**
      * Collect snapshot — routes to local or remote based on PID.
@@ -109,6 +120,9 @@ public final class JvmSnapshotCollector {
         CodeCacheSnapshot cc = collectCodeCache(pid);
         Map<String, Long> nmt = collectNmtCommittedKb(pid);
 
+        List<String> vmArgs = List.copyOf(rt.getInputArguments());
+        G1Stats g1Stats = extractG1Stats(vmArgs, gcAlgorithm);
+
         return new JvmSnapshot(
                 heap.getUsed(), heap.getMax(), heap.getCommitted(),
                 mem.getNonHeapMemoryUsage().getUsed(),
@@ -121,9 +135,10 @@ public final class JvmSnapshotCollector {
                 cl.getLoadedClassCount(), cl.getTotalLoadedClassCount(), cl.getUnloadedClassCount(),
                 mem.getObjectPendingFinalizationCount(),
                 rt.getVmName(), rt.getVmVersion(), gcAlgorithm,
-                List.copyOf(rt.getInputArguments()),
+                vmArgs,
                 maxRecentPauseMs,
-                cc.usedKb, cc.sizeKb, nmt
+                cc.usedKb, cc.sizeKb, nmt,
+                g1Stats
         );
     }
 
@@ -297,6 +312,9 @@ public final class JvmSnapshotCollector {
         CodeCacheSnapshot cc = collectCodeCache(pid);
         Map<String, Long> nmt = collectNmtCommittedKb(pid);
 
+        List<String> remoteVmArgs = List.copyOf(vmFlags);
+        G1Stats g1Stats = extractG1Stats(remoteVmArgs, gcAlgorithm);
+
         return new JvmSnapshot(
                 heapUsed, heapMax, heapCommitted, nonHeapUsed,
                 Map.copyOf(pools),
@@ -307,10 +325,48 @@ public final class JvmSnapshotCollector {
                 List.of(),
                 0, 0, 0, 0,
                 vmName, vmVersion, gcAlgorithm,
-                List.copyOf(vmFlags),
+                remoteVmArgs,
                 maxRecentPauseMs,
-                cc.usedKb, cc.sizeKb, nmt
+                cc.usedKb, cc.sizeKb, nmt,
+                g1Stats
         );
+    }
+
+    /**
+     * Extracts G1-specific stats by detecting {@code -Xlog:gc*:file=<path>} in
+     * the VM arguments and parsing the log file. Returns {@link G1Stats#empty()}
+     * when:
+     * <ul>
+     *   <li>the collector is not G1,</li>
+     *   <li>no GC log file flag is present,</li>
+     *   <li>the log file is missing, unreadable, or larger than {@link #MAX_LOG_BYTES}.</li>
+     * </ul>
+     * Best-effort — failures are added to {@link #warnings} but never throw.
+     */
+    static G1Stats extractG1Stats(List<String> vmArgs, String gcAlgorithm) {
+        if (vmArgs == null || vmArgs.isEmpty()) return G1Stats.empty();
+        if (gcAlgorithm == null || !gcAlgorithm.contains("G1")) return G1Stats.empty();
+
+        Path logPath = null;
+        for (String flag : vmArgs) {
+            Matcher m = GC_LOG_FILE_FLAG.matcher(flag);
+            if (m.find()) {
+                logPath = Path.of(m.group(1));
+                break;
+            }
+        }
+        if (logPath == null) return G1Stats.empty();
+
+        try {
+            if (!Files.isReadable(logPath)) return G1Stats.empty();
+            long size = Files.size(logPath);
+            if (size <= 0 || size > MAX_LOG_BYTES) return G1Stats.empty();
+            GcLogParser.ParseResult result = GcLogParser.parseWithPhases(logPath);
+            return result.g1Stats();
+        } catch (Exception e) {
+            warnings.get().add("GC log parse failed for " + logPath + ": " + e.getMessage());
+            return G1Stats.empty();
+        }
     }
 
     /** Best-effort code-cache totals; returns zeros on failure (doctor degrades gracefully). */

--- a/argus-diagnostics/src/main/java/io/argus/diagnostics/doctor/JvmSnapshotCollector.java
+++ b/argus-diagnostics/src/main/java/io/argus/diagnostics/doctor/JvmSnapshotCollector.java
@@ -28,9 +28,15 @@ public final class JvmSnapshotCollector {
     private static final Pattern JCMD_HEAP_TOTAL_USED_KB = Pattern.compile("total\\s+(\\d+)K.*used\\s+(\\d+)K");
     private static final Pattern JCMD_HEAP_POOL_PARSE = Pattern.compile("(\\w[\\w\\s-]*)\\s+(?:total\\s+)?(\\d+)K.*used\\s+(\\d+)K");
 
-    /** Extracts the GC log file path from -Xlog:gc*:file=<path> style flags. Captures only the file= portion. */
+    /**
+     * Extracts the GC log file path from -Xlog flags of the form
+     * {@code -Xlog:gc:file=<path>} or {@code -Xlog:gc*=info:file=<path>:time,level}.
+     * Requires the literal {@code :file=} marker — flags that only log to stdout/stderr
+     * (no file=) intentionally do not match, so callers know there is no log to tail.
+     * Captures the path verbatim into group 1.
+     */
     private static final Pattern GC_LOG_FILE_FLAG = Pattern.compile(
-            "-Xlog:gc[^:\\s]*:(?:file=)?([^:\\s,]+)", Pattern.CASE_INSENSITIVE);
+            "-Xlog:gc[^\\s]*?:file=([^:\\s,]+)", Pattern.CASE_INSENSITIVE);
 
     /** Maximum GC log size we'll re-parse in the snapshot path (10 MB). */
     private static final long MAX_LOG_BYTES = 10L * 1024 * 1024;

--- a/argus-diagnostics/src/main/java/io/argus/diagnostics/doctor/rules/G1EvacuationFailureRule.java
+++ b/argus-diagnostics/src/main/java/io/argus/diagnostics/doctor/rules/G1EvacuationFailureRule.java
@@ -1,0 +1,47 @@
+package io.argus.diagnostics.doctor.rules;
+
+import io.argus.diagnostics.doctor.*;
+
+import java.util.List;
+
+/**
+ * Detects G1 evacuation failure ("To-space exhausted") in the GC log.
+ *
+ * <p>G1's evacuation phase copies live objects from the collection set to
+ * survivor / old regions. When the JVM can't reserve enough free regions to
+ * complete the evacuation, it falls back to in-place compaction — extremely
+ * expensive and a strong signal of imminent OOM.
+ *
+ * <p>Fires CRITICAL when {@link io.argus.diagnostics.gclog.G1Stats#evacuationFailures()}
+ * is &gt; 0. Requires the target JVM to have {@code -Xlog:gc:file=<path>}
+ * configured so {@link JvmSnapshotCollector} can parse the log; otherwise
+ * the rule is silent.
+ * Skipped entirely for non-G1 collectors.
+ */
+public final class G1EvacuationFailureRule implements HealthRule {
+
+    @Override
+    public List<Finding> evaluate(JvmSnapshot s) {
+        if (!s.gcAlgorithm().contains("G1")) return List.of();
+
+        int failures = s.g1Stats().evacuationFailures();
+        if (failures <= 0) return List.of();
+
+        var b = Finding.builder(Severity.CRITICAL, "GC",
+                "G1 evacuation failure ('To-space exhausted') observed "
+                        + failures + " time" + (failures == 1 ? "" : "s"));
+
+        b.detail("Evacuation fell back to in-place compaction — extremely expensive and "
+                + "a strong signal of imminent OOM. Heap is too small or allocation rate "
+                + "exceeded G1's evacuation budget.");
+
+        b.recommend("Raise -Xmx, raise -XX:G1ReservePercent toward 15 (default 10) for "
+                + "evacuation headroom, and profile allocation rate with argus profile "
+                + "<PID> --event=alloc.");
+
+        b.flag("-XX:G1ReservePercent=15");
+        b.flag("-Xmx<raise>");
+
+        return List.of(b.build());
+    }
+}

--- a/argus-diagnostics/src/main/java/io/argus/diagnostics/doctor/rules/G1FullGcRule.java
+++ b/argus-diagnostics/src/main/java/io/argus/diagnostics/doctor/rules/G1FullGcRule.java
@@ -1,0 +1,49 @@
+package io.argus.diagnostics.doctor.rules;
+
+import io.argus.diagnostics.doctor.*;
+
+import java.util.List;
+
+/**
+ * Detects Full GC pauses under G1.
+ *
+ * <p>G1 is designed to never trigger a Full GC during steady-state operation.
+ * Mixed cycles and concurrent marking should reclaim old-gen space before
+ * pressure forces a Full GC. A non-zero {@code G1 Old Generation} collector
+ * count therefore indicates one of: extreme allocation burst, evacuation
+ * failure, sustained humongous pressure, or memory leak.
+ *
+ * <p>Fires CRITICAL when the {@code G1 Old Generation} collector has any
+ * recorded GC count.
+ * Skipped entirely for non-G1 collectors.
+ */
+public final class G1FullGcRule implements HealthRule {
+
+    @Override
+    public List<Finding> evaluate(JvmSnapshot s) {
+        if (!s.gcAlgorithm().contains("G1")) return List.of();
+
+        for (JvmSnapshot.GcInfo info : s.collectors()) {
+            if (!info.name().contains("G1 Old Generation")) continue;
+            if (info.count() <= 0) continue;
+
+            var b = Finding.builder(Severity.CRITICAL, "GC",
+                    "G1 Full GC observed (" + info.count() + " occurrence"
+                            + (info.count() == 1 ? "" : "s") + ")");
+
+            b.detail("G1 Old Generation collector recorded " + info.count()
+                    + " GC events totalling " + info.timeMs()
+                    + "ms — G1 should not Full GC in steady state");
+
+            b.recommend("Inspect with argus heap / argus diff to find the allocator that overwhelmed G1; "
+                    + "raise -Xmx, lower -XX:InitiatingHeapOccupancyPercent (default 45), "
+                    + "or run argus g1 <PID> for JFR-level evacuation detail.");
+
+            b.flag("-Xmx<raise>");
+            b.flag("-XX:InitiatingHeapOccupancyPercent=<lower>");
+
+            return List.of(b.build());
+        }
+        return List.of();
+    }
+}

--- a/argus-diagnostics/src/main/java/io/argus/diagnostics/doctor/rules/G1HumongousPressureRule.java
+++ b/argus-diagnostics/src/main/java/io/argus/diagnostics/doctor/rules/G1HumongousPressureRule.java
@@ -1,0 +1,69 @@
+package io.argus.diagnostics.doctor.rules;
+
+import io.argus.diagnostics.doctor.*;
+
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Detects sustained humongous-allocation pressure under G1.
+ *
+ * <p>G1 marks any allocation ≥ regionSize/2 as humongous, allocating it
+ * directly into old gen. Frequent humongous allocations trigger concurrent
+ * cycles regardless of IHOP and can cause fragmentation; a humongous region
+ * count above ~10% of total regions indicates a tuning problem (region size
+ * too small for the workload).
+ *
+ * <p>Fires WARNING when either:
+ * <ul>
+ *   <li>{@link io.argus.diagnostics.gclog.G1Stats#humongousAllocationCycles()} ≥ 3, OR</li>
+ *   <li>peak humongous regions ≥ 10 with default region size (no explicit
+ *       {@code -XX:G1HeapRegionSize}).</li>
+ * </ul>
+ * Skipped entirely for non-G1 collectors.
+ */
+public final class G1HumongousPressureRule implements HealthRule {
+
+    static final int MIN_HUMONGOUS_CYCLES = 3;
+    static final int PEAK_REGION_THRESHOLD = 10;
+
+    private static final Pattern REGION_SIZE_FLAG = Pattern.compile(
+            "-XX:G1HeapRegionSize=(\\d+)([KMG]?)", Pattern.CASE_INSENSITIVE);
+
+    @Override
+    public List<Finding> evaluate(JvmSnapshot s) {
+        if (!s.gcAlgorithm().contains("G1")) return List.of();
+
+        var stats = s.g1Stats();
+        boolean cyclesHigh = stats.humongousAllocationCycles() >= MIN_HUMONGOUS_CYCLES;
+        boolean peakHighOnDefault = stats.humongousRegionsPeak() >= PEAK_REGION_THRESHOLD
+                && !hasExplicitRegionSize(s.vmFlags());
+
+        if (!cyclesHigh && !peakHighOnDefault) return List.of();
+
+        var b = Finding.builder(Severity.WARNING, "GC",
+                "Sustained G1 humongous-allocation pressure (" + stats.humongousAllocationCycles()
+                        + " cycles, peak " + stats.humongousRegionsPeak() + " regions)");
+
+        b.detail("Allocations ≥ regionSize/2 are forced into old gen and trigger concurrent "
+                + "cycles regardless of IHOP. Frequent humongous activity points to a "
+                + "region size too small for the workload's largest allocations.");
+
+        b.recommend("Profile humongous allocation sites with argus g1 <PID> "
+                + "and raise -XX:G1HeapRegionSize to 2× the largest observed humongous "
+                + "allocation (so it's no longer marked humongous).");
+
+        b.flag("-XX:G1HeapRegionSize=16m");
+
+        return List.of(b.build());
+    }
+
+    static boolean hasExplicitRegionSize(List<String> vmFlags) {
+        for (String flag : vmFlags) {
+            Matcher m = REGION_SIZE_FLAG.matcher(flag);
+            if (m.find()) return true;
+        }
+        return false;
+    }
+}

--- a/argus-diagnostics/src/main/java/io/argus/diagnostics/doctor/rules/G1IhopConfigurationRule.java
+++ b/argus-diagnostics/src/main/java/io/argus/diagnostics/doctor/rules/G1IhopConfigurationRule.java
@@ -1,0 +1,77 @@
+package io.argus.diagnostics.doctor.rules;
+
+import io.argus.diagnostics.doctor.*;
+
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Detects misconfigured G1 IHOP (Initiating Heap Occupancy Percent).
+ *
+ * <p>IHOP controls when G1 starts the concurrent marking cycle. If it's too high
+ * (e.g. 70+%), the cycle may not finish before old gen fills, forcing Full GC.
+ * If adaptive IHOP is disabled while the manual value is high, G1 cannot react
+ * to allocation-rate spikes.
+ *
+ * <p>Fires WARNING when:
+ * <ul>
+ *   <li>{@code -XX:-G1UseAdaptiveIHOP} (adaptive disabled) AND
+ *       {@code -XX:InitiatingHeapOccupancyPercent &gt;= 70}.</li>
+ * </ul>
+ * Skipped entirely for non-G1 collectors.
+ */
+public final class G1IhopConfigurationRule implements HealthRule {
+
+    private static final Pattern IHOP_FLAG = Pattern.compile(
+            "-XX:InitiatingHeapOccupancyPercent=(\\d+)", Pattern.CASE_INSENSITIVE);
+
+    private static final Pattern ADAPTIVE_IHOP_FLAG = Pattern.compile(
+            "-XX:([+-])G1UseAdaptiveIHOP", Pattern.CASE_INSENSITIVE);
+
+    static final int HIGH_IHOP_THRESHOLD = 70;
+
+    @Override
+    public List<Finding> evaluate(JvmSnapshot s) {
+        if (!s.gcAlgorithm().contains("G1")) return List.of();
+
+        Boolean adaptive = parseAdaptive(s.vmFlags());
+        int     ihop     = parseIhop(s.vmFlags());
+
+        if (adaptive == null || adaptive) return List.of(); // adaptive on (default) — fine
+        if (ihop < HIGH_IHOP_THRESHOLD)   return List.of();
+
+        var b = Finding.builder(Severity.WARNING, "GC",
+                "Adaptive IHOP disabled with high manual threshold (" + ihop + "%)");
+
+        b.detail("-XX:-G1UseAdaptiveIHOP -XX:InitiatingHeapOccupancyPercent=" + ihop
+                + " — concurrent cycle may not finish before old gen fills, risking Full GC");
+
+        b.recommend("Re-enable adaptive IHOP with -XX:+G1UseAdaptiveIHOP, "
+                + "or lower -XX:InitiatingHeapOccupancyPercent to 45–55 to start marking earlier.");
+
+        b.flag("-XX:+G1UseAdaptiveIHOP");
+        b.flag("-XX:InitiatingHeapOccupancyPercent=45");
+
+        return List.of(b.build());
+    }
+
+    static Boolean parseAdaptive(List<String> vmFlags) {
+        for (String flag : vmFlags) {
+            Matcher m = ADAPTIVE_IHOP_FLAG.matcher(flag);
+            if (m.find()) return "+".equals(m.group(1));
+        }
+        return null;
+    }
+
+    static int parseIhop(List<String> vmFlags) {
+        for (String flag : vmFlags) {
+            Matcher m = IHOP_FLAG.matcher(flag);
+            if (m.find()) {
+                try { return Integer.parseInt(m.group(1)); }
+                catch (NumberFormatException ignored) {}
+            }
+        }
+        return 45; // JVM default
+    }
+}

--- a/argus-diagnostics/src/main/java/io/argus/diagnostics/doctor/rules/G1MixedStarvationRule.java
+++ b/argus-diagnostics/src/main/java/io/argus/diagnostics/doctor/rules/G1MixedStarvationRule.java
@@ -1,0 +1,49 @@
+package io.argus.diagnostics.doctor.rules;
+
+import io.argus.diagnostics.doctor.*;
+
+import java.util.List;
+
+/**
+ * Detects G1 mixed-GC starvation: concurrent mark cycles complete but no
+ * Mixed pause follows within the observed log window.
+ *
+ * <p>Under normal G1 operation, a concurrent mark cycle is followed by 8
+ * (or {@code -XX:G1MixedGCCountTarget}) Mixed pauses that incrementally clean
+ * up old regions. If concurrent cycles fire but Mixed pauses don't, old gen
+ * keeps growing until a Full GC is forced — the worst possible outcome under G1.
+ *
+ * <p>Fires WARNING when {@link io.argus.diagnostics.gclog.G1Stats#mixedStarvationSuspected()}
+ * returns {@code true} AND at least 2 concurrent cycles have completed (to
+ * avoid false positives on very short log windows).
+ * Skipped entirely for non-G1 collectors.
+ */
+public final class G1MixedStarvationRule implements HealthRule {
+
+    static final int MIN_CONCURRENT_CYCLES = 2;
+
+    @Override
+    public List<Finding> evaluate(JvmSnapshot s) {
+        if (!s.gcAlgorithm().contains("G1")) return List.of();
+
+        var stats = s.g1Stats();
+        if (!stats.mixedStarvationSuspected()) return List.of();
+        if (stats.concurrentCycleMarkers() < MIN_CONCURRENT_CYCLES) return List.of();
+
+        var b = Finding.builder(Severity.WARNING, "GC",
+                "G1 mixed-GC starvation suspected (" + stats.concurrentCycleMarkers()
+                        + " concurrent cycles, 0 Mixed pauses)");
+
+        b.detail("Concurrent marking is finishing but G1 is not running Mixed pauses to "
+                + "reclaim old regions. Old gen will keep growing until a Full GC is forced.");
+
+        b.recommend("Lower -XX:InitiatingHeapOccupancyPercent (try 35–40) so concurrent "
+                + "cycles complete earlier, and verify -XX:G1MixedGCCountTarget (default 8) "
+                + "and -XX:G1OldCSetRegionThresholdPercent (default 10).");
+
+        b.flag("-XX:InitiatingHeapOccupancyPercent=40");
+        b.flag("-XX:G1MixedGCCountTarget=8");
+
+        return List.of(b.build());
+    }
+}

--- a/argus-diagnostics/src/main/java/io/argus/diagnostics/doctor/rules/G1RegionSizeRule.java
+++ b/argus-diagnostics/src/main/java/io/argus/diagnostics/doctor/rules/G1RegionSizeRule.java
@@ -1,0 +1,94 @@
+package io.argus.diagnostics.doctor.rules;
+
+import io.argus.diagnostics.doctor.*;
+
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Detects mis-sized G1 regions for the current heap.
+ *
+ * <p>G1's default region size scales as a power of two between 1MB and 32MB based
+ * on max heap, capped at 2048 regions. For very large heaps (&gt; 64GB) the JVM may
+ * cap at 32MB regions and run with &gt; 2048 regions — at that point an explicit
+ * override is worth considering. For small heaps (&lt; 2GB) with no explicit override,
+ * tiny regions (1–2MB) make the humongous threshold very low (≥ regionSize/2) and
+ * mark many normal allocations as humongous.
+ *
+ * <p>Fires WARNING when:
+ * <ul>
+ *   <li>heap &gt; 32 GB AND no explicit {@code -XX:G1HeapRegionSize}, OR</li>
+ *   <li>explicit {@code -XX:G1HeapRegionSize} smaller than the JVM default for
+ *       this heap (humongous-allocation risk).</li>
+ * </ul>
+ * Skipped entirely for non-G1 collectors.
+ */
+public final class G1RegionSizeRule implements HealthRule {
+
+    private static final Pattern REGION_SIZE_FLAG = Pattern.compile(
+            "-XX:G1HeapRegionSize=(\\d+)([KMG]?)", Pattern.CASE_INSENSITIVE);
+
+    static final long LARGE_HEAP_BYTES = 32L * 1024 * 1024 * 1024; // 32 GB
+
+    @Override
+    public List<Finding> evaluate(JvmSnapshot s) {
+        if (!s.gcAlgorithm().contains("G1")) return List.of();
+        if (s.heapMax() <= 0) return List.of();
+
+        long explicitRegionBytes = explicitRegionBytes(s.vmFlags());
+
+        // Large heap, no explicit region size — JVM caps at 32MB regions which may
+        // mean very high region count; suggest explicit tuning.
+        if (s.heapMax() > LARGE_HEAP_BYTES && explicitRegionBytes <= 0) {
+            var b = Finding.builder(Severity.WARNING, "GC",
+                    "Large heap on G1 without explicit -XX:G1HeapRegionSize");
+            b.detail(String.format(
+                    "heap max %.1f GB with default region sizing; G1 will cap regions at 32MB "
+                            + "and the resulting region count may exceed 2048",
+                    s.heapMax() / 1_073_741_824.0));
+            b.recommend("Set -XX:G1HeapRegionSize=32m (or 64m for >128GB heaps) "
+                    + "to bound region count and predictable evacuation cost.");
+            b.flag("-XX:G1HeapRegionSize=32m");
+            return List.of(b.build());
+        }
+
+        // Tiny explicit region on a non-tiny heap → humongous spike risk.
+        if (explicitRegionBytes > 0 && explicitRegionBytes <= 2L * 1024 * 1024
+                && s.heapMax() >= 4L * 1024 * 1024 * 1024) {
+            var b = Finding.builder(Severity.WARNING, "GC",
+                    "Tiny G1 region size on a ≥ 4 GB heap (humongous spike risk)");
+            b.detail(String.format(
+                    "-XX:G1HeapRegionSize=%dM with -Xmx %.1f GB — "
+                            + "humongous threshold is %dKB, common allocations may be marked humongous",
+                    explicitRegionBytes / (1024 * 1024),
+                    s.heapMax() / 1_073_741_824.0,
+                    (explicitRegionBytes / 1024) / 2));
+            b.recommend("Raise -XX:G1HeapRegionSize to 8m or 16m and re-profile humongous incidence.");
+            b.flag("-XX:G1HeapRegionSize=8m");
+            return List.of(b.build());
+        }
+
+        return List.of();
+    }
+
+    static long explicitRegionBytes(List<String> vmFlags) {
+        for (String flag : vmFlags) {
+            Matcher m = REGION_SIZE_FLAG.matcher(flag);
+            if (m.find()) {
+                long v;
+                try { v = Long.parseLong(m.group(1)); }
+                catch (NumberFormatException e) { continue; }
+                String unit = m.group(2);
+                if (unit == null || unit.isEmpty()) return v; // bytes
+                switch (unit.toUpperCase()) {
+                    case "K": return v * 1024L;
+                    case "M": return v * 1024L * 1024L;
+                    case "G": return v * 1024L * 1024L * 1024L;
+                    default:  return v;
+                }
+            }
+        }
+        return 0;
+    }
+}

--- a/argus-diagnostics/src/main/java/io/argus/diagnostics/g1/G1Baseline.java
+++ b/argus-diagnostics/src/main/java/io/argus/diagnostics/g1/G1Baseline.java
@@ -1,0 +1,435 @@
+package io.argus.diagnostics.g1;
+
+import io.argus.diagnostics.format.DiagnosticsFormat;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Instant;
+import java.time.format.DateTimeParseException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Persistent G1GC snapshot for trend / diff analysis.
+ *
+ * <p>Serialised as a plain-text properties file (key=value, one per line) so
+ * no JSON library is required. Mirrors {@link io.argus.diagnostics.zgc.ZgcBaseline}.
+ *
+ * <p>File format:
+ * <pre>
+ * version=1
+ * capturedAt=2026-05-27T12:00:00Z
+ * pid=12345
+ * regionSizeMb=4
+ * targetPauseMs=200
+ * ihopPercent=45
+ * adaptiveIhop=true
+ * heapCommittedBytes=4294967296
+ * maxHeapBytes=8589934592
+ * totalRegions=2048
+ * edenRegions=400
+ * survivorRegions=20
+ * oldRegions=900
+ * humongousRegions=8
+ * youngCycles=120
+ * mixedCycles=8
+ * concurrentCycles=2
+ * fullGcCycles=0
+ * avgYoungPauseMs=42.10
+ * avgMixedPauseMs=85.50
+ * maxPauseMs=120.40
+ * bytesCopiedYoung=2147483648
+ * bytesCopiedOld=536870912
+ * evacuationFailures=0
+ * avgMmuPercent=95.20
+ * minMmuPercent=88.10
+ * predictedIhopPercent=45.00
+ * actualIhopPercent=46.50
+ * humongousAllocationCycles=0
+ * fullGcSeen=false
+ * evacuationFailureSeen=false
+ * mixedStarvation=false
+ * ihopMistimed=false
+ * topHumongousFrames=com.example.Foo.bar(Foo.java:42)|3|16777216;com.example.Bar.baz(Bar.java:10)|1|33554432
+ * </pre>
+ */
+public final class G1Baseline {
+
+    public final Instant capturedAt;
+    public final int     pid;
+    public final int     regionSizeMb;
+    public final int     targetPauseMs;
+    public final int     ihopPercent;
+    public final boolean adaptiveIhop;
+    public final long    heapCommittedBytes;
+    public final long    maxHeapBytes;
+    public final int     totalRegions;
+    public final int     edenRegions;
+    public final int     survivorRegions;
+    public final int     oldRegions;
+    public final int     humongousRegions;
+    public final int     youngCycles;
+    public final int     mixedCycles;
+    public final int     concurrentCycles;
+    public final int     fullGcCycles;
+    public final double  avgYoungPauseMs;
+    public final double  avgMixedPauseMs;
+    public final double  maxPauseMs;
+    public final long    bytesCopiedYoung;
+    public final long    bytesCopiedOld;
+    public final int     evacuationFailures;
+    public final double  avgMmuPercent;
+    public final double  minMmuPercent;
+    public final double  predictedIhopPercent;
+    public final double  actualIhopPercent;
+    public final int     humongousAllocationCycles;
+    public final boolean fullGcSeen;
+    public final boolean evacuationFailureSeen;
+    public final boolean mixedStarvation;
+    public final boolean ihopMistimed;
+
+    /** Each entry is {@code "frame|count|maxBytes"}, semicolon-separated in the file. */
+    public final List<String> topHumongousFrames;
+
+    public G1Baseline(
+            Instant capturedAt, int pid,
+            int regionSizeMb, int targetPauseMs, int ihopPercent, boolean adaptiveIhop,
+            long heapCommittedBytes, long maxHeapBytes,
+            int totalRegions, int edenRegions, int survivorRegions,
+            int oldRegions, int humongousRegions,
+            int youngCycles, int mixedCycles, int concurrentCycles, int fullGcCycles,
+            double avgYoungPauseMs, double avgMixedPauseMs, double maxPauseMs,
+            long bytesCopiedYoung, long bytesCopiedOld, int evacuationFailures,
+            double avgMmuPercent, double minMmuPercent,
+            double predictedIhopPercent, double actualIhopPercent,
+            int humongousAllocationCycles,
+            boolean fullGcSeen, boolean evacuationFailureSeen,
+            boolean mixedStarvation, boolean ihopMistimed,
+            List<String> topHumongousFrames) {
+        this.capturedAt              = capturedAt;
+        this.pid                     = pid;
+        this.regionSizeMb            = regionSizeMb;
+        this.targetPauseMs           = targetPauseMs;
+        this.ihopPercent             = ihopPercent;
+        this.adaptiveIhop            = adaptiveIhop;
+        this.heapCommittedBytes      = heapCommittedBytes;
+        this.maxHeapBytes            = maxHeapBytes;
+        this.totalRegions            = totalRegions;
+        this.edenRegions             = edenRegions;
+        this.survivorRegions         = survivorRegions;
+        this.oldRegions              = oldRegions;
+        this.humongousRegions        = humongousRegions;
+        this.youngCycles             = youngCycles;
+        this.mixedCycles             = mixedCycles;
+        this.concurrentCycles        = concurrentCycles;
+        this.fullGcCycles            = fullGcCycles;
+        this.avgYoungPauseMs         = avgYoungPauseMs;
+        this.avgMixedPauseMs         = avgMixedPauseMs;
+        this.maxPauseMs              = maxPauseMs;
+        this.bytesCopiedYoung        = bytesCopiedYoung;
+        this.bytesCopiedOld          = bytesCopiedOld;
+        this.evacuationFailures      = evacuationFailures;
+        this.avgMmuPercent           = avgMmuPercent;
+        this.minMmuPercent           = minMmuPercent;
+        this.predictedIhopPercent    = predictedIhopPercent;
+        this.actualIhopPercent       = actualIhopPercent;
+        this.humongousAllocationCycles = humongousAllocationCycles;
+        this.fullGcSeen              = fullGcSeen;
+        this.evacuationFailureSeen   = evacuationFailureSeen;
+        this.mixedStarvation         = mixedStarvation;
+        this.ihopMistimed            = ihopMistimed;
+        this.topHumongousFrames      = topHumongousFrames == null ? List.of() : List.copyOf(topHumongousFrames);
+    }
+
+    // ── Severity ─────────────────────────────────────────────────────────────
+
+    public enum Severity { INFO, WARN, REGRESSION }
+
+    public static final class DiffRow {
+        private final String label;
+        private final String baselineValue;
+        private final String currentValue;
+        private final String delta;
+        private final Severity severity;
+
+        public DiffRow(String label, String baselineValue, String currentValue,
+                       String delta, Severity severity) {
+            this.label = label;
+            this.baselineValue = baselineValue;
+            this.currentValue = currentValue;
+            this.delta = delta;
+            this.severity = severity;
+        }
+
+        public String label() { return label; }
+        public String baselineValue() { return baselineValue; }
+        public String currentValue() { return currentValue; }
+        public String delta() { return delta; }
+        public Severity severity() { return severity; }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (!(o instanceof DiffRow)) return false;
+            DiffRow that = (DiffRow) o;
+            return java.util.Objects.equals(label, that.label)
+                    && java.util.Objects.equals(baselineValue, that.baselineValue)
+                    && java.util.Objects.equals(currentValue, that.currentValue)
+                    && java.util.Objects.equals(delta, that.delta)
+                    && severity == that.severity;
+        }
+
+        @Override
+        public int hashCode() {
+            return java.util.Objects.hash(label, baselineValue, currentValue, delta, severity);
+        }
+    }
+
+    // ── save ─────────────────────────────────────────────────────────────────
+
+    public static void save(Path file, G1Diagnosis d, int pid) throws IOException {
+        StringBuilder humSb = new StringBuilder();
+        for (int i = 0; i < d.humongousHotspots.size(); i++) {
+            G1Diagnosis.HumongousHotspot h = d.humongousHotspots.get(i);
+            if (i > 0) humSb.append(';');
+            humSb.append(escapeField(h.frame())).append('|')
+                    .append(h.count()).append('|').append(h.maxBytes());
+        }
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("version=1\n");
+        sb.append("capturedAt=").append(Instant.now()).append('\n');
+        sb.append("pid=").append(pid).append('\n');
+        sb.append("regionSizeMb=").append(d.regionSizeMb).append('\n');
+        sb.append("targetPauseMs=").append(d.targetPauseMs).append('\n');
+        sb.append("ihopPercent=").append(d.ihopPercent).append('\n');
+        sb.append("adaptiveIhop=").append(d.adaptiveIhop).append('\n');
+        sb.append("heapCommittedBytes=").append(d.heapCommittedBytes).append('\n');
+        sb.append("maxHeapBytes=").append(d.maxHeapBytes).append('\n');
+        sb.append("totalRegions=").append(d.totalRegions).append('\n');
+        sb.append("edenRegions=").append(d.edenRegions).append('\n');
+        sb.append("survivorRegions=").append(d.survivorRegions).append('\n');
+        sb.append("oldRegions=").append(d.oldRegions).append('\n');
+        sb.append("humongousRegions=").append(d.humongousRegions).append('\n');
+        sb.append("youngCycles=").append(d.youngCycles).append('\n');
+        sb.append("mixedCycles=").append(d.mixedCycles).append('\n');
+        sb.append("concurrentCycles=").append(d.concurrentCycles).append('\n');
+        sb.append("fullGcCycles=").append(d.fullGcCycles).append('\n');
+        sb.append("avgYoungPauseMs=").append(String.format("%.6f", d.avgYoungPauseMs)).append('\n');
+        sb.append("avgMixedPauseMs=").append(String.format("%.6f", d.avgMixedPauseMs)).append('\n');
+        sb.append("maxPauseMs=").append(String.format("%.6f", d.maxPauseMs)).append('\n');
+        sb.append("bytesCopiedYoung=").append(d.bytesCopiedYoung).append('\n');
+        sb.append("bytesCopiedOld=").append(d.bytesCopiedOld).append('\n');
+        sb.append("evacuationFailures=").append(d.evacuationFailures).append('\n');
+        sb.append("avgMmuPercent=").append(String.format("%.6f", d.avgMmuPercent)).append('\n');
+        sb.append("minMmuPercent=").append(String.format("%.6f", d.minMmuPercent)).append('\n');
+        sb.append("predictedIhopPercent=").append(String.format("%.6f", d.predictedIhopPercent)).append('\n');
+        sb.append("actualIhopPercent=").append(String.format("%.6f", d.actualIhopPercent)).append('\n');
+        sb.append("humongousAllocationCycles=").append(d.humongousAllocationCycles).append('\n');
+        sb.append("fullGcSeen=").append(d.fullGcSeen).append('\n');
+        sb.append("evacuationFailureSeen=").append(d.evacuationFailureSeen).append('\n');
+        sb.append("mixedStarvation=").append(d.mixedStarvation).append('\n');
+        sb.append("ihopMistimed=").append(d.ihopMistimed).append('\n');
+        sb.append("topHumongousFrames=").append(humSb).append('\n');
+
+        Files.writeString(file, sb.toString());
+    }
+
+    // ── load ─────────────────────────────────────────────────────────────────
+
+    public static G1Baseline load(Path file) throws IOException {
+        String t = Files.readString(file);
+        return new G1Baseline(
+                parseInstant(t, "capturedAt"),
+                (int) parseLong(t, "pid", 0),
+                (int) parseLong(t, "regionSizeMb", 0),
+                (int) parseLong(t, "targetPauseMs", 0),
+                (int) parseLong(t, "ihopPercent", 0),
+                parseBool(t, "adaptiveIhop", false),
+                parseLong(t, "heapCommittedBytes", 0),
+                parseLong(t, "maxHeapBytes", 0),
+                (int) parseLong(t, "totalRegions", 0),
+                (int) parseLong(t, "edenRegions", 0),
+                (int) parseLong(t, "survivorRegions", 0),
+                (int) parseLong(t, "oldRegions", 0),
+                (int) parseLong(t, "humongousRegions", 0),
+                (int) parseLong(t, "youngCycles", 0),
+                (int) parseLong(t, "mixedCycles", 0),
+                (int) parseLong(t, "concurrentCycles", 0),
+                (int) parseLong(t, "fullGcCycles", 0),
+                parseDouble(t, "avgYoungPauseMs", 0.0),
+                parseDouble(t, "avgMixedPauseMs", 0.0),
+                parseDouble(t, "maxPauseMs", 0.0),
+                parseLong(t, "bytesCopiedYoung", 0),
+                parseLong(t, "bytesCopiedOld", 0),
+                (int) parseLong(t, "evacuationFailures", 0),
+                parseDouble(t, "avgMmuPercent", 0.0),
+                parseDouble(t, "minMmuPercent", 0.0),
+                parseDouble(t, "predictedIhopPercent", 0.0),
+                parseDouble(t, "actualIhopPercent", 0.0),
+                (int) parseLong(t, "humongousAllocationCycles", 0),
+                parseBool(t, "fullGcSeen", false),
+                parseBool(t, "evacuationFailureSeen", false),
+                parseBool(t, "mixedStarvation", false),
+                parseBool(t, "ihopMistimed", false),
+                parseHumongousFrames(t));
+    }
+
+    // ── diff ─────────────────────────────────────────────────────────────────
+
+    public static List<DiffRow> diff(G1Baseline baseline, G1Diagnosis current) {
+        List<DiffRow> rows = new ArrayList<>();
+
+        // Heap committed
+        long baseCommit = baseline.heapCommittedBytes;
+        long curCommit  = current.heapCommittedBytes;
+        long commitDelta = curCommit - baseCommit;
+        Severity commitSeverity = commitDelta > 0 ? WARN : INFO;
+        rows.add(new DiffRow("heapCommitted",
+                DiagnosticsFormat.formatBytes(baseCommit),
+                DiagnosticsFormat.formatBytes(curCommit),
+                formatBytesDelta(commitDelta), commitSeverity));
+
+        // Full GC
+        boolean baseFull = baseline.fullGcSeen;
+        boolean curFull  = current.fullGcSeen;
+        Severity fullSeverity = INFO;
+        if (!baseFull && curFull) fullSeverity = REGRESSION;
+        else if (curFull)         fullSeverity = WARN;
+        rows.add(new DiffRow("fullGcSeen",
+                baseFull ? "yes" : "no",
+                curFull  ? "yes" : "no",
+                (!baseFull && curFull) ? "NEW" : (curFull ? "persists" : "none"),
+                fullSeverity));
+
+        // Evacuation failure
+        boolean baseEvac = baseline.evacuationFailureSeen;
+        boolean curEvac  = current.evacuationFailureSeen;
+        Severity evacSeverity = INFO;
+        if (!baseEvac && curEvac) evacSeverity = REGRESSION;
+        else if (curEvac)         evacSeverity = WARN;
+        rows.add(new DiffRow("evacuationFailure",
+                baseEvac ? "yes" : "no",
+                curEvac  ? "yes" : "no",
+                (!baseEvac && curEvac) ? "NEW" : (curEvac ? "persists" : "none"),
+                evacSeverity));
+
+        // Mixed starvation
+        boolean baseMix = baseline.mixedStarvation;
+        boolean curMix  = current.mixedStarvation;
+        Severity mixSeverity = INFO;
+        if (!baseMix && curMix) mixSeverity = REGRESSION;
+        else if (curMix)        mixSeverity = WARN;
+        rows.add(new DiffRow("mixedStarvation",
+                baseMix ? "yes" : "no",
+                curMix  ? "yes" : "no",
+                (!baseMix && curMix) ? "NEW" : (curMix ? "persists" : "none"),
+                mixSeverity));
+
+        // Humongous cycle count
+        int baseHum = baseline.humongousAllocationCycles;
+        int curHum  = current.humongousAllocationCycles;
+        int humDelta = curHum - baseHum;
+        Severity humSeverity = INFO;
+        if (baseHum == 0 && curHum > 0) humSeverity = REGRESSION;
+        else if (baseHum > 0 && humDelta > baseHum * 0.5) humSeverity = WARN;
+        else if (humDelta > 0) humSeverity = WARN;
+        rows.add(new DiffRow("humongousCycles",
+                String.valueOf(baseHum),
+                String.valueOf(curHum),
+                (humDelta >= 0 ? "+" : "") + humDelta,
+                humSeverity));
+
+        // Max pause
+        double baseMax = baseline.maxPauseMs;
+        double curMax  = current.maxPauseMs;
+        double maxDelta = curMax - baseMax;
+        Severity pauseSeverity = INFO;
+        if (baseMax > 0 && maxDelta / baseMax > 0.50) pauseSeverity = REGRESSION;
+        else if (maxDelta > 0)                         pauseSeverity = WARN;
+        rows.add(new DiffRow("maxPause",
+                String.format("%.2fms", baseMax),
+                String.format("%.2fms", curMax),
+                String.format("%+.2fms", maxDelta),
+                pauseSeverity));
+
+        // Min MMU (drop > 20% = regression)
+        double baseMmu = baseline.minMmuPercent;
+        double curMmu  = current.minMmuPercent;
+        double mmuDelta = curMmu - baseMmu;
+        Severity mmuSeverity = INFO;
+        if (baseMmu > 0 && (baseMmu - curMmu) / baseMmu > 0.20) mmuSeverity = REGRESSION;
+        else if (mmuDelta < 0) mmuSeverity = WARN;
+        rows.add(new DiffRow("minMmu",
+                String.format("%.1f%%", baseMmu),
+                String.format("%.1f%%", curMmu),
+                String.format("%+.1f%%", mmuDelta),
+                mmuSeverity));
+
+        return rows;
+    }
+
+    // ── Helpers ──────────────────────────────────────────────────────────────
+
+    private static final Severity INFO       = Severity.INFO;
+    private static final Severity WARN       = Severity.WARN;
+    private static final Severity REGRESSION = Severity.REGRESSION;
+
+    public static String formatBytesDelta(long delta) {
+        if (delta == 0) return "0";
+        String sign = delta > 0 ? "+" : "-";
+        return sign + DiagnosticsFormat.formatBytes(Math.abs(delta));
+    }
+
+    private static String escapeField(String s) {
+        if (s == null) return "";
+        return s.replace("\\", "\\\\")
+                .replace(";", "\\;")
+                .replace("|", "\\|")
+                .replace("\n", " ")
+                .replace("\r", " ");
+    }
+
+    private static long parseLong(String text, String key, long defaultValue) {
+        Matcher m = Pattern.compile("(?m)^" + Pattern.quote(key) + "=(-?\\d+)").matcher(text);
+        return m.find() ? Long.parseLong(m.group(1)) : defaultValue;
+    }
+
+    private static double parseDouble(String text, String key, double defaultValue) {
+        Matcher m = Pattern.compile("(?m)^" + Pattern.quote(key) + "=(-?[\\d.]+(?:[Ee][+-]?\\d+)?)").matcher(text);
+        try { return m.find() ? Double.parseDouble(m.group(1)) : defaultValue; }
+        catch (NumberFormatException e) { return defaultValue; }
+    }
+
+    private static boolean parseBool(String text, String key, boolean defaultValue) {
+        Matcher m = Pattern.compile("(?m)^" + Pattern.quote(key) + "=(true|false)").matcher(text);
+        return m.find() ? Boolean.parseBoolean(m.group(1)) : defaultValue;
+    }
+
+    private static String parseString(String text, String key, String defaultValue) {
+        Matcher m = Pattern.compile("(?m)^" + Pattern.quote(key) + "=(.*)$").matcher(text);
+        return m.find() ? m.group(1).trim() : defaultValue;
+    }
+
+    private static Instant parseInstant(String text, String key) {
+        String raw = parseString(text, key, "");
+        if (raw.isEmpty()) return Instant.EPOCH;
+        try { return Instant.parse(raw); }
+        catch (DateTimeParseException e) { return Instant.EPOCH; }
+    }
+
+    private static List<String> parseHumongousFrames(String text) {
+        String raw = parseString(text, "topHumongousFrames", "");
+        List<String> out = new ArrayList<>();
+        if (raw.isEmpty()) return out;
+        String[] parts = raw.split("(?<!\\\\);");
+        for (String part : parts) {
+            String unescaped = part.replace("\\;", ";").replace("\\|", "|").replace("\\\\", "\\");
+            if (!unescaped.isBlank()) out.add(unescaped);
+        }
+        return out;
+    }
+}

--- a/argus-diagnostics/src/main/java/io/argus/diagnostics/g1/G1Baseline.java
+++ b/argus-diagnostics/src/main/java/io/argus/diagnostics/g1/G1Baseline.java
@@ -9,6 +9,7 @@ import java.time.Instant;
 import java.time.format.DateTimeParseException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -218,16 +219,16 @@ public final class G1Baseline {
         sb.append("mixedCycles=").append(d.mixedCycles).append('\n');
         sb.append("concurrentCycles=").append(d.concurrentCycles).append('\n');
         sb.append("fullGcCycles=").append(d.fullGcCycles).append('\n');
-        sb.append("avgYoungPauseMs=").append(String.format("%.6f", d.avgYoungPauseMs)).append('\n');
-        sb.append("avgMixedPauseMs=").append(String.format("%.6f", d.avgMixedPauseMs)).append('\n');
-        sb.append("maxPauseMs=").append(String.format("%.6f", d.maxPauseMs)).append('\n');
+        sb.append("avgYoungPauseMs=").append(String.format(Locale.ROOT, "%.6f", d.avgYoungPauseMs)).append('\n');
+        sb.append("avgMixedPauseMs=").append(String.format(Locale.ROOT, "%.6f", d.avgMixedPauseMs)).append('\n');
+        sb.append("maxPauseMs=").append(String.format(Locale.ROOT, "%.6f", d.maxPauseMs)).append('\n');
         sb.append("bytesCopiedYoung=").append(d.bytesCopiedYoung).append('\n');
         sb.append("bytesCopiedOld=").append(d.bytesCopiedOld).append('\n');
         sb.append("evacuationFailures=").append(d.evacuationFailures).append('\n');
-        sb.append("avgMmuPercent=").append(String.format("%.6f", d.avgMmuPercent)).append('\n');
-        sb.append("minMmuPercent=").append(String.format("%.6f", d.minMmuPercent)).append('\n');
-        sb.append("predictedIhopPercent=").append(String.format("%.6f", d.predictedIhopPercent)).append('\n');
-        sb.append("actualIhopPercent=").append(String.format("%.6f", d.actualIhopPercent)).append('\n');
+        sb.append("avgMmuPercent=").append(String.format(Locale.ROOT, "%.6f", d.avgMmuPercent)).append('\n');
+        sb.append("minMmuPercent=").append(String.format(Locale.ROOT, "%.6f", d.minMmuPercent)).append('\n');
+        sb.append("predictedIhopPercent=").append(String.format(Locale.ROOT, "%.6f", d.predictedIhopPercent)).append('\n');
+        sb.append("actualIhopPercent=").append(String.format(Locale.ROOT, "%.6f", d.actualIhopPercent)).append('\n');
         sb.append("humongousAllocationCycles=").append(d.humongousAllocationCycles).append('\n');
         sb.append("fullGcSeen=").append(d.fullGcSeen).append('\n');
         sb.append("evacuationFailureSeen=").append(d.evacuationFailureSeen).append('\n');
@@ -348,12 +349,19 @@ public final class G1Baseline {
         double curMax  = current.maxPauseMs;
         double maxDelta = curMax - baseMax;
         Severity pauseSeverity = INFO;
-        if (baseMax > 0 && maxDelta / baseMax > 0.50) pauseSeverity = REGRESSION;
-        else if (maxDelta > 0)                         pauseSeverity = WARN;
+        if (baseMax > 0 && maxDelta / baseMax > 0.50) {
+            pauseSeverity = REGRESSION;
+        } else if (baseMax == 0 && curMax > 20.0) {
+            // 0 → N: baseline had no pause data; first observed pause above 20 ms is a regression
+            // (warm-up / known-clean state worsened to a measurable pause).
+            pauseSeverity = REGRESSION;
+        } else if (maxDelta > 0) {
+            pauseSeverity = WARN;
+        }
         rows.add(new DiffRow("maxPause",
-                String.format("%.2fms", baseMax),
-                String.format("%.2fms", curMax),
-                String.format("%+.2fms", maxDelta),
+                String.format(Locale.ROOT, "%.2fms", baseMax),
+                String.format(Locale.ROOT, "%.2fms", curMax),
+                String.format(Locale.ROOT, "%+.2fms", maxDelta),
                 pauseSeverity));
 
         // Min MMU (drop > 20% = regression)
@@ -364,10 +372,22 @@ public final class G1Baseline {
         if (baseMmu > 0 && (baseMmu - curMmu) / baseMmu > 0.20) mmuSeverity = REGRESSION;
         else if (mmuDelta < 0) mmuSeverity = WARN;
         rows.add(new DiffRow("minMmu",
-                String.format("%.1f%%", baseMmu),
-                String.format("%.1f%%", curMmu),
-                String.format("%+.1f%%", mmuDelta),
+                String.format(Locale.ROOT, "%.1f%%", baseMmu),
+                String.format(Locale.ROOT, "%.1f%%", curMmu),
+                String.format(Locale.ROOT, "%+.1f%%", mmuDelta),
                 mmuSeverity));
+
+        // IHOP mistimed (boolean): newly set = REGRESSION, persists = WARN.
+        boolean baseIhop = baseline.ihopMistimed;
+        boolean curIhop  = current.ihopMistimed;
+        Severity ihopSeverity = INFO;
+        if (!baseIhop && curIhop) ihopSeverity = REGRESSION;
+        else if (curIhop)         ihopSeverity = WARN;
+        rows.add(new DiffRow("ihopMistimed",
+                baseIhop ? "yes" : "no",
+                curIhop  ? "yes" : "no",
+                (!baseIhop && curIhop) ? "NEW" : (curIhop ? "persists" : "none"),
+                ihopSeverity));
 
         return rows;
     }
@@ -427,7 +447,17 @@ public final class G1Baseline {
         if (raw.isEmpty()) return out;
         String[] parts = raw.split("(?<!\\\\);");
         for (String part : parts) {
-            String unescaped = part.replace("\\;", ";").replace("\\|", "|").replace("\\\\", "\\");
+            // Unescape order is the inverse of escapeField (which escapes backslash FIRST,
+            // then delimiters). Here we unescape delimiters FIRST, then backslash LAST —
+            // otherwise inputs like `\\\\;` collapse the double-backslash before we have
+            // a chance to recognise it as escaping the semicolon, and the semicolon
+            // delimiter is lost. Using placeholders that cannot appear in the source
+            // makes the order safe regardless.
+            String unescaped = part
+                    .replace("\\\\", " BS ")  // protect escaped backslash
+                    .replace("\\;",  ";")                 // unescape semicolon
+                    .replace("\\|",  "|")                 // unescape pipe
+                    .replace(" BS ", "\\");    // restore backslash
             if (!unescaped.isBlank()) out.add(unescaped);
         }
         return out;

--- a/argus-diagnostics/src/main/java/io/argus/diagnostics/g1/G1Diagnosis.java
+++ b/argus-diagnostics/src/main/java/io/argus/diagnostics/g1/G1Diagnosis.java
@@ -1,0 +1,156 @@
+package io.argus.diagnostics.g1;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Aggregated G1GC health snapshot built from a 30-second JFR capture.
+ *
+ * <p>Populated by {@link G1JfrCollector} from the following JFR events:
+ * {@code jdk.G1GarbageCollection}, {@code jdk.G1HeapSummary},
+ * {@code jdk.G1EvacuationYoungStatistics}, {@code jdk.G1EvacuationOldStatistics},
+ * {@code jdk.G1MMU}, {@code jdk.G1AdaptiveIHOP}, {@code jdk.GarbageCollection}
+ * (label-based phase samples), {@code jdk.ObjectAllocationOutsideTLAB}
+ * (humongous hotspot attribution).
+ *
+ * <p>Verdict logic ({@link #compute()}):
+ * <ul>
+ *   <li>{@link Verdict#UNHEALTHY} when Full GC occurred OR evacuation failure was seen.</li>
+ *   <li>{@link Verdict#WARNING}   when mixed-cycle starvation, IHOP mistiming,
+ *       humongous allocation cycles, or max pause &gt; 2× target are observed.</li>
+ *   <li>{@link Verdict#HEALTHY}   otherwise.</li>
+ * </ul>
+ */
+public final class G1Diagnosis {
+
+    public enum Verdict { HEALTHY, WARNING, UNHEALTHY }
+
+    /**
+     * Top humongous-class allocation site correlated with humongous cycles,
+     * derived from {@code jdk.ObjectAllocationOutsideTLAB} events whose
+     * allocation size is &ge; regionSize/2.
+     */
+    public static final class HumongousHotspot {
+        private final String frame;
+        private final long count;
+        private final long maxBytes;
+
+        public HumongousHotspot(String frame, long count, long maxBytes) {
+            this.frame = frame;
+            this.count = count;
+            this.maxBytes = maxBytes;
+        }
+
+        public String frame() { return frame; }
+        public long count() { return count; }
+        public long maxBytes() { return maxBytes; }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (!(o instanceof HumongousHotspot)) return false;
+            HumongousHotspot that = (HumongousHotspot) o;
+            return count == that.count
+                    && maxBytes == that.maxBytes
+                    && java.util.Objects.equals(frame, that.frame);
+        }
+
+        @Override
+        public int hashCode() {
+            return java.util.Objects.hash(frame, count, maxBytes);
+        }
+
+        @Override
+        public String toString() {
+            return "HumongousHotspot[frame=" + frame + ", count=" + count
+                    + ", maxBytes=" + maxBytes + "]";
+        }
+    }
+
+    // ── Process / GC identity ───────────────────────────────────────────────
+    public boolean usingG1;
+    public String  jvmVersion = "";
+    /** -XX:G1HeapRegionSize in MB (0 = JVM default / unknown). */
+    public int     regionSizeMb;
+    /** -XX:MaxGCPauseMillis target (200 = JVM default). */
+    public int     targetPauseMs;
+    /** -XX:InitiatingHeapOccupancyPercent (45 = JVM default). */
+    public int     ihopPercent;
+    /** {@code true} when -XX:+G1UseAdaptiveIHOP (the JVM default since JDK 15). */
+    public boolean adaptiveIhop;
+
+    // ── Heap (bytes) ────────────────────────────────────────────────────────
+    public long heapCommittedBytes;
+    public long maxHeapBytes;
+
+    // ── Region counts (from jdk.G1HeapSummary; last sample wins) ────────────
+    public int totalRegions;
+    public int edenRegions;
+    public int survivorRegions;
+    public int oldRegions;
+    public int humongousRegions;
+
+    // ── Cycle counters ──────────────────────────────────────────────────────
+    public int    youngCycles;
+    public int    mixedCycles;
+    public int    concurrentCycles;
+    public int    fullGcCycles;
+    public double avgYoungPauseMs;
+    public double avgMixedPauseMs;
+    public double maxPauseMs;
+
+    // ── Evacuation (from jdk.G1EvacuationYoung/OldStatistics) ───────────────
+    public long bytesCopiedYoung;
+    public long bytesCopiedOld;
+    /** Count of evacuation failures (to-space exhausted) observed in the window. */
+    public int  evacuationFailures;
+
+    // ── MMU (from jdk.G1MMU) ────────────────────────────────────────────────
+    public double avgMmuPercent;
+    public double minMmuPercent;
+
+    // ── IHOP (from jdk.G1AdaptiveIHOP) ──────────────────────────────────────
+    public double predictedIhopPercent;
+    public double actualIhopPercent;
+
+    // ── Humongous ───────────────────────────────────────────────────────────
+    /** Count of cycles whose cause field mentions "Humongous Allocation". */
+    public int humongousAllocationCycles;
+
+    /** Top humongous-class allocation call sites; populated only when humongous cycles seen. */
+    public final List<HumongousHotspot> humongousHotspots = new ArrayList<>();
+
+    /** Total number of humongous-sized allocation events seen during the capture. */
+    public long totalHumongousAllocEvents;
+
+    // ── Derived booleans ────────────────────────────────────────────────────
+    /** True when any evacuation event reported failure. */
+    public boolean evacuationFailureSeen;
+    /** True when any Full GC pause was observed under G1. */
+    public boolean fullGcSeen;
+    /**
+     * True when a concurrent cycle finished but no Mixed pause was observed
+     * within the capture window — heuristic; only meaningful when at least
+     * one concurrent cycle has completed.
+     */
+    public boolean mixedStarvation;
+    /**
+     * True when {@code |predictedIhop - actualIhop| > 15 percentage points}
+     * AND at least one concurrent cycle finished during the window.
+     */
+    public boolean ihopMistimed;
+
+    /** Computes the overall verdict from the populated fields. */
+    public Verdict compute() {
+        if (fullGcSeen || evacuationFailureSeen) {
+            return Verdict.UNHEALTHY;
+        }
+        double pauseTarget = targetPauseMs > 0 ? targetPauseMs : 200.0;
+        if (mixedStarvation || ihopMistimed
+                || humongousAllocationCycles > 0
+                || maxPauseMs > pauseTarget * 2.0) {
+            return Verdict.WARNING;
+        }
+        return Verdict.HEALTHY;
+    }
+}

--- a/argus-diagnostics/src/main/java/io/argus/diagnostics/g1/G1JfrCollector.java
+++ b/argus-diagnostics/src/main/java/io/argus/diagnostics/g1/G1JfrCollector.java
@@ -90,16 +90,31 @@ public final class G1JfrCollector {
                     }
                     case "jdk.G1HeapSummary": {
                         // Last sample wins — we want the most recent snapshot.
-                        int eden = safeGetInt(event, "edenUsedRegions");
-                        int sur  = safeGetInt(event, "survivorUsedRegions");
-                        int old  = safeGetInt(event, "oldUsedRegions");
-                        int hum  = safeGetInt(event, "humongousUsedRegions");
-                        int tot  = safeGetInt(event, "numberOfRegions");
-                        if (eden > 0 || sur > 0 || old > 0 || hum > 0) {
-                            d.edenRegions      = eden;
-                            d.survivorRegions  = sur;
-                            d.oldRegions       = old;
-                            d.humongousRegions = hum;
+                        //
+                        // jdk.G1HeapSummary in OpenJDK 11–21 emits SIZE-based fields
+                        // (edenUsedSize, edenTotalSize, survivorUsedSize, oldGenUsedSize,
+                        // humongousUsedSize) plus regionSize + numberOfRegions. The earlier
+                        // implementation read non-existent *UsedRegions fields and silently
+                        // got zero everywhere. We now derive region counts by dividing the
+                        // used-size by regionSize.
+                        long regionSize = safeGetLong(event, "regionSize");
+                        if (regionSize <= 0 && regionSizeBytes > 0) regionSize = regionSizeBytes;
+                        int tot = safeGetInt(event, "numberOfRegions");
+                        long edenUsed     = safeGetLong(event, "edenUsedSize");
+                        long survivorUsed = safeGetLong(event, "survivorUsedSize");
+                        long oldUsed      = safeGetLong(event, "oldGenUsedSize");
+                        long humUsed      = safeGetLong(event, "humongousUsedSize");
+                        if (regionSize > 0) {
+                            int eden = (int) ((edenUsed + regionSize - 1) / regionSize);
+                            int sur  = (int) ((survivorUsed + regionSize - 1) / regionSize);
+                            int old  = (int) ((oldUsed + regionSize - 1) / regionSize);
+                            int hum  = (int) ((humUsed + regionSize - 1) / regionSize);
+                            if (eden > 0 || sur > 0 || old > 0 || hum > 0) {
+                                d.edenRegions      = eden;
+                                d.survivorRegions  = sur;
+                                d.oldRegions       = old;
+                                d.humongousRegions = hum;
+                            }
                         }
                         if (tot > 0) d.totalRegions = tot;
                         break;

--- a/argus-diagnostics/src/main/java/io/argus/diagnostics/g1/G1JfrCollector.java
+++ b/argus-diagnostics/src/main/java/io/argus/diagnostics/g1/G1JfrCollector.java
@@ -1,0 +1,282 @@
+package io.argus.diagnostics.g1;
+
+import jdk.jfr.consumer.RecordedEvent;
+import jdk.jfr.consumer.RecordedFrame;
+import jdk.jfr.consumer.RecordedStackTrace;
+import jdk.jfr.consumer.RecordingFile;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Reads a JFR recording produced by {@code jcmd JFR.start ... settings=profile}
+ * and populates a {@link G1Diagnosis}.
+ *
+ * <p>Subscribed events:
+ * <ul>
+ *   <li>{@code jdk.G1GarbageCollection}                — G1 cycle type (Young/Mixed/Concurrent).</li>
+ *   <li>{@code jdk.G1HeapSummary}                       — region counts (eden/survivor/old/humongous).</li>
+ *   <li>{@code jdk.G1EvacuationYoungStatistics}         — young evacuation bytes + failure flag.</li>
+ *   <li>{@code jdk.G1EvacuationOldStatistics}           — old evacuation bytes + failure flag.</li>
+ *   <li>{@code jdk.G1MMU}                                — minimum mutator utilization samples.</li>
+ *   <li>{@code jdk.G1AdaptiveIHOP}                       — predicted vs. actual IHOP threshold.</li>
+ *   <li>{@code jdk.GarbageCollection}                    — Pause Young (Mixed/Prepare Mixed) + Full GC labels.</li>
+ *   <li>{@code jdk.ObjectAllocationOutsideTLAB}          — humongous-class allocation hotspots.</li>
+ * </ul>
+ *
+ * <p>G1-specific events fire only when G1 is the active GC; they are silently
+ * absent on other collectors and the corresponding fields stay zero.
+ */
+public final class G1JfrCollector {
+
+    private G1JfrCollector() {}
+
+    /**
+     * Reads the JFR file and fills the supplied diagnosis. The {@code usingG1},
+     * {@code jvmVersion}, {@code regionSizeMb}, {@code targetPauseMs},
+     * {@code ihopPercent}, {@code adaptiveIhop}, {@code heapCommittedBytes},
+     * and {@code maxHeapBytes} fields are expected to be set by the caller
+     * before invocation; this method only updates the JFR-derived fields.
+     */
+    public static void collect(Path jfrFile, G1Diagnosis d) throws IOException {
+        long youngPauseNs = 0; int youngPauseCount = 0;
+        long mixedPauseNs = 0; int mixedPauseCount = 0;
+        long maxPauseNs   = 0;
+
+        double mmuSum = 0; int mmuCount = 0; double mmuMin = Double.POSITIVE_INFINITY;
+
+        boolean concurrentCycleFinished = false;
+        boolean mixedPauseSeenAfterConcurrent = false;
+
+        long humongousMaxBytes = 0;
+        long totalHumongousEvents = 0;
+        Map<String, long[]> humongousByFrame = new HashMap<>(); // [count, maxBytes]
+
+        long regionSizeBytes = d.regionSizeMb > 0 ? (long) d.regionSizeMb * 1024L * 1024L : 0;
+
+        try (RecordingFile rf = new RecordingFile(jfrFile)) {
+            while (rf.hasMoreEvents()) {
+                RecordedEvent event = rf.readEvent();
+                String typeName = event.getEventType().getName();
+
+                switch (typeName) {
+                    case "jdk.G1GarbageCollection": {
+                        String type = safeGetString(event, "type");
+                        long durNs = event.getDuration().toNanos();
+                        if (durNs > maxPauseNs) maxPauseNs = durNs;
+                        if (type != null && type.toLowerCase().contains("mixed")) {
+                            mixedPauseNs += durNs;
+                            mixedPauseCount++;
+                            d.mixedCycles++;
+                            if (concurrentCycleFinished) {
+                                mixedPauseSeenAfterConcurrent = true;
+                            }
+                        } else if (type != null && (type.toLowerCase().contains("concurrent")
+                                || type.toLowerCase().contains("normal start"))) {
+                            d.concurrentCycles++;
+                            concurrentCycleFinished = true;
+                        } else {
+                            // Default: treat as a young pause cycle.
+                            youngPauseNs += durNs;
+                            youngPauseCount++;
+                            d.youngCycles++;
+                        }
+                        break;
+                    }
+                    case "jdk.G1HeapSummary": {
+                        // Last sample wins — we want the most recent snapshot.
+                        int eden = safeGetInt(event, "edenUsedRegions");
+                        int sur  = safeGetInt(event, "survivorUsedRegions");
+                        int old  = safeGetInt(event, "oldUsedRegions");
+                        int hum  = safeGetInt(event, "humongousUsedRegions");
+                        int tot  = safeGetInt(event, "numberOfRegions");
+                        if (eden > 0 || sur > 0 || old > 0 || hum > 0) {
+                            d.edenRegions      = eden;
+                            d.survivorRegions  = sur;
+                            d.oldRegions       = old;
+                            d.humongousRegions = hum;
+                        }
+                        if (tot > 0) d.totalRegions = tot;
+                        break;
+                    }
+                    case "jdk.G1EvacuationYoungStatistics": {
+                        long bytes = safeGetLong(event, "totalBytes");
+                        if (bytes > 0) d.bytesCopiedYoung += bytes;
+                        if (safeGetBool(event, "failed")) {
+                            d.evacuationFailures++;
+                            d.evacuationFailureSeen = true;
+                        }
+                        break;
+                    }
+                    case "jdk.G1EvacuationOldStatistics": {
+                        long bytes = safeGetLong(event, "totalBytes");
+                        if (bytes > 0) d.bytesCopiedOld += bytes;
+                        if (safeGetBool(event, "failed")) {
+                            d.evacuationFailures++;
+                            d.evacuationFailureSeen = true;
+                        }
+                        break;
+                    }
+                    case "jdk.G1MMU": {
+                        // jdk.G1MMU reports a percent (0..100) of mutator availability.
+                        double pct = safeGetDouble(event, "mutatorUtilization");
+                        if (pct <= 0) pct = safeGetDouble(event, "utilization");
+                        if (pct > 0) {
+                            mmuSum += pct;
+                            mmuCount++;
+                            if (pct < mmuMin) mmuMin = pct;
+                        }
+                        break;
+                    }
+                    case "jdk.G1AdaptiveIHOP": {
+                        double predicted = safeGetDouble(event, "thresholdPercentage");
+                        if (predicted <= 0) predicted = safeGetDouble(event, "predictedThreshold");
+                        double actual = safeGetDouble(event, "currentOccupancyPercentage");
+                        if (actual <= 0) actual = safeGetDouble(event, "actualOccupancyPercentage");
+                        if (predicted > 0) d.predictedIhopPercent = predicted;
+                        if (actual > 0)    d.actualIhopPercent    = actual;
+                        break;
+                    }
+                    case "jdk.GarbageCollection": {
+                        // Catch Full GC + label-based fallback for older JDKs where
+                        // jdk.G1GarbageCollection is unavailable.
+                        String name = safeGetString(event, "name");
+                        String cause = safeGetString(event, "cause");
+                        long durNs = event.getDuration().toNanos();
+                        if (durNs > maxPauseNs) maxPauseNs = durNs;
+                        if (name == null) break;
+                        if (name.contains("Full") || name.contains("System.gc")) {
+                            d.fullGcCycles++;
+                            d.fullGcSeen = true;
+                        }
+                        if (cause != null && cause.contains("Humongous")) {
+                            d.humongousAllocationCycles++;
+                        }
+                        break;
+                    }
+                    case "jdk.ObjectAllocationOutsideTLAB": {
+                        long bytes = safeGetLong(event, "allocationSize");
+                        if (regionSizeBytes > 0 && bytes >= regionSizeBytes / 2) {
+                            totalHumongousEvents++;
+                            if (bytes > humongousMaxBytes) humongousMaxBytes = bytes;
+                            String topFrame = extractTopUserFrame(event);
+                            if (topFrame != null) {
+                                long[] agg = humongousByFrame.computeIfAbsent(
+                                        topFrame, k -> new long[2]);
+                                agg[0]++;
+                                if (bytes > agg[1]) agg[1] = bytes;
+                            }
+                        }
+                        break;
+                    }
+                    default:
+                        break;
+                }
+            }
+        }
+
+        // ── Aggregates ───────────────────────────────────────────────────────
+        if (youngPauseCount > 0) d.avgYoungPauseMs = (youngPauseNs / 1_000_000.0) / youngPauseCount;
+        if (mixedPauseCount > 0) d.avgMixedPauseMs = (mixedPauseNs / 1_000_000.0) / mixedPauseCount;
+        d.maxPauseMs = maxPauseNs / 1_000_000.0;
+
+        if (mmuCount > 0) {
+            d.avgMmuPercent = mmuSum / mmuCount;
+            d.minMmuPercent = mmuMin == Double.POSITIVE_INFINITY ? 0 : mmuMin;
+        }
+
+        // Mixed starvation: concurrent cycle finished but no Mixed pause seen after.
+        if (concurrentCycleFinished && !mixedPauseSeenAfterConcurrent) {
+            d.mixedStarvation = true;
+        }
+
+        // IHOP mistiming: > 15pp delta AND a concurrent cycle was observed.
+        if (d.predictedIhopPercent > 0 && d.actualIhopPercent > 0
+                && Math.abs(d.predictedIhopPercent - d.actualIhopPercent) > 15.0
+                && d.concurrentCycles > 0) {
+            d.ihopMistimed = true;
+        }
+
+        // Build humongous hotspots (top-5 by count).
+        d.totalHumongousAllocEvents = totalHumongousEvents;
+        if (!humongousByFrame.isEmpty()) {
+            final int TOP_K = 5;
+            List<Map.Entry<String, long[]>> sorted = new ArrayList<>(humongousByFrame.entrySet());
+            sorted.sort((a, b) -> Long.compare(b.getValue()[0], a.getValue()[0]));
+            for (int i = 0; i < Math.min(TOP_K, sorted.size()); i++) {
+                Map.Entry<String, long[]> e = sorted.get(i);
+                d.humongousHotspots.add(new G1Diagnosis.HumongousHotspot(
+                        e.getKey(), e.getValue()[0], e.getValue()[1]));
+            }
+        }
+    }
+
+    // ── Helpers ──────────────────────────────────────────────────────────────
+
+    private static String safeGetString(RecordedEvent event, String field) {
+        try { return event.getString(field); } catch (Exception e) { return ""; }
+    }
+
+    private static long safeGetLong(RecordedEvent event, String field) {
+        try { return event.getLong(field); } catch (Exception e) { return 0; }
+    }
+
+    private static int safeGetInt(RecordedEvent event, String field) {
+        try { return event.getInt(field); }
+        catch (Exception e) {
+            try { return (int) event.getLong(field); } catch (Exception e2) { return 0; }
+        }
+    }
+
+    private static double safeGetDouble(RecordedEvent event, String field) {
+        try { return event.getDouble(field); } catch (Exception e) { return 0.0; }
+    }
+
+    private static boolean safeGetBool(RecordedEvent event, String field) {
+        try { return event.getBoolean(field); } catch (Exception e) { return false; }
+    }
+
+    /**
+     * Walks the event stack trace and returns the first non-JDK frame formatted as
+     * {@code ClassName.methodName(FileName:line)}. Falls back to the first frame
+     * when all frames belong to JDK-internal packages. Returns {@code null} when
+     * no stack trace is present.
+     */
+    static String extractTopUserFrame(RecordedEvent event) {
+        RecordedStackTrace stack = event.getStackTrace();
+        if (stack == null) return null;
+        List<RecordedFrame> frames = stack.getFrames();
+        if (frames.isEmpty()) return null;
+
+        RecordedFrame fallback = null;
+        for (RecordedFrame frame : frames) {
+            if (frame.getMethod() == null) continue;
+            String cls = frame.getMethod().getType().getName();
+            if (cls == null) continue;
+            if (fallback == null) fallback = frame;
+            if (!cls.startsWith("java.")
+                    && !cls.startsWith("jdk.")
+                    && !cls.startsWith("sun.")
+                    && !cls.startsWith("com.sun.")) {
+                return formatFrame(frame);
+            }
+        }
+        return fallback != null ? formatFrame(fallback) : null;
+    }
+
+    private static String formatFrame(RecordedFrame frame) {
+        String cls  = frame.getMethod().getType().getName();
+        String mth  = frame.getMethod().getName();
+        int    line = frame.getLineNumber();
+        String simpleClass = cls.contains(".") ? cls.substring(cls.lastIndexOf('.') + 1) : cls;
+        String fileName = simpleClass.contains("$")
+                ? simpleClass.substring(0, simpleClass.indexOf('$')) + ".java"
+                : simpleClass + ".java";
+        return cls + "." + mth + "(" + fileName + ":" + line + ")";
+    }
+}

--- a/argus-diagnostics/src/main/java/io/argus/diagnostics/gclog/G1Stats.java
+++ b/argus-diagnostics/src/main/java/io/argus/diagnostics/gclog/G1Stats.java
@@ -1,0 +1,80 @@
+package io.argus.diagnostics.gclog;
+
+/**
+ * G1-specific aggregate stats extracted from a GC log file.
+ *
+ * <p>Populated by {@link GcLogParser} alongside the generic event list, using
+ * the G1 pattern set in {@link GcLogPatterns}. Surfaces signals that the
+ * generic {@link GcEvent} stream loses (evacuation failure, humongous-region
+ * deltas, mixed vs. prepare-mixed pause classification, concurrent-cycle
+ * markers).
+ *
+ * <p>Empty for non-G1 logs ({@link #present()} returns {@code false}). Callers
+ * that branch on G1-specific recommendations should gate on {@code present()}.
+ */
+public final class G1Stats {
+
+    private final int evacuationFailures;
+    private final int humongousAllocationCycles;
+    private final int humongousRegionsPeak;
+    private final int mixedPauses;
+    private final int prepareMixedPauses;
+    private final int concurrentCycleMarkers;
+    private final boolean fullGcSeen;
+
+    public G1Stats(int evacuationFailures,
+                   int humongousAllocationCycles,
+                   int humongousRegionsPeak,
+                   int mixedPauses,
+                   int prepareMixedPauses,
+                   int concurrentCycleMarkers,
+                   boolean fullGcSeen) {
+        this.evacuationFailures        = evacuationFailures;
+        this.humongousAllocationCycles = humongousAllocationCycles;
+        this.humongousRegionsPeak      = humongousRegionsPeak;
+        this.mixedPauses               = mixedPauses;
+        this.prepareMixedPauses        = prepareMixedPauses;
+        this.concurrentCycleMarkers    = concurrentCycleMarkers;
+        this.fullGcSeen                = fullGcSeen;
+    }
+
+    public static G1Stats empty() {
+        return new G1Stats(0, 0, 0, 0, 0, 0, false);
+    }
+
+    public int  evacuationFailures()        { return evacuationFailures; }
+    public int  humongousAllocationCycles() { return humongousAllocationCycles; }
+    public int  humongousRegionsPeak()      { return humongousRegionsPeak; }
+    public int  mixedPauses()               { return mixedPauses; }
+    public int  prepareMixedPauses()        { return prepareMixedPauses; }
+    public int  concurrentCycleMarkers()    { return concurrentCycleMarkers; }
+    public boolean fullGcSeen()             { return fullGcSeen; }
+
+    /** True when at least one G1-specific signal was extracted from the log. */
+    public boolean present() {
+        return evacuationFailures > 0 || humongousAllocationCycles > 0
+                || humongousRegionsPeak > 0 || mixedPauses > 0
+                || prepareMixedPauses > 0 || concurrentCycleMarkers > 0
+                || fullGcSeen;
+    }
+
+    /**
+     * Heuristic: a concurrent cycle was observed but no Mixed pause followed
+     * within the log. Caller must verify the log window is long enough; a
+     * sub-second log fragment will trip this falsely.
+     */
+    public boolean mixedStarvationSuspected() {
+        return concurrentCycleMarkers > 0 && mixedPauses == 0;
+    }
+
+    @Override
+    public String toString() {
+        return "G1Stats[evacFailures=" + evacuationFailures
+                + ", humongousCycles=" + humongousAllocationCycles
+                + ", humongousPeak=" + humongousRegionsPeak
+                + ", mixed=" + mixedPauses
+                + ", prepareMixed=" + prepareMixedPauses
+                + ", concurrent=" + concurrentCycleMarkers
+                + ", fullGc=" + fullGcSeen + "]";
+    }
+}

--- a/argus-diagnostics/src/main/java/io/argus/diagnostics/gclog/GcLogAnalysis.java
+++ b/argus-diagnostics/src/main/java/io/argus/diagnostics/gclog/GcLogAnalysis.java
@@ -26,6 +26,7 @@ public final class GcLogAnalysis {
     private final GcRateAnalyzer.RateAnalysis rateAnalysis;
     private final GcLeakDetector.LeakAnalysis leakAnalysis;
     private final AllocationStallSummary allocationStalls;
+    private final G1Stats g1Stats;
 
     public GcLogAnalysis(int totalEvents, int pauseEvents, int fullGcEvents, int concurrentEvents,
                          double durationSec, double throughputPercent,
@@ -37,6 +38,38 @@ public final class GcLogAnalysis {
                 durationSec, throughputPercent, totalPauseMs, maxPauseMs,
                 p50PauseMs, p95PauseMs, p99PauseMs, avgPauseMs, peakHeapKB, avgHeapAfterKB,
                 causeBreakdown, recommendations, null, null, null);
+    }
+
+    public GcLogAnalysis(int totalEvents, int pauseEvents, int fullGcEvents, int concurrentEvents,
+                         double durationSec, double throughputPercent,
+                         long totalPauseMs, long maxPauseMs, long p50PauseMs, long p95PauseMs,
+                         long p99PauseMs, long avgPauseMs, long peakHeapKB, long avgHeapAfterKB,
+                         Map<String, CauseStats> causeBreakdown,
+                         List<TuningRecommendation> recommendations,
+                         GcRateAnalyzer.RateAnalysis rateAnalysis,
+                         GcLeakDetector.LeakAnalysis leakAnalysis,
+                         AllocationStallSummary allocationStalls,
+                         G1Stats g1Stats) {
+        this.totalEvents = totalEvents;
+        this.pauseEvents = pauseEvents;
+        this.fullGcEvents = fullGcEvents;
+        this.concurrentEvents = concurrentEvents;
+        this.durationSec = durationSec;
+        this.throughputPercent = throughputPercent;
+        this.totalPauseMs = totalPauseMs;
+        this.maxPauseMs = maxPauseMs;
+        this.p50PauseMs = p50PauseMs;
+        this.p95PauseMs = p95PauseMs;
+        this.p99PauseMs = p99PauseMs;
+        this.avgPauseMs = avgPauseMs;
+        this.peakHeapKB = peakHeapKB;
+        this.avgHeapAfterKB = avgHeapAfterKB;
+        this.causeBreakdown = causeBreakdown;
+        this.recommendations = recommendations;
+        this.rateAnalysis = rateAnalysis;
+        this.leakAnalysis = leakAnalysis;
+        this.allocationStalls = allocationStalls;
+        this.g1Stats = g1Stats == null ? G1Stats.empty() : g1Stats;
     }
 
     public GcLogAnalysis(int totalEvents, int pauseEvents, int fullGcEvents, int concurrentEvents,
@@ -62,25 +95,11 @@ public final class GcLogAnalysis {
                          GcRateAnalyzer.RateAnalysis rateAnalysis,
                          GcLeakDetector.LeakAnalysis leakAnalysis,
                          AllocationStallSummary allocationStalls) {
-        this.totalEvents = totalEvents;
-        this.pauseEvents = pauseEvents;
-        this.fullGcEvents = fullGcEvents;
-        this.concurrentEvents = concurrentEvents;
-        this.durationSec = durationSec;
-        this.throughputPercent = throughputPercent;
-        this.totalPauseMs = totalPauseMs;
-        this.maxPauseMs = maxPauseMs;
-        this.p50PauseMs = p50PauseMs;
-        this.p95PauseMs = p95PauseMs;
-        this.p99PauseMs = p99PauseMs;
-        this.avgPauseMs = avgPauseMs;
-        this.peakHeapKB = peakHeapKB;
-        this.avgHeapAfterKB = avgHeapAfterKB;
-        this.causeBreakdown = causeBreakdown;
-        this.recommendations = recommendations;
-        this.rateAnalysis = rateAnalysis;
-        this.leakAnalysis = leakAnalysis;
-        this.allocationStalls = allocationStalls;
+        this(totalEvents, pauseEvents, fullGcEvents, concurrentEvents,
+                durationSec, throughputPercent, totalPauseMs, maxPauseMs,
+                p50PauseMs, p95PauseMs, p99PauseMs, avgPauseMs, peakHeapKB, avgHeapAfterKB,
+                causeBreakdown, recommendations, rateAnalysis, leakAnalysis,
+                allocationStalls, null);
     }
 
     public int totalEvents() { return totalEvents; }
@@ -103,6 +122,8 @@ public final class GcLogAnalysis {
     public GcLeakDetector.LeakAnalysis leakAnalysis() { return leakAnalysis; }
     /** Returns the ZGC Allocation Stall summary, or null if no stalls were observed. */
     public AllocationStallSummary allocationStalls() { return allocationStalls; }
+    /** Returns the G1-specific aggregate stats; always non-null, may be {@code G1Stats.empty()}. */
+    public G1Stats g1Stats() { return g1Stats; }
 
     public static final class CauseStats {
         private final String cause;

--- a/argus-diagnostics/src/main/java/io/argus/diagnostics/gclog/GcLogAnalyzer.java
+++ b/argus-diagnostics/src/main/java/io/argus/diagnostics/gclog/GcLogAnalyzer.java
@@ -11,6 +11,25 @@ import java.util.stream.Collectors;
  */
 public final class GcLogAnalyzer {
 
+    /**
+     * Phase-aware overload that propagates {@link G1Stats} from the parser
+     * through to the analysis. Use this overload when the caller already has
+     * a {@link GcLogParser.ParseResult} from {@link GcLogParser#parseWithPhases}.
+     */
+    public static GcLogAnalysis analyze(GcLogParser.ParseResult result) {
+        GcLogAnalysis base = analyze(result.events());
+        if (!result.g1Stats().present()) return base;
+        // Wrap with G1Stats attached. We keep all other fields identical.
+        return new GcLogAnalysis(
+                base.totalEvents(), base.pauseEvents(), base.fullGcEvents(), base.concurrentEvents(),
+                base.durationSec(), base.throughputPercent(),
+                base.totalPauseMs(), base.maxPauseMs(), base.p50PauseMs(), base.p95PauseMs(),
+                base.p99PauseMs(), base.avgPauseMs(), base.peakHeapKB(), base.avgHeapAfterKB(),
+                base.causeBreakdown(), base.recommendations(),
+                base.rateAnalysis(), base.leakAnalysis(), base.allocationStalls(),
+                result.g1Stats());
+    }
+
     public static GcLogAnalysis analyze(List<GcEvent> events) {
         if (events.isEmpty()) {
             return new GcLogAnalysis(0, 0, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 0, Map.of(), List.of());

--- a/argus-diagnostics/src/main/java/io/argus/diagnostics/gclog/GcLogParser.java
+++ b/argus-diagnostics/src/main/java/io/argus/diagnostics/gclog/GcLogParser.java
@@ -22,18 +22,31 @@ public final class GcLogParser {
 
     /**
      * Result container for phase-aware parsing.
+     *
+     * <p>Carries an optional {@link G1Stats} accumulator populated alongside
+     * the generic event list when the log contains G1-specific lines
+     * (To-space exhausted, Humongous regions, Pause Young (Mixed), …).
+     * {@link #g1Stats()} returns {@link G1Stats#empty()} when no G1 signals
+     * were observed — callers should branch on {@link G1Stats#present()}.
      */
     public static final class ParseResult {
         private final List<GcEvent> events;
         private final List<GcPhaseEvent> phases;
+        private final G1Stats g1Stats;
 
         public ParseResult(List<GcEvent> events, List<GcPhaseEvent> phases) {
+            this(events, phases, G1Stats.empty());
+        }
+
+        public ParseResult(List<GcEvent> events, List<GcPhaseEvent> phases, G1Stats g1Stats) {
             this.events = events;
             this.phases = phases;
+            this.g1Stats = g1Stats == null ? G1Stats.empty() : g1Stats;
         }
 
         public List<GcEvent> events() { return events; }
         public List<GcPhaseEvent> phases() { return phases; }
+        public G1Stats g1Stats() { return g1Stats; }
 
         @Override
         public boolean equals(Object o) {
@@ -41,17 +54,19 @@ public final class GcLogParser {
             if (!(o instanceof ParseResult)) return false;
             ParseResult that = (ParseResult) o;
             return java.util.Objects.equals(events, that.events)
-                    && java.util.Objects.equals(phases, that.phases);
+                    && java.util.Objects.equals(phases, that.phases)
+                    && java.util.Objects.equals(g1Stats, that.g1Stats);
         }
 
         @Override
         public int hashCode() {
-            return java.util.Objects.hash(events, phases);
+            return java.util.Objects.hash(events, phases, g1Stats);
         }
 
         @Override
         public String toString() {
-            return "ParseResult[events=" + events + ", phases=" + phases + "]";
+            return "ParseResult[events=" + events + ", phases=" + phases
+                    + ", g1Stats=" + g1Stats + "]";
         }
     }
 
@@ -63,6 +78,15 @@ public final class GcLogParser {
         List<GcEvent> events = new ArrayList<>();
         List<GcPhaseEvent> phases = new ArrayList<>();
         FormatState state = new FormatState();
+
+        // G1-specific accumulators — populated alongside the generic event scan.
+        int g1EvacFailures = 0;
+        int g1HumongousAlloc = 0;
+        int g1HumongousPeak = 0;
+        int g1MixedPauses = 0;
+        int g1PrepareMixed = 0;
+        int g1ConcurrentMarkers = 0;
+        boolean g1FullGcSeen = false;
 
         try (BufferedReader reader = Files.newBufferedReader(logFile)) {
             String line;
@@ -77,11 +101,45 @@ public final class GcLogParser {
                     }
                 }
 
+                // G1-specific signal extraction. Cheap string-contains checks
+                // gate the more expensive regex matches.
+                if (line.contains("To-space exhausted") || line.contains("Evacuation Failure")) {
+                    g1EvacFailures++;
+                }
+                if (line.contains("Humongous Allocation")) {
+                    g1HumongousAlloc++;
+                }
+                if (line.contains("Humongous regions:")) {
+                    Matcher hm = GcLogPatterns.G1_HUMONGOUS_LINE.matcher(line);
+                    if (hm.find()) {
+                        try {
+                            int before = Integer.parseInt(hm.group(1));
+                            int after  = Integer.parseInt(hm.group(2));
+                            int peak = Math.max(before, after);
+                            if (peak > g1HumongousPeak) g1HumongousPeak = peak;
+                        } catch (NumberFormatException ignored) {}
+                    }
+                }
+                if (line.contains("Pause Young (Prepare Mixed)")) {
+                    g1PrepareMixed++;
+                } else if (line.contains("Pause Young (Mixed)")) {
+                    g1MixedPauses++;
+                }
+                if (line.contains("Concurrent Mark Cycle") || line.contains("Concurrent Cycle")) {
+                    g1ConcurrentMarkers++;
+                }
+                if (line.contains("Pause Full")) {
+                    g1FullGcSeen = true;
+                }
+
                 GcEvent event = state.unified ? parseUnifiedLine(line, state) : parseLegacyLine(line);
                 if (event != null) events.add(event);
             }
         }
-        return new ParseResult(events, phases);
+
+        G1Stats g1 = new G1Stats(g1EvacFailures, g1HumongousAlloc, g1HumongousPeak,
+                g1MixedPauses, g1PrepareMixed, g1ConcurrentMarkers, g1FullGcSeen);
+        return new ParseResult(events, phases, g1);
     }
 
     private static GcPhaseEvent parsePhraseLine(String line) {

--- a/argus-diagnostics/src/main/java/io/argus/diagnostics/gclog/GcLogPatterns.java
+++ b/argus-diagnostics/src/main/java/io/argus/diagnostics/gclog/GcLogPatterns.java
@@ -37,5 +37,26 @@ public final class GcLogPatterns {
     public static final Pattern GC_PHASE = Pattern.compile(
             "GC\\((\\d+)\\)\\s+(.+?):\\s+(\\d+\\.?\\d*)ms");
 
+    // ── G1-specific patterns ──────────────────────────────────────────────
+    /** Fires on "To-space exhausted" or "Evacuation Failure" lines. */
+    public static final Pattern G1_EVAC_FAILURE = Pattern.compile(
+            "To-space exhausted|Evacuation Failure");
+
+    /** Captures humongous region delta from "Humongous regions: N->M" lines. */
+    public static final Pattern G1_HUMONGOUS_LINE = Pattern.compile(
+            "Humongous regions: (\\d+)->(\\d+)");
+
+    /** Matches G1 mixed pauses: "Pause Young (Mixed) ..." */
+    public static final Pattern G1_MIXED_PAUSE = Pattern.compile(
+            "Pause Young \\(Mixed\\)");
+
+    /** Matches "Pause Young (Prepare Mixed) ..." — concurrent cycle finished, mixed scheduled. */
+    public static final Pattern G1_PREPARE_MIXED = Pattern.compile(
+            "Pause Young \\(Prepare Mixed\\)");
+
+    /** Matches "Concurrent Mark Cycle" begin/end markers. */
+    public static final Pattern G1_CONCURRENT_BEG = Pattern.compile(
+            "Concurrent Mark Cycle");
+
     private GcLogPatterns() {}
 }

--- a/argus-diagnostics/src/main/java/io/argus/diagnostics/gcscore/GcScoreCalculator.java
+++ b/argus-diagnostics/src/main/java/io/argus/diagnostics/gcscore/GcScoreCalculator.java
@@ -37,7 +37,9 @@ public final class GcScoreCalculator {
      * means "unknown / use standard weights".
      */
     public static GcScoreResult compute(GcLogAnalysis a, String gcAlgorithm) {
-        boolean isZgc = gcAlgorithm != null && gcAlgorithm.toUpperCase().contains("ZGC");
+        String algo = gcAlgorithm == null ? "" : gcAlgorithm.toUpperCase();
+        boolean isZgc = algo.contains("ZGC");
+        boolean isG1  = !isZgc && algo.contains("G1");
 
         List<AxisScore> axes = new ArrayList<>();
 
@@ -60,10 +62,10 @@ public final class GcScoreCalculator {
             axes.add(scoreZgcAllocationPressure(a.totalEvents(), a.durationSec()));
         }
 
-        int overall = weightedOverall(axes, isZgc);
+        int overall = weightedOverall(axes, isZgc, isG1);
         String grade = grade(overall);
         String summary = summaryFor(grade);
-        List<String> hints = selectHints(axes, isZgc);
+        List<String> hints = selectHints(axes, isZgc, isG1);
 
         return new GcScoreResult(axes, overall, grade, summary, hints);
     }
@@ -193,7 +195,15 @@ public final class GcScoreCalculator {
      * Backward-compatible overload used by tests that call the method directly.
      */
     static int weightedOverall(List<AxisScore> axes) {
-        return weightedOverall(axes, false);
+        return weightedOverall(axes, false, false);
+    }
+
+    /**
+     * Two-arg variant retained for backward compatibility with callers that
+     * only branched on ZGC. Defaults isG1 to false.
+     */
+    static int weightedOverall(List<AxisScore> axes, boolean isZgc) {
+        return weightedOverall(axes, isZgc, false);
     }
 
     /**
@@ -206,13 +216,24 @@ public final class GcScoreCalculator {
      * weight is redistributed to throughput (0.30) and the new
      * "Allocation pressure (ZGC)" axis (index 6) at 0.15. This reflects that
      * sub-ms ZGC pauses are expected by design and should not dominate the score.
+     *
+     * <p>G1 weights: pause axes keep standard thresholds (G1 targets
+     * MaxGCPauseMillis = 200 ms), but Full-GC frequency is weighted higher
+     * (0.25 vs 0.15 standard) because Full GC under G1 is always a pathology
+     * — the saved weight comes from pause-p99 (0.22) and tail (0.13).
      */
-    static int weightedOverall(List<AxisScore> axes, boolean isZgc) {
+    static int weightedOverall(List<AxisScore> axes, boolean isZgc, boolean isG1) {
         // Standard weights: [p99, tail, throughput, fullGcFreq, allocRate, promoRatio]
         // ZGC weights:      [p99, tail, throughput, fullGcFreq, allocRate, promoRatio, allocPressure]
-        double[] weights = isZgc
-                ? new double[]{0.12, 0.08, 0.30, 0.15, 0.10, 0.10, 0.15}
-                : new double[]{0.25, 0.15, 0.25, 0.15, 0.10, 0.10};
+        // G1 weights:       [p99, tail, throughput, fullGcFreq, allocRate, promoRatio]
+        double[] weights;
+        if (isZgc) {
+            weights = new double[]{0.12, 0.08, 0.30, 0.15, 0.10, 0.10, 0.15};
+        } else if (isG1) {
+            weights = new double[]{0.22, 0.13, 0.20, 0.25, 0.10, 0.10};
+        } else {
+            weights = new double[]{0.25, 0.15, 0.25, 0.15, 0.10, 0.10};
+        }
         double sum = 0, wAvail = 0;
         for (int i = 0; i < axes.size(); i++) {
             AxisScore ax = axes.get(i);
@@ -252,19 +273,39 @@ public final class GcScoreCalculator {
      * Backward-compatible overload.
      */
     static List<String> selectHints(List<AxisScore> axes) {
-        return selectHints(axes, false);
+        return selectHints(axes, false, false);
     }
 
+    /** Backward-compatible two-arg overload (ZGC vs standard). */
     static List<String> selectHints(List<AxisScore> axes, boolean isZgc) {
+        return selectHints(axes, isZgc, false);
+    }
+
+    static List<String> selectHints(List<AxisScore> axes, boolean isZgc, boolean isG1) {
         List<String> hints = new ArrayList<>();
         for (AxisScore ax : axes) {
             if (ax.verdict() == AxisScore.Verdict.PASS || ax.verdict() == AxisScore.Verdict.NA) continue;
-            String hint = isZgc ? hintForZgc(ax) : hintFor(ax);
+            String hint;
+            if (isZgc)       hint = hintForZgc(ax);
+            else if (isG1)   hint = hintForG1(ax);
+            else             hint = hintFor(ax);
             if (hint != null) hints.add(hint);
             if (hints.size() >= 3) break;
         }
         if (hints.isEmpty()) hints.add("GC health looks good — no changes needed.");
         return hints;
+    }
+
+    private static String hintForG1(AxisScore ax) {
+        switch (ax.name()) {
+            case "Pause p99": return "G1 p99 above target — lower -XX:MaxGCPauseMillis (e.g. 150) or raise -Xmx to give G1 more headroom";
+            case "Pause tail (max)": return "G1 tail pauses spiking — check for humongous allocations (argus g1 <PID>) and consider -XX:G1HeapRegionSize tuning";
+            case "Throughput": return "Low throughput under G1 — raise -Xmx, raise -XX:ParallelGCThreads, or check for evacuation failures with argus g1 <PID>";
+            case "Full GC frequency": return "G1 Full GC observed — pathological under G1; raise -Xmx, lower -XX:InitiatingHeapOccupancyPercent, or inspect with argus heap";
+            case "Allocation rate": return "Very high allocation rate — run argus flame --type=alloc to find hot allocation sites";
+            case "Promotion ratio": return "High promotion ratio under G1 — survivors overflowing; raise -XX:MaxTenuringThreshold or increase young gen with -XX:G1NewSizePercent";
+            default: return null;
+        }
     }
 
     private static String hintFor(AxisScore ax) {

--- a/argus-diagnostics/src/main/java/io/argus/diagnostics/zgc/ZgcBaseline.java
+++ b/argus-diagnostics/src/main/java/io/argus/diagnostics/zgc/ZgcBaseline.java
@@ -9,6 +9,7 @@ import java.time.Instant;
 import java.time.format.DateTimeParseException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -68,6 +69,15 @@ public final class ZgcBaseline {
     public final boolean softMaxBreached;
     public final boolean cycleOverlap;
 
+    // ── ZGC residual JFR signals (page allocation, uncommit, concurrent phases) ──
+    public final long   zPageAllocationCount;
+    public final long   zUncommittedBytes;
+    public final int    zUncommitEvents;
+    public final double concurrentMarkMs;
+    public final double concurrentRelocateMs;
+    public final int    concurrentMarkSamples;
+    public final int    concurrentRelocateSamples;
+
     /** Each entry is {@code "frame|pct"}, semicolon-separated in the file. */
     public final List<String> topAllocFrames;
 
@@ -80,6 +90,26 @@ public final class ZgcBaseline {
             int stallCount, double stallTotalMs, double stallMaxMs, String stallMaxThread,
             boolean softMaxBreached, boolean cycleOverlap,
             List<String> topAllocFrames) {
+        this(capturedAt, pid, generational, heapCommittedBytes, softMaxHeapBytes, maxHeapBytes,
+                minorCycles, majorCycles, avgCycleIntervalSec, avgCycleDurationSec,
+                pauseMarkStartMs, pauseMarkEndMs, pauseRelocateStartMs,
+                stallCount, stallTotalMs, stallMaxMs, stallMaxThread,
+                softMaxBreached, cycleOverlap, topAllocFrames,
+                0L, 0L, 0, 0.0, 0.0, 0, 0);
+    }
+
+    public ZgcBaseline(
+            Instant capturedAt, int pid, boolean generational,
+            long heapCommittedBytes, long softMaxHeapBytes, long maxHeapBytes,
+            int minorCycles, int majorCycles,
+            double avgCycleIntervalSec, double avgCycleDurationSec,
+            double pauseMarkStartMs, double pauseMarkEndMs, double pauseRelocateStartMs,
+            int stallCount, double stallTotalMs, double stallMaxMs, String stallMaxThread,
+            boolean softMaxBreached, boolean cycleOverlap,
+            List<String> topAllocFrames,
+            long zPageAllocationCount, long zUncommittedBytes, int zUncommitEvents,
+            double concurrentMarkMs, double concurrentRelocateMs,
+            int concurrentMarkSamples, int concurrentRelocateSamples) {
         this.capturedAt          = capturedAt;
         this.pid                 = pid;
         this.generational        = generational;
@@ -100,6 +130,13 @@ public final class ZgcBaseline {
         this.softMaxBreached     = softMaxBreached;
         this.cycleOverlap        = cycleOverlap;
         this.topAllocFrames      = topAllocFrames == null ? List.of() : List.copyOf(topAllocFrames);
+        this.zPageAllocationCount     = zPageAllocationCount;
+        this.zUncommittedBytes        = zUncommittedBytes;
+        this.zUncommitEvents          = zUncommitEvents;
+        this.concurrentMarkMs         = concurrentMarkMs;
+        this.concurrentRelocateMs     = concurrentRelocateMs;
+        this.concurrentMarkSamples    = concurrentMarkSamples;
+        this.concurrentRelocateSamples = concurrentRelocateSamples;
     }
 
     // ── Severity ─────────────────────────────────────────────────────────────
@@ -172,7 +209,7 @@ public final class ZgcBaseline {
             ZgcDiagnosis.AllocHotspot h = d.stallAllocHotspots.get(i);
             if (i > 0) allocSb.append(';');
             allocSb.append(escapeField(h.frame())).append('|')
-                   .append(String.format("%.2f", h.pct()));
+                   .append(String.format(Locale.ROOT, "%.2f", h.pct()));
         }
 
         StringBuilder sb = new StringBuilder();
@@ -185,18 +222,26 @@ public final class ZgcBaseline {
         sb.append("maxHeapBytes=").append(d.maxHeapBytes).append('\n');
         sb.append("minorCycles=").append(d.minorCycles).append('\n');
         sb.append("majorCycles=").append(d.majorCycles).append('\n');
-        sb.append("avgCycleIntervalSec=").append(String.format("%.6f", d.avgCycleIntervalSec)).append('\n');
-        sb.append("avgCycleDurationSec=").append(String.format("%.6f", d.avgCycleDurationSec)).append('\n');
-        sb.append("pauseMarkStartMs=").append(String.format("%.6f", d.pauseMarkStartMs)).append('\n');
-        sb.append("pauseMarkEndMs=").append(String.format("%.6f", d.pauseMarkEndMs)).append('\n');
-        sb.append("pauseRelocateStartMs=").append(String.format("%.6f", d.pauseRelocateStartMs)).append('\n');
+        sb.append("avgCycleIntervalSec=").append(String.format(Locale.ROOT, "%.6f", d.avgCycleIntervalSec)).append('\n');
+        sb.append("avgCycleDurationSec=").append(String.format(Locale.ROOT, "%.6f", d.avgCycleDurationSec)).append('\n');
+        sb.append("pauseMarkStartMs=").append(String.format(Locale.ROOT, "%.6f", d.pauseMarkStartMs)).append('\n');
+        sb.append("pauseMarkEndMs=").append(String.format(Locale.ROOT, "%.6f", d.pauseMarkEndMs)).append('\n');
+        sb.append("pauseRelocateStartMs=").append(String.format(Locale.ROOT, "%.6f", d.pauseRelocateStartMs)).append('\n');
         sb.append("stallCount=").append(stallCount).append('\n');
-        sb.append("stallTotalMs=").append(String.format("%.6f", stallTotalMs)).append('\n');
-        sb.append("stallMaxMs=").append(String.format("%.6f", stallMaxMs)).append('\n');
+        sb.append("stallTotalMs=").append(String.format(Locale.ROOT, "%.6f", stallTotalMs)).append('\n');
+        sb.append("stallMaxMs=").append(String.format(Locale.ROOT, "%.6f", stallMaxMs)).append('\n');
         sb.append("stallMaxThread=").append(escapeField(stallMaxThread)).append('\n');
         sb.append("softMaxBreached=").append(d.softMaxBreached).append('\n');
         sb.append("cycleOverlap=").append(d.cycleOverlap).append('\n');
         sb.append("topAllocFrames=").append(allocSb).append('\n');
+        // Residual ZGC signals — added 1.5.0; older baselines omit these and load() defaults to 0.
+        sb.append("zPageAllocationCount=").append(d.zPageAllocationCount).append('\n');
+        sb.append("zUncommittedBytes=").append(d.zUncommittedBytes).append('\n');
+        sb.append("zUncommitEvents=").append(d.zUncommitEvents).append('\n');
+        sb.append("concurrentMarkMs=").append(String.format(Locale.ROOT, "%.6f", d.concurrentMarkMs)).append('\n');
+        sb.append("concurrentRelocateMs=").append(String.format(Locale.ROOT, "%.6f", d.concurrentRelocateMs)).append('\n');
+        sb.append("concurrentMarkSamples=").append(d.concurrentMarkSamples).append('\n');
+        sb.append("concurrentRelocateSamples=").append(d.concurrentRelocateSamples).append('\n');
 
         Files.writeString(file, sb.toString());
     }
@@ -227,6 +272,14 @@ public final class ZgcBaseline {
         boolean cycleOverlap         = parseBool(text, "cycleOverlap", false);
         List<String> topAllocFrames  = parseAllocFrames(text);
 
+        long    zPageAllocationCount  = parseLong(text, "zPageAllocationCount", 0);
+        long    zUncommittedBytes     = parseLong(text, "zUncommittedBytes", 0);
+        int     zUncommitEvents       = (int) parseLong(text, "zUncommitEvents", 0);
+        double  concurrentMarkMs      = parseDouble(text, "concurrentMarkMs", 0.0);
+        double  concurrentRelocateMs  = parseDouble(text, "concurrentRelocateMs", 0.0);
+        int     concurrentMarkSamples = (int) parseLong(text, "concurrentMarkSamples", 0);
+        int     concurrentRelocateSamples = (int) parseLong(text, "concurrentRelocateSamples", 0);
+
         return new ZgcBaseline(
                 capturedAt, pid, generational,
                 heapCommittedBytes, softMaxHeapBytes, maxHeapBytes,
@@ -235,7 +288,10 @@ public final class ZgcBaseline {
                 pauseMarkStartMs, pauseMarkEndMs, pauseRelocateStartMs,
                 stallCount, stallTotalMs, stallMaxMs, stallMaxThread,
                 softMaxBreached, cycleOverlap,
-                topAllocFrames);
+                topAllocFrames,
+                zPageAllocationCount, zUncommittedBytes, zUncommitEvents,
+                concurrentMarkMs, concurrentRelocateMs,
+                concurrentMarkSamples, concurrentRelocateSamples);
     }
 
     // ── diff ─────────────────────────────────────────────────────────────────
@@ -308,9 +364,9 @@ public final class ZgcBaseline {
             markEndSeverity = WARN;
         }
         rows.add(new DiffRow("pauseMarkEnd",
-                String.format("%.2fms", baseMarkEnd),
-                String.format("%.2fms", curMarkEnd),
-                String.format("%+.2fms", markEndDelta),
+                String.format(Locale.ROOT, "%.2fms", baseMarkEnd),
+                String.format(Locale.ROOT, "%.2fms", curMarkEnd),
+                String.format(Locale.ROOT, "%+.2fms", markEndDelta),
                 markEndSeverity));
 
         // SoftMax breach

--- a/argus-diagnostics/src/main/java/io/argus/diagnostics/zgc/ZgcBaseline.java
+++ b/argus-diagnostics/src/main/java/io/argus/diagnostics/zgc/ZgcBaseline.java
@@ -381,6 +381,47 @@ public final class ZgcBaseline {
                 (!baseBreach && curBreach) ? "NEW" : (curBreach ? "persists" : "none"),
                 breachSeverity));
 
+        // ── Residual ZGC signals (page allocation / uncommit / concurrent phases) ──
+        // Only emit rows when either side has non-zero data, so older baselines
+        // (pre-1.5.0) don't clutter the diff with all-zero rows.
+
+        // Page allocation churn
+        long basePages = baseline.zPageAllocationCount;
+        long curPages  = current.zPageAllocationCount;
+        if (basePages > 0 || curPages > 0) {
+            long pageDelta = curPages - basePages;
+            Severity pageSeverity = INFO;
+            if (basePages > 0 && pageDelta > basePages) pageSeverity = WARN; // doubled
+            rows.add(new DiffRow("zPageAllocationCount",
+                    String.valueOf(basePages), String.valueOf(curPages),
+                    (pageDelta >= 0 ? "+" : "") + pageDelta, pageSeverity));
+        }
+
+        // Uncommit bytes
+        long baseUncommit = baseline.zUncommittedBytes;
+        long curUncommit  = current.zUncommittedBytes;
+        if (baseUncommit > 0 || curUncommit > 0) {
+            long uncDelta = curUncommit - baseUncommit;
+            rows.add(new DiffRow("zUncommittedBytes",
+                    DiagnosticsFormat.formatBytes(baseUncommit),
+                    DiagnosticsFormat.formatBytes(curUncommit),
+                    formatBytesDelta(uncDelta), INFO));
+        }
+
+        // Concurrent Mark phase time
+        double baseMark = baseline.concurrentMarkMs;
+        double curMark  = current.concurrentMarkMs;
+        if (baseMark > 0 || curMark > 0) {
+            double markDelta = curMark - baseMark;
+            Severity markSev = INFO;
+            if (baseMark > 0 && markDelta / baseMark > 0.50) markSev = WARN;
+            rows.add(new DiffRow("concurrentMarkMs",
+                    String.format(Locale.ROOT, "%.2fms", baseMark),
+                    String.format(Locale.ROOT, "%.2fms", curMark),
+                    String.format(Locale.ROOT, "%+.2fms", markDelta),
+                    markSev));
+        }
+
         return rows;
     }
 

--- a/argus-diagnostics/src/main/java/io/argus/diagnostics/zgc/ZgcDiagnosis.java
+++ b/argus-diagnostics/src/main/java/io/argus/diagnostics/zgc/ZgcDiagnosis.java
@@ -130,6 +130,24 @@ public final class ZgcDiagnosis {
     /** Total number of allocation events seen in the JFR capture (for the header n= label). */
     public long totalAllocEvents;
 
+    // ── Page allocation / uncommit (from jdk.ZPageAllocation / jdk.ZUncommit) ──
+    /** Total ZPageAllocation events seen during the capture (committed page count). */
+    public long zPageAllocationCount;
+    /** Total bytes uncommitted (released back to OS) during the capture. */
+    public long zUncommittedBytes;
+    /** Count of ZUncommit events observed. */
+    public int  zUncommitEvents;
+
+    // ── Concurrent phase totals (from jdk.GarbageCollection name labels) ──
+    /** Sum of Concurrent Mark phase durations (ms). */
+    public double concurrentMarkMs;
+    /** Sum of Concurrent Relocate phase durations (ms). */
+    public double concurrentRelocateMs;
+    /** Count of Concurrent Mark phase samples. */
+    public int    concurrentMarkSamples;
+    /** Count of Concurrent Relocate phase samples. */
+    public int    concurrentRelocateSamples;
+
     // ── Derived booleans ────────────────────────────────────────────────────
     /** True when any GCHeapSummary sample shows committed > softMaxHeapBytes. */
     public boolean softMaxBreached;

--- a/argus-diagnostics/src/main/java/io/argus/diagnostics/zgc/ZgcJfrCollector.java
+++ b/argus-diagnostics/src/main/java/io/argus/diagnostics/zgc/ZgcJfrCollector.java
@@ -145,6 +145,14 @@ public final class ZgcJfrCollector {
                             markEndNs += durNs; markEndCount++;
                         } else if (name.contains("Pause Relocate Start")) {
                             relocStartNs += durNs; relocStartCount++;
+                        } else if (name.contains("Concurrent Mark")
+                                && !name.contains("Free")
+                                && !name.contains("Roots")) {
+                            d.concurrentMarkMs += durNs / 1_000_000.0;
+                            d.concurrentMarkSamples++;
+                        } else if (name.contains("Concurrent Relocate")) {
+                            d.concurrentRelocateMs += durNs / 1_000_000.0;
+                            d.concurrentRelocateSamples++;
                         }
                         break;
                     }
@@ -168,6 +176,24 @@ public final class ZgcJfrCollector {
                         String topFrame = extractTopUserFrame(event);
                         if (topFrame != null) {
                             allocCounts.merge(topFrame, 1L, Long::sum);
+                        }
+                        break;
+                    }
+                    case "jdk.ZPageAllocation": {
+                        d.zPageAllocationCount++;
+                        break;
+                    }
+                    case "jdk.ZUncommit": {
+                        d.zUncommitEvents++;
+                        // ZUncommit reports `to`/`from` (committed range collapsed back); sum the delta.
+                        try {
+                            long from = event.getLong("from");
+                            long to   = event.getLong("to");
+                            if (from > to) d.zUncommittedBytes += (from - to);
+                        } catch (Exception ignored) {
+                            // Fallback: try `size` field on older JDKs.
+                            try { d.zUncommittedBytes += event.getLong("size"); }
+                            catch (Exception ignored2) {}
                         }
                         break;
                     }

--- a/argus-diagnostics/src/main/java/io/argus/diagnostics/zgc/ZgcJfrCollector.java
+++ b/argus-diagnostics/src/main/java/io/argus/diagnostics/zgc/ZgcJfrCollector.java
@@ -186,15 +186,10 @@ public final class ZgcJfrCollector {
                     case "jdk.ZUncommit": {
                         d.zUncommitEvents++;
                         // ZUncommit reports `to`/`from` (committed range collapsed back); sum the delta.
-                        try {
-                            long from = event.getLong("from");
-                            long to   = event.getLong("to");
-                            if (from > to) d.zUncommittedBytes += (from - to);
-                        } catch (Exception ignored) {
-                            // Fallback: try `size` field on older JDKs.
-                            try { d.zUncommittedBytes += event.getLong("size"); }
-                            catch (Exception ignored2) {}
-                        }
+                        // Narrow catches to the JFR API exceptions for missing/typed fields so that
+                        // truly unexpected errors propagate instead of being swallowed silently.
+                        long delta = readUncommitDelta(event);
+                        if (delta > 0) d.zUncommittedBytes += delta;
                         break;
                     }
                     default:
@@ -236,6 +231,29 @@ public final class ZgcJfrCollector {
 
     private static String safeGetString(RecordedEvent event, String field) {
         try { return event.getString(field); } catch (Exception e) { return ""; }
+    }
+
+    /**
+     * Reads the bytes released by a {@code jdk.ZUncommit} event. The JFR field names
+     * are JDK-version-dependent — newer JDKs expose {@code from}/{@code to} (the
+     * collapsed committed range); older JDKs expose a single {@code size} field.
+     * Returns 0 when neither shape is present so the metric stays consistent.
+     * Narrow exceptions ({@link IllegalArgumentException}, {@link NullPointerException},
+     * {@link ClassCastException}) — anything else escapes so we don't mask real bugs.
+     */
+    static long readUncommitDelta(RecordedEvent event) {
+        try {
+            long from = event.getLong("from");
+            long to   = event.getLong("to");
+            return from > to ? (from - to) : 0;
+        } catch (IllegalArgumentException | NullPointerException | ClassCastException expected) {
+            // Field shape changed across JDK versions — try fallback.
+        }
+        try {
+            return event.getLong("size");
+        } catch (IllegalArgumentException | NullPointerException | ClassCastException expected) {
+            return 0;
+        }
     }
 
     /**

--- a/argus-diagnostics/src/test/java/io/argus/diagnostics/doctor/JvmSnapshotCollectorGcLogFlagTest.java
+++ b/argus-diagnostics/src/test/java/io/argus/diagnostics/doctor/JvmSnapshotCollectorGcLogFlagTest.java
@@ -1,0 +1,82 @@
+package io.argus.diagnostics.doctor;
+
+import io.argus.diagnostics.gclog.G1Stats;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests the {@code -Xlog:gc:file=<path>} flag detection used by
+ * {@link JvmSnapshotCollector#extractG1Stats(List, String)}.
+ *
+ * <p>The regex must:
+ * <ul>
+ *   <li>Capture the path (and only the path) when {@code :file=} is present.</li>
+ *   <li>Not match flags that log only to stdout/stderr (so JFR-aware doctor rules
+ *       don't fire spuriously on a wrongly-captured path).</li>
+ * </ul>
+ *
+ * <p>This test does not actually parse a GC log — it verifies the regex
+ * decision by checking whether extractG1Stats returns G1Stats.empty()
+ * when given non-G1 input. The interesting failure is the regex; we use
+ * an unreadable / non-existent path so the file-open path safely fails
+ * and returns empty(), which doesn't tell us anything about the regex.
+ * Instead we test the regex pattern directly via a tiny mirror.
+ */
+class JvmSnapshotCollectorGcLogFlagTest {
+
+    /** Mirror of the production pattern — keep in sync with JvmSnapshotCollector.GC_LOG_FILE_FLAG. */
+    private static final java.util.regex.Pattern PATTERN = java.util.regex.Pattern.compile(
+            "-Xlog:gc[^\\s]*?:file=([^:\\s,]+)", java.util.regex.Pattern.CASE_INSENSITIVE);
+
+    private static String matchPath(String flag) {
+        var m = PATTERN.matcher(flag);
+        return m.find() ? m.group(1) : null;
+    }
+
+    @Test
+    void simple_file_form_captures_path_only() {
+        assertEquals("/tmp/gc.log", matchPath("-Xlog:gc:file=/tmp/gc.log"));
+    }
+
+    @Test
+    void decorated_file_form_captures_path_only() {
+        // -Xlog:gc*=info:file=/var/log/gc.log:time,level,tags
+        assertEquals("/var/log/gc.log",
+                matchPath("-Xlog:gc*=info:file=/var/log/gc.log:time,level,tags"));
+    }
+
+    @Test
+    void without_file_eq_does_not_match() {
+        // -Xlog:gc:stdout — no file= → should not match.
+        assertNull(matchPath("-Xlog:gc:stdout"));
+    }
+
+    @Test
+    void without_file_eq_decorated_does_not_match() {
+        // -Xlog:gc=info:stderr — log to stderr, no file= → should not match.
+        assertNull(matchPath("-Xlog:gc=info:stderr"));
+    }
+
+    @Test
+    void unrelated_xlog_flag_does_not_match() {
+        assertNull(matchPath("-Xlog:os+thread=info"));
+    }
+
+    @Test
+    void extract_returns_empty_for_non_g1_collector() {
+        G1Stats result = JvmSnapshotCollector.extractG1Stats(
+                List.of("-Xlog:gc:file=/tmp/gc.log"), "ZGC");
+        assertSame(G1Stats.empty().getClass(), result.getClass());
+        assertFalse(result.present());
+    }
+
+    @Test
+    void extract_returns_empty_for_no_log_flag() {
+        G1Stats result = JvmSnapshotCollector.extractG1Stats(
+                List.of("-Xmx4g"), "G1 Young Generation");
+        assertFalse(result.present());
+    }
+}

--- a/argus-diagnostics/src/test/java/io/argus/diagnostics/doctor/rules/G1JfrRulesTest.java
+++ b/argus-diagnostics/src/test/java/io/argus/diagnostics/doctor/rules/G1JfrRulesTest.java
@@ -1,0 +1,135 @@
+package io.argus.diagnostics.doctor.rules;
+
+import io.argus.diagnostics.doctor.Finding;
+import io.argus.diagnostics.doctor.JvmSnapshot;
+import io.argus.diagnostics.doctor.Severity;
+import io.argus.diagnostics.gclog.G1Stats;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests for the three JFR/log-aware G1 doctor rules backed by {@link G1Stats}
+ * read from the GC log via {@code JvmSnapshotCollector.extractG1Stats}.
+ */
+class G1JfrRulesTest {
+
+    private static JvmSnapshot snapshot(String gcAlgorithm, List<String> flags, G1Stats g1) {
+        return new JvmSnapshot(
+                /* heapUsed     */ 0,
+                /* heapMax      */ 4L * 1024 * 1024 * 1024,
+                /* heapCommitted*/ 0,
+                /* nonHeapUsed  */ 0,
+                /* memoryPools  */ Map.of(),
+                /* collectors   */ List.of(new JvmSnapshot.GcInfo("G1 Young Generation", 100, 1500)),
+                /* totalGcCount */ 100,
+                /* totalGcTimeMs*/ 1500,
+                /* uptimeMs     */ 60_000,
+                /* processCpu   */ 0, /* systemCpu */ 0, /* procs */ 4,
+                /* threadCount  */ 0, /* daemon */ 0, /* peak */ 0,
+                /* threadStates */ Map.of(), /* deadlocked */ 0,
+                /* buffers      */ List.of(),
+                /* loadedClasses*/ 0, /* totalLoadedCl */ 0, /* unloadedCl */ 0,
+                /* pendingFin   */ 0,
+                "HotSpot 64-Bit Server VM", "21", gcAlgorithm, flags,
+                /* maxRecentPauseMs */ 0,
+                /* codeCacheUsedKb  */ 0, /* codeCacheSizeKb */ 0,
+                /* nmt              */ Map.of(),
+                g1);
+    }
+
+    // ── G1EvacuationFailureRule ──────────────────────────────────────────────
+
+    @Test
+    void evacuationFailure_fires_on_any_failure() {
+        G1Stats s = new G1Stats(/*evac*/ 2, 0, 0, 0, 0, 0, false);
+        List<Finding> f = new G1EvacuationFailureRule().evaluate(snapshot("G1", List.of(), s));
+        assertEquals(1, f.size());
+        assertEquals(Severity.CRITICAL, f.get(0).severity());
+        assertTrue(f.get(0).title().contains("evacuation"));
+    }
+
+    @Test
+    void evacuationFailure_silent_when_no_failure() {
+        G1Stats s = new G1Stats(0, 5, 8, 4, 1, 1, false);
+        assertTrue(new G1EvacuationFailureRule().evaluate(snapshot("G1", List.of(), s)).isEmpty());
+    }
+
+    @Test
+    void evacuationFailure_skipped_for_non_g1() {
+        G1Stats s = new G1Stats(2, 0, 0, 0, 0, 0, false);
+        assertTrue(new G1EvacuationFailureRule().evaluate(snapshot("ZGC", List.of(), s)).isEmpty());
+    }
+
+    // ── G1MixedStarvationRule ────────────────────────────────────────────────
+
+    @Test
+    void mixedStarvation_fires_when_concurrent_without_mixed() {
+        // 3 concurrent cycles, 0 mixed pauses → starvation suspected.
+        G1Stats s = new G1Stats(0, 0, 0, /*mixed*/ 0, 0, /*concurrent*/ 3, false);
+        List<Finding> f = new G1MixedStarvationRule().evaluate(snapshot("G1", List.of(), s));
+        assertEquals(1, f.size());
+        assertEquals(Severity.WARNING, f.get(0).severity());
+        assertTrue(f.get(0).title().contains("starvation"));
+    }
+
+    @Test
+    void mixedStarvation_silent_when_mixed_pauses_seen() {
+        G1Stats s = new G1Stats(0, 0, 0, /*mixed*/ 4, 0, /*concurrent*/ 3, false);
+        assertTrue(new G1MixedStarvationRule().evaluate(snapshot("G1", List.of(), s)).isEmpty());
+    }
+
+    @Test
+    void mixedStarvation_silent_when_concurrent_cycle_count_too_low() {
+        // Only 1 concurrent cycle — not enough data for confident starvation call.
+        G1Stats s = new G1Stats(0, 0, 0, 0, 0, /*concurrent*/ 1, false);
+        assertTrue(new G1MixedStarvationRule().evaluate(snapshot("G1", List.of(), s)).isEmpty());
+    }
+
+    @Test
+    void mixedStarvation_skipped_for_non_g1() {
+        G1Stats s = new G1Stats(0, 0, 0, 0, 0, 5, false);
+        assertTrue(new G1MixedStarvationRule().evaluate(snapshot("ZGC", List.of(), s)).isEmpty());
+    }
+
+    // ── G1HumongousPressureRule ──────────────────────────────────────────────
+
+    @Test
+    void humongous_fires_on_high_cycle_count() {
+        G1Stats s = new G1Stats(0, /*humCycles*/ 5, 0, 0, 0, 0, false);
+        List<Finding> f = new G1HumongousPressureRule().evaluate(snapshot("G1", List.of(), s));
+        assertEquals(1, f.size());
+        assertEquals(Severity.WARNING, f.get(0).severity());
+    }
+
+    @Test
+    void humongous_fires_on_high_peak_with_default_region_size() {
+        G1Stats s = new G1Stats(0, 0, /*humPeak*/ 20, 0, 0, 0, false);
+        List<Finding> f = new G1HumongousPressureRule().evaluate(snapshot("G1", List.of(), s));
+        assertEquals(1, f.size());
+    }
+
+    @Test
+    void humongous_silent_when_high_peak_with_explicit_region_size() {
+        // Operator already tuned region size — don't double-warn.
+        G1Stats s = new G1Stats(0, 0, 20, 0, 0, 0, false);
+        assertTrue(new G1HumongousPressureRule()
+                .evaluate(snapshot("G1", List.of("-XX:G1HeapRegionSize=16m"), s))
+                .isEmpty());
+    }
+
+    @Test
+    void humongous_silent_on_low_pressure() {
+        G1Stats s = new G1Stats(0, 1, 2, 0, 0, 0, false);
+        assertTrue(new G1HumongousPressureRule().evaluate(snapshot("G1", List.of(), s)).isEmpty());
+    }
+
+    @Test
+    void humongous_skipped_for_non_g1() {
+        G1Stats s = new G1Stats(0, 10, 30, 0, 0, 0, false);
+        assertTrue(new G1HumongousPressureRule().evaluate(snapshot("ZGC", List.of(), s)).isEmpty());
+    }
+}

--- a/argus-diagnostics/src/test/java/io/argus/diagnostics/doctor/rules/G1RulesTest.java
+++ b/argus-diagnostics/src/test/java/io/argus/diagnostics/doctor/rules/G1RulesTest.java
@@ -1,0 +1,174 @@
+package io.argus.diagnostics.doctor.rules;
+
+import io.argus.diagnostics.doctor.Finding;
+import io.argus.diagnostics.doctor.JvmSnapshot;
+import io.argus.diagnostics.doctor.Severity;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class G1RulesTest {
+
+    // ── helpers ──────────────────────────────────────────────────────────────
+
+    private static JvmSnapshot snapshot(String gcAlgorithm,
+                                        long heapMax,
+                                        List<JvmSnapshot.GcInfo> collectors,
+                                        List<String> flags) {
+        return new JvmSnapshot(
+                /* heapUsed     */ 0,
+                /* heapMax      */ heapMax,
+                /* heapCommitted*/ 0,
+                /* nonHeapUsed  */ 0,
+                /* memoryPools  */ Map.of(),
+                collectors,
+                /* totalGcCount */ collectors.stream().mapToLong(JvmSnapshot.GcInfo::count).sum(),
+                /* totalGcTimeMs*/ collectors.stream().mapToLong(JvmSnapshot.GcInfo::timeMs).sum(),
+                /* uptimeMs     */ 60_000,
+                /* processCpu   */ 0, /* systemCpu */ 0, /* procs */ 4,
+                /* threadCount  */ 0, /* daemon */ 0, /* peak */ 0,
+                /* threadStates */ Map.of(), /* deadlocked */ 0,
+                /* buffers      */ List.of(),
+                /* loadedClasses*/ 0, /* totalLoadedCl */ 0, /* unloadedCl */ 0,
+                /* pendingFin   */ 0,
+                "HotSpot 64-Bit Server VM", "21", gcAlgorithm, flags);
+    }
+
+    // ── G1FullGcRule ────────────────────────────────────────────────────────
+
+    @Test
+    void g1FullGc_fires_when_old_generation_count_positive() {
+        List<JvmSnapshot.GcInfo> gcs = List.of(
+                new JvmSnapshot.GcInfo("G1 Young Generation", 200, 1500),
+                new JvmSnapshot.GcInfo("G1 Old Generation", 1, 800)
+        );
+        JvmSnapshot s = snapshot("G1 Young Generation, G1 Old Generation",
+                4L * 1024 * 1024 * 1024, gcs, List.of());
+
+        List<Finding> findings = new G1FullGcRule().evaluate(s);
+        assertEquals(1, findings.size());
+        assertEquals(Severity.CRITICAL, findings.get(0).severity());
+        assertTrue(findings.get(0).title().contains("Full GC"));
+    }
+
+    @Test
+    void g1FullGc_silent_when_old_generation_count_zero() {
+        List<JvmSnapshot.GcInfo> gcs = List.of(
+                new JvmSnapshot.GcInfo("G1 Young Generation", 200, 1500),
+                new JvmSnapshot.GcInfo("G1 Old Generation", 0, 0)
+        );
+        JvmSnapshot s = snapshot("G1 Young Generation, G1 Old Generation",
+                4L * 1024 * 1024 * 1024, gcs, List.of());
+
+        assertTrue(new G1FullGcRule().evaluate(s).isEmpty());
+    }
+
+    @Test
+    void g1FullGc_skipped_for_non_g1_collector() {
+        List<JvmSnapshot.GcInfo> gcs = List.of(
+                new JvmSnapshot.GcInfo("ZGC Major Cycles", 5, 50)
+        );
+        JvmSnapshot s = snapshot("ZGC", 4L * 1024 * 1024 * 1024, gcs, List.of());
+        assertTrue(new G1FullGcRule().evaluate(s).isEmpty());
+    }
+
+    // ── G1RegionSizeRule ────────────────────────────────────────────────────
+
+    @Test
+    void regionSize_warns_when_large_heap_without_explicit_region() {
+        JvmSnapshot s = snapshot("G1 Young Generation",
+                64L * 1024 * 1024 * 1024,
+                List.of(new JvmSnapshot.GcInfo("G1 Young Generation", 10, 100)),
+                List.of() // no -XX:G1HeapRegionSize
+        );
+        List<Finding> findings = new G1RegionSizeRule().evaluate(s);
+        assertEquals(1, findings.size());
+        assertEquals(Severity.WARNING, findings.get(0).severity());
+    }
+
+    @Test
+    void regionSize_warns_on_tiny_region_with_nontiny_heap() {
+        JvmSnapshot s = snapshot("G1 Young Generation",
+                8L * 1024 * 1024 * 1024,
+                List.of(new JvmSnapshot.GcInfo("G1 Young Generation", 10, 100)),
+                List.of("-XX:G1HeapRegionSize=1m")
+        );
+        List<Finding> findings = new G1RegionSizeRule().evaluate(s);
+        assertEquals(1, findings.size());
+        assertTrue(findings.get(0).title().contains("Tiny"));
+    }
+
+    @Test
+    void regionSize_silent_on_well_configured() {
+        JvmSnapshot s = snapshot("G1 Young Generation",
+                8L * 1024 * 1024 * 1024,
+                List.of(new JvmSnapshot.GcInfo("G1 Young Generation", 10, 100)),
+                List.of("-XX:G1HeapRegionSize=16m")
+        );
+        assertTrue(new G1RegionSizeRule().evaluate(s).isEmpty());
+    }
+
+    @Test
+    void regionSize_skipped_for_non_g1() {
+        JvmSnapshot s = snapshot("ZGC", 64L * 1024 * 1024 * 1024,
+                List.of(), List.of());
+        assertTrue(new G1RegionSizeRule().evaluate(s).isEmpty());
+    }
+
+    // ── G1IhopConfigurationRule ─────────────────────────────────────────────
+
+    @Test
+    void ihop_warns_when_adaptive_off_and_manual_high() {
+        JvmSnapshot s = snapshot("G1 Young Generation",
+                4L * 1024 * 1024 * 1024,
+                List.of(new JvmSnapshot.GcInfo("G1 Young Generation", 10, 100)),
+                List.of("-XX:-G1UseAdaptiveIHOP", "-XX:InitiatingHeapOccupancyPercent=80")
+        );
+        List<Finding> findings = new G1IhopConfigurationRule().evaluate(s);
+        assertEquals(1, findings.size());
+        assertEquals(Severity.WARNING, findings.get(0).severity());
+    }
+
+    @Test
+    void ihop_silent_when_adaptive_on() {
+        JvmSnapshot s = snapshot("G1 Young Generation",
+                4L * 1024 * 1024 * 1024,
+                List.of(new JvmSnapshot.GcInfo("G1 Young Generation", 10, 100)),
+                List.of("-XX:+G1UseAdaptiveIHOP", "-XX:InitiatingHeapOccupancyPercent=80")
+        );
+        assertTrue(new G1IhopConfigurationRule().evaluate(s).isEmpty());
+    }
+
+    @Test
+    void ihop_silent_when_no_explicit_flag() {
+        // default: adaptive on, IHOP 45 — both healthy
+        JvmSnapshot s = snapshot("G1 Young Generation",
+                4L * 1024 * 1024 * 1024,
+                List.of(new JvmSnapshot.GcInfo("G1 Young Generation", 10, 100)),
+                List.of()
+        );
+        assertTrue(new G1IhopConfigurationRule().evaluate(s).isEmpty());
+    }
+
+    @Test
+    void ihop_silent_when_adaptive_off_but_threshold_safe() {
+        JvmSnapshot s = snapshot("G1 Young Generation",
+                4L * 1024 * 1024 * 1024,
+                List.of(new JvmSnapshot.GcInfo("G1 Young Generation", 10, 100)),
+                List.of("-XX:-G1UseAdaptiveIHOP", "-XX:InitiatingHeapOccupancyPercent=45")
+        );
+        assertTrue(new G1IhopConfigurationRule().evaluate(s).isEmpty());
+    }
+
+    @Test
+    void ihop_skipped_for_non_g1() {
+        JvmSnapshot s = snapshot("ZGC", 4L * 1024 * 1024 * 1024,
+                List.of(),
+                List.of("-XX:-G1UseAdaptiveIHOP", "-XX:InitiatingHeapOccupancyPercent=90")
+        );
+        assertTrue(new G1IhopConfigurationRule().evaluate(s).isEmpty());
+    }
+}

--- a/argus-diagnostics/src/test/java/io/argus/diagnostics/g1/G1BaselineLocaleTest.java
+++ b/argus-diagnostics/src/test/java/io/argus/diagnostics/g1/G1BaselineLocaleTest.java
@@ -1,0 +1,97 @@
+package io.argus.diagnostics.g1;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Locale;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Verifies that G1Baseline save/load survives a non-English locale.
+ *
+ * <p>Without {@code Locale.ROOT} on the {@code String.format} calls, German /
+ * French locales produce "42,5" while the parseDouble regex expects "42.5",
+ * silently zeroing every floating-point field on reload.
+ */
+class G1BaselineLocaleTest {
+
+    private Locale previous;
+
+    @BeforeEach
+    void switchLocale() {
+        previous = Locale.getDefault();
+        Locale.setDefault(Locale.GERMANY);
+    }
+
+    @AfterEach
+    void restoreLocale() {
+        Locale.setDefault(previous);
+    }
+
+    @Test
+    void roundtrip_preserves_floats_in_german_locale(@TempDir Path tmp) throws Exception {
+        G1Diagnosis d = new G1Diagnosis();
+        d.usingG1 = true;
+        d.regionSizeMb = 16;
+        d.targetPauseMs = 200;
+        d.heapCommittedBytes = 4L * 1024 * 1024 * 1024;
+        d.maxPauseMs = 184.5;
+        d.avgYoungPauseMs = 38.2;
+        d.avgMmuPercent = 95.1;
+        d.minMmuPercent = 88.3;
+        d.predictedIhopPercent = 45.0;
+        d.actualIhopPercent = 46.2;
+
+        Path file = tmp.resolve("g1.baseline");
+        G1Baseline.save(file, d, 12345);
+        G1Baseline loaded = G1Baseline.load(file);
+
+        // Without Locale.ROOT these would all be 0.0.
+        assertEquals(184.5, loaded.maxPauseMs, 0.01);
+        assertEquals(38.2, loaded.avgYoungPauseMs, 0.01);
+        assertEquals(95.1, loaded.avgMmuPercent, 0.01);
+        assertEquals(88.3, loaded.minMmuPercent, 0.01);
+        assertEquals(45.0, loaded.predictedIhopPercent, 0.01);
+        assertEquals(46.2, loaded.actualIhopPercent, 0.01);
+    }
+
+    @Test
+    void diff_maxPause_marks_zero_to_high_as_regression(@TempDir Path tmp) throws Exception {
+        // Baseline captured during warm-up with no GC events yet.
+        G1Diagnosis base = new G1Diagnosis();
+        base.maxPauseMs = 0;
+        Path f = tmp.resolve("base.props");
+        G1Baseline.save(f, base, 1);
+
+        // Current capture shows 100ms pauses — 0 → 100 should be REGRESSION, not WARN.
+        G1Diagnosis current = new G1Diagnosis();
+        current.maxPauseMs = 100;
+
+        List<G1Baseline.DiffRow> rows = G1Baseline.diff(G1Baseline.load(f), current);
+        G1Baseline.DiffRow row = rows.stream()
+                .filter(r -> "maxPause".equals(r.label())).findFirst().orElseThrow();
+        assertEquals(G1Baseline.Severity.REGRESSION, row.severity());
+    }
+
+    @Test
+    void diff_includes_ihop_mistimed_row(@TempDir Path tmp) throws Exception {
+        G1Diagnosis base = new G1Diagnosis();
+        base.ihopMistimed = false;
+        Path f = tmp.resolve("base.props");
+        G1Baseline.save(f, base, 1);
+
+        G1Diagnosis current = new G1Diagnosis();
+        current.ihopMistimed = true;
+
+        List<G1Baseline.DiffRow> rows = G1Baseline.diff(G1Baseline.load(f), current);
+        G1Baseline.DiffRow row = rows.stream()
+                .filter(r -> "ihopMistimed".equals(r.label())).findFirst().orElseThrow();
+        assertEquals(G1Baseline.Severity.REGRESSION, row.severity());
+        assertEquals("NEW", row.delta());
+    }
+}

--- a/argus-diagnostics/src/test/java/io/argus/diagnostics/g1/G1BaselineTest.java
+++ b/argus-diagnostics/src/test/java/io/argus/diagnostics/g1/G1BaselineTest.java
@@ -1,0 +1,115 @@
+package io.argus.diagnostics.g1;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Path;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class G1BaselineTest {
+
+    @Test
+    void save_then_load_roundtrip(@TempDir Path tmp) throws Exception {
+        G1Diagnosis d = new G1Diagnosis();
+        d.usingG1 = true;
+        d.regionSizeMb = 16;
+        d.targetPauseMs = 200;
+        d.ihopPercent = 45;
+        d.adaptiveIhop = true;
+        d.heapCommittedBytes = 4L * 1024 * 1024 * 1024;
+        d.maxHeapBytes = 8L * 1024 * 1024 * 1024;
+        d.totalRegions = 2048;
+        d.edenRegions = 400;
+        d.youngCycles = 120;
+        d.mixedCycles = 8;
+        d.maxPauseMs = 120.4;
+        d.avgMmuPercent = 95.2;
+        d.minMmuPercent = 88.1;
+
+        Path file = tmp.resolve("g1.baseline");
+        G1Baseline.save(file, d, 12345);
+
+        G1Baseline loaded = G1Baseline.load(file);
+        assertEquals(12345, loaded.pid);
+        assertEquals(16, loaded.regionSizeMb);
+        assertEquals(200, loaded.targetPauseMs);
+        assertEquals(45, loaded.ihopPercent);
+        assertTrue(loaded.adaptiveIhop);
+        assertEquals(4L * 1024 * 1024 * 1024, loaded.heapCommittedBytes);
+        assertEquals(2048, loaded.totalRegions);
+        assertEquals(120, loaded.youngCycles);
+        assertEquals(8, loaded.mixedCycles);
+        assertEquals(120.4, loaded.maxPauseMs, 0.01);
+        assertEquals(95.2, loaded.avgMmuPercent, 0.01);
+    }
+
+    @Test
+    void diff_marks_new_full_gc_as_regression(@TempDir Path tmp) throws Exception {
+        G1Diagnosis base = new G1Diagnosis();
+        base.usingG1 = true;
+        base.fullGcSeen = false;
+        Path f = tmp.resolve("base.props");
+        G1Baseline.save(f, base, 1);
+
+        G1Diagnosis current = new G1Diagnosis();
+        current.usingG1 = true;
+        current.fullGcSeen = true;
+        current.fullGcCycles = 1;
+
+        List<G1Baseline.DiffRow> rows = G1Baseline.diff(G1Baseline.load(f), current);
+
+        G1Baseline.DiffRow fullRow = rows.stream()
+                .filter(r -> "fullGcSeen".equals(r.label())).findFirst().orElseThrow();
+        assertEquals(G1Baseline.Severity.REGRESSION, fullRow.severity());
+        assertEquals("NEW", fullRow.delta());
+    }
+
+    @Test
+    void diff_marks_new_evacuation_failure_as_regression(@TempDir Path tmp) throws Exception {
+        G1Diagnosis base = new G1Diagnosis();
+        Path f = tmp.resolve("base.props");
+        G1Baseline.save(f, base, 1);
+
+        G1Diagnosis current = new G1Diagnosis();
+        current.evacuationFailureSeen = true;
+
+        List<G1Baseline.DiffRow> rows = G1Baseline.diff(G1Baseline.load(f), current);
+        G1Baseline.DiffRow row = rows.stream()
+                .filter(r -> "evacuationFailure".equals(r.label())).findFirst().orElseThrow();
+        assertEquals(G1Baseline.Severity.REGRESSION, row.severity());
+    }
+
+    @Test
+    void diff_marks_max_pause_increase_above_50pct_as_regression(@TempDir Path tmp) throws Exception {
+        G1Diagnosis base = new G1Diagnosis();
+        base.maxPauseMs = 100;
+        Path f = tmp.resolve("base.props");
+        G1Baseline.save(f, base, 1);
+
+        G1Diagnosis current = new G1Diagnosis();
+        current.maxPauseMs = 200; // +100% — well over 50%
+
+        List<G1Baseline.DiffRow> rows = G1Baseline.diff(G1Baseline.load(f), current);
+        G1Baseline.DiffRow row = rows.stream()
+                .filter(r -> "maxPause".equals(r.label())).findFirst().orElseThrow();
+        assertEquals(G1Baseline.Severity.REGRESSION, row.severity());
+    }
+
+    @Test
+    void diff_marks_mmu_drop_above_20pct_as_regression(@TempDir Path tmp) throws Exception {
+        G1Diagnosis base = new G1Diagnosis();
+        base.minMmuPercent = 90;
+        Path f = tmp.resolve("base.props");
+        G1Baseline.save(f, base, 1);
+
+        G1Diagnosis current = new G1Diagnosis();
+        current.minMmuPercent = 60; // dropped 33%
+
+        List<G1Baseline.DiffRow> rows = G1Baseline.diff(G1Baseline.load(f), current);
+        G1Baseline.DiffRow row = rows.stream()
+                .filter(r -> "minMmu".equals(r.label())).findFirst().orElseThrow();
+        assertEquals(G1Baseline.Severity.REGRESSION, row.severity());
+    }
+}

--- a/argus-diagnostics/src/test/java/io/argus/diagnostics/g1/G1DiagnosisVerdictTest.java
+++ b/argus-diagnostics/src/test/java/io/argus/diagnostics/g1/G1DiagnosisVerdictTest.java
@@ -1,0 +1,89 @@
+package io.argus.diagnostics.g1;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class G1DiagnosisVerdictTest {
+
+    @Test
+    void healthy_when_no_pathology() {
+        G1Diagnosis d = new G1Diagnosis();
+        d.targetPauseMs = 200;
+        d.maxPauseMs = 80; // < target
+        d.youngCycles = 50;
+        d.mixedCycles = 4;
+        assertEquals(G1Diagnosis.Verdict.HEALTHY, d.compute());
+    }
+
+    @Test
+    void unhealthy_when_full_gc_seen() {
+        G1Diagnosis d = new G1Diagnosis();
+        d.targetPauseMs = 200;
+        d.fullGcSeen = true;
+        d.fullGcCycles = 1;
+        assertEquals(G1Diagnosis.Verdict.UNHEALTHY, d.compute());
+    }
+
+    @Test
+    void unhealthy_when_evacuation_failure() {
+        G1Diagnosis d = new G1Diagnosis();
+        d.targetPauseMs = 200;
+        d.evacuationFailureSeen = true;
+        d.evacuationFailures = 1;
+        assertEquals(G1Diagnosis.Verdict.UNHEALTHY, d.compute());
+    }
+
+    @Test
+    void warning_when_mixed_starvation() {
+        G1Diagnosis d = new G1Diagnosis();
+        d.targetPauseMs = 200;
+        d.mixedStarvation = true;
+        assertEquals(G1Diagnosis.Verdict.WARNING, d.compute());
+    }
+
+    @Test
+    void warning_when_ihop_mistimed() {
+        G1Diagnosis d = new G1Diagnosis();
+        d.targetPauseMs = 200;
+        d.ihopMistimed = true;
+        assertEquals(G1Diagnosis.Verdict.WARNING, d.compute());
+    }
+
+    @Test
+    void warning_when_humongous_cycles_present() {
+        G1Diagnosis d = new G1Diagnosis();
+        d.targetPauseMs = 200;
+        d.humongousAllocationCycles = 3;
+        assertEquals(G1Diagnosis.Verdict.WARNING, d.compute());
+    }
+
+    @Test
+    void warning_when_max_pause_exceeds_2x_target() {
+        G1Diagnosis d = new G1Diagnosis();
+        d.targetPauseMs = 200;
+        d.maxPauseMs = 450; // > 2 × 200
+        assertEquals(G1Diagnosis.Verdict.WARNING, d.compute());
+    }
+
+    @Test
+    void full_gc_dominates_other_warnings() {
+        G1Diagnosis d = new G1Diagnosis();
+        d.targetPauseMs = 200;
+        d.fullGcSeen = true;
+        d.mixedStarvation = true;
+        d.humongousAllocationCycles = 5;
+        assertEquals(G1Diagnosis.Verdict.UNHEALTHY, d.compute());
+    }
+
+    @Test
+    void default_target_pause_falls_back_to_200_when_zero() {
+        G1Diagnosis d = new G1Diagnosis();
+        d.targetPauseMs = 0; // unknown
+        d.maxPauseMs = 350; // < 400 (2 × default 200) → still HEALTHY
+        assertEquals(G1Diagnosis.Verdict.HEALTHY, d.compute());
+
+        d.maxPauseMs = 410; // > 400
+        assertEquals(G1Diagnosis.Verdict.WARNING, d.compute());
+    }
+}

--- a/argus-diagnostics/src/test/java/io/argus/diagnostics/gclog/G1StatsParserTest.java
+++ b/argus-diagnostics/src/test/java/io/argus/diagnostics/gclog/G1StatsParserTest.java
@@ -22,8 +22,7 @@ class G1StatsParserTest {
     }
 
     @Test
-    void evacuation_failure_counted() throws Exception {
-        @TempDir Path tmp = Files.createTempDirectory("g1log");
+    void evacuation_failure_counted(@TempDir Path tmp) throws Exception {
         Path log = writeLog(tmp, ""
                 + "[0.500s][info][gc] GC(1) Pause Young (Normal) (G1 Evacuation Pause) 256M->250M(512M) 12.5ms\n"
                 + "[0.800s][info][gc] GC(2) To-space exhausted\n"
@@ -33,8 +32,7 @@ class G1StatsParserTest {
     }
 
     @Test
-    void humongous_signals_collected() throws Exception {
-        @TempDir Path tmp = Files.createTempDirectory("g1log");
+    void humongous_signals_collected(@TempDir Path tmp) throws Exception {
         Path log = writeLog(tmp, ""
                 + "[0.500s][info][gc] GC(1) Pause Young (Normal) (G1 Humongous Allocation) 256M->250M(512M) 12.5ms\n"
                 + "[0.700s][info][gc,heap] GC(2) Humongous regions: 4->6\n"
@@ -45,8 +43,7 @@ class G1StatsParserTest {
     }
 
     @Test
-    void mixed_vs_prepare_mixed_distinguished() throws Exception {
-        @TempDir Path tmp = Files.createTempDirectory("g1log");
+    void mixed_vs_prepare_mixed_distinguished(@TempDir Path tmp) throws Exception {
         Path log = writeLog(tmp, ""
                 + "[1.000s][info][gc] GC(1) Pause Young (Prepare Mixed) (G1 Evacuation Pause) 256M->250M(512M) 12.5ms\n"
                 + "[2.000s][info][gc] GC(2) Pause Young (Mixed) (G1 Evacuation Pause) 250M->245M(512M) 14.2ms\n"
@@ -57,8 +54,7 @@ class G1StatsParserTest {
     }
 
     @Test
-    void concurrent_cycle_markers_counted() throws Exception {
-        @TempDir Path tmp = Files.createTempDirectory("g1log");
+    void concurrent_cycle_markers_counted(@TempDir Path tmp) throws Exception {
         Path log = writeLog(tmp, ""
                 + "[1.000s][info][gc] GC(1) Concurrent Mark Cycle\n"
                 + "[2.000s][info][gc] GC(2) Concurrent Mark Cycle\n");
@@ -67,8 +63,7 @@ class G1StatsParserTest {
     }
 
     @Test
-    void mixed_starvation_suspected_when_concurrent_without_mixed() throws Exception {
-        @TempDir Path tmp = Files.createTempDirectory("g1log");
+    void mixed_starvation_suspected_when_concurrent_without_mixed(@TempDir Path tmp) throws Exception {
         Path log = writeLog(tmp, ""
                 + "[1.000s][info][gc] GC(1) Concurrent Mark Cycle\n"
                 + "[2.000s][info][gc] GC(2) Concurrent Mark Cycle\n");
@@ -77,8 +72,7 @@ class G1StatsParserTest {
     }
 
     @Test
-    void non_g1_log_yields_empty_stats() throws Exception {
-        @TempDir Path tmp = Files.createTempDirectory("g1log");
+    void non_g1_log_yields_empty_stats(@TempDir Path tmp) throws Exception {
         Path log = writeLog(tmp, ""
                 + "[0.500s][info][gc] GC(1) Pause Mark Start 0.4ms\n"
                 + "[0.800s][info][gc] GC(1) Pause Mark End 2.1ms\n");
@@ -88,8 +82,7 @@ class G1StatsParserTest {
     }
 
     @Test
-    void full_gc_seen_on_pause_full() throws Exception {
-        @TempDir Path tmp = Files.createTempDirectory("g1log");
+    void full_gc_seen_on_pause_full(@TempDir Path tmp) throws Exception {
         Path log = writeLog(tmp, ""
                 + "[1.000s][info][gc] GC(1) Pause Full (G1 Compaction Pause) 512M->500M(512M) 850ms\n");
         GcLogParser.ParseResult result = GcLogParser.parseWithPhases(log);

--- a/argus-diagnostics/src/test/java/io/argus/diagnostics/gclog/G1StatsParserTest.java
+++ b/argus-diagnostics/src/test/java/io/argus/diagnostics/gclog/G1StatsParserTest.java
@@ -1,0 +1,98 @@
+package io.argus.diagnostics.gclog;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests that {@link GcLogParser#parseWithPhases} populates {@link G1Stats}
+ * from a synthetic G1 log fragment.
+ */
+class G1StatsParserTest {
+
+    private static Path writeLog(Path dir, String content) throws IOException {
+        Path f = dir.resolve("gc.log");
+        Files.writeString(f, content);
+        return f;
+    }
+
+    @Test
+    void evacuation_failure_counted() throws Exception {
+        @TempDir Path tmp = Files.createTempDirectory("g1log");
+        Path log = writeLog(tmp, ""
+                + "[0.500s][info][gc] GC(1) Pause Young (Normal) (G1 Evacuation Pause) 256M->250M(512M) 12.5ms\n"
+                + "[0.800s][info][gc] GC(2) To-space exhausted\n"
+                + "[1.000s][info][gc] GC(3) Pause Young (Normal) (G1 Evacuation Pause) 260M->258M(512M) 14.2ms\n");
+        GcLogParser.ParseResult result = GcLogParser.parseWithPhases(log);
+        assertEquals(1, result.g1Stats().evacuationFailures());
+    }
+
+    @Test
+    void humongous_signals_collected() throws Exception {
+        @TempDir Path tmp = Files.createTempDirectory("g1log");
+        Path log = writeLog(tmp, ""
+                + "[0.500s][info][gc] GC(1) Pause Young (Normal) (G1 Humongous Allocation) 256M->250M(512M) 12.5ms\n"
+                + "[0.700s][info][gc,heap] GC(2) Humongous regions: 4->6\n"
+                + "[0.900s][info][gc] GC(2) Pause Young (Normal) (G1 Humongous Allocation) 260M->258M(512M) 14.2ms\n");
+        GcLogParser.ParseResult result = GcLogParser.parseWithPhases(log);
+        assertEquals(2, result.g1Stats().humongousAllocationCycles());
+        assertEquals(6, result.g1Stats().humongousRegionsPeak());
+    }
+
+    @Test
+    void mixed_vs_prepare_mixed_distinguished() throws Exception {
+        @TempDir Path tmp = Files.createTempDirectory("g1log");
+        Path log = writeLog(tmp, ""
+                + "[1.000s][info][gc] GC(1) Pause Young (Prepare Mixed) (G1 Evacuation Pause) 256M->250M(512M) 12.5ms\n"
+                + "[2.000s][info][gc] GC(2) Pause Young (Mixed) (G1 Evacuation Pause) 250M->245M(512M) 14.2ms\n"
+                + "[3.000s][info][gc] GC(3) Pause Young (Mixed) (G1 Evacuation Pause) 248M->242M(512M) 13.8ms\n");
+        GcLogParser.ParseResult result = GcLogParser.parseWithPhases(log);
+        assertEquals(2, result.g1Stats().mixedPauses());
+        assertEquals(1, result.g1Stats().prepareMixedPauses());
+    }
+
+    @Test
+    void concurrent_cycle_markers_counted() throws Exception {
+        @TempDir Path tmp = Files.createTempDirectory("g1log");
+        Path log = writeLog(tmp, ""
+                + "[1.000s][info][gc] GC(1) Concurrent Mark Cycle\n"
+                + "[2.000s][info][gc] GC(2) Concurrent Mark Cycle\n");
+        GcLogParser.ParseResult result = GcLogParser.parseWithPhases(log);
+        assertEquals(2, result.g1Stats().concurrentCycleMarkers());
+    }
+
+    @Test
+    void mixed_starvation_suspected_when_concurrent_without_mixed() throws Exception {
+        @TempDir Path tmp = Files.createTempDirectory("g1log");
+        Path log = writeLog(tmp, ""
+                + "[1.000s][info][gc] GC(1) Concurrent Mark Cycle\n"
+                + "[2.000s][info][gc] GC(2) Concurrent Mark Cycle\n");
+        GcLogParser.ParseResult result = GcLogParser.parseWithPhases(log);
+        assertTrue(result.g1Stats().mixedStarvationSuspected());
+    }
+
+    @Test
+    void non_g1_log_yields_empty_stats() throws Exception {
+        @TempDir Path tmp = Files.createTempDirectory("g1log");
+        Path log = writeLog(tmp, ""
+                + "[0.500s][info][gc] GC(1) Pause Mark Start 0.4ms\n"
+                + "[0.800s][info][gc] GC(1) Pause Mark End 2.1ms\n");
+        GcLogParser.ParseResult result = GcLogParser.parseWithPhases(log);
+        assertFalse(result.g1Stats().present(),
+                "Expected empty G1Stats for ZGC log, got " + result.g1Stats());
+    }
+
+    @Test
+    void full_gc_seen_on_pause_full() throws Exception {
+        @TempDir Path tmp = Files.createTempDirectory("g1log");
+        Path log = writeLog(tmp, ""
+                + "[1.000s][info][gc] GC(1) Pause Full (G1 Compaction Pause) 512M->500M(512M) 850ms\n");
+        GcLogParser.ParseResult result = GcLogParser.parseWithPhases(log);
+        assertTrue(result.g1Stats().fullGcSeen());
+    }
+}

--- a/argus-diagnostics/src/test/java/io/argus/diagnostics/gcscore/GcScoreCalculatorG1Test.java
+++ b/argus-diagnostics/src/test/java/io/argus/diagnostics/gcscore/GcScoreCalculatorG1Test.java
@@ -1,0 +1,104 @@
+package io.argus.diagnostics.gcscore;
+
+import io.argus.diagnostics.gclog.GcLogAnalysis;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class GcScoreCalculatorG1Test {
+
+    /**
+     * Construct a GcLogAnalysis with G1 cause keys and the specified pause/fullGc
+     * profile. Keeps remaining fields at sane defaults so the tests focus on
+     * what they're varying.
+     */
+    private static GcLogAnalysis g1Analysis(int totalEvents, int fullGcEvents,
+                                            long maxPauseMs, long p99PauseMs,
+                                            double durationSec, double throughputPct) {
+        Map<String, GcLogAnalysis.CauseStats> causes = Map.of(
+                "G1 Evacuation Pause",
+                new GcLogAnalysis.CauseStats("G1 Evacuation Pause",
+                        totalEvents - fullGcEvents, /*totalMs*/ p99PauseMs * (totalEvents - fullGcEvents),
+                        maxPauseMs, p99PauseMs / 2, p99PauseMs));
+        return new GcLogAnalysis(
+                /* totalEvents      */ totalEvents,
+                /* pauseEvents      */ totalEvents,
+                /* fullGcEvents     */ fullGcEvents,
+                /* concurrentEvents */ 0,
+                /* durationSec      */ durationSec,
+                /* throughputPercent*/ throughputPct,
+                /* totalPauseMs     */ p99PauseMs * totalEvents,
+                /* maxPauseMs       */ maxPauseMs,
+                /* p50PauseMs       */ p99PauseMs / 3,
+                /* p95PauseMs       */ p99PauseMs / 2,
+                /* p99PauseMs       */ p99PauseMs,
+                /* avgPauseMs       */ p99PauseMs / 2,
+                /* peakHeapKB       */ 0,
+                /* avgHeapAfterKB   */ 0,
+                causes,
+                List.of(),
+                /* rateAnalysis     */ null,
+                /* leakAnalysis     */ null);
+    }
+
+    @Test
+    void g1_branch_uses_standard_pause_scorers() {
+        // p99 = 350 ms → standard scorer returns WARN (200 < x ≤ 500).
+        GcLogAnalysis a = g1Analysis(100, 0, 400, 350, 60, 95);
+        GcScoreResult r = GcScoreCalculator.compute(a, "G1GC");
+        AxisScore p99 = r.axes().get(0);
+        assertEquals("Pause p99", p99.name());
+        assertEquals(AxisScore.Verdict.WARN, p99.verdict());
+    }
+
+    @Test
+    void g1_branch_weights_full_gc_higher_than_standard() {
+        // 10 Full GCs / 60s = 600/hour → standard scorer FAIL on both, but the
+        // G1 weight on this axis (0.25) is higher than standard (0.15), so the
+        // G1 score should be lower.
+        GcLogAnalysis a = g1Analysis(100, 10, 80, 60, 60, 99);
+
+        GcScoreResult g1Score  = GcScoreCalculator.compute(a, "G1GC");
+        GcScoreResult stdScore = GcScoreCalculator.compute(a, "");
+
+        assertTrue(g1Score.overall() < stdScore.overall(),
+                "G1 overall (" + g1Score.overall() + ") should be lower than standard ("
+                        + stdScore.overall() + ") when Full GC dominates");
+    }
+
+    @Test
+    void g1_axis_count_matches_standard_six() {
+        GcScoreResult r = GcScoreCalculator.compute(
+                g1Analysis(100, 0, 80, 60, 60, 99.5), "G1GC");
+        assertEquals(6, r.axes().size());
+    }
+
+    @Test
+    void g1_healthy_grade_is_A_or_B() {
+        GcScoreResult r = GcScoreCalculator.compute(
+                g1Analysis(120, 0, 80, 60, 60, 99.5), "G1GC");
+        assertTrue(r.grade().equals("A") || r.grade().equals("B"),
+                "Expected A or B for healthy G1, got " + r.grade() + " (overall=" + r.overall() + ")");
+    }
+
+    @Test
+    void g1_hint_for_full_gc_mentions_g1_specific_remedy() {
+        GcLogAnalysis a = g1Analysis(50, 5, 150, 100, 60, 97);
+        GcScoreResult r = GcScoreCalculator.compute(a, "G1GC");
+        List<String> hints = r.hints();
+        assertTrue(hints.stream().anyMatch(h -> h.contains("Full GC")
+                        && (h.contains("InitiatingHeapOccupancyPercent") || h.contains("argus heap"))),
+                "Expected G1-specific Full GC hint, got: " + hints);
+    }
+
+    @Test
+    void weights_sum_to_one_for_g1() {
+        double[] weights = new double[]{0.22, 0.13, 0.20, 0.25, 0.10, 0.10};
+        double sum = 0;
+        for (double w : weights) sum += w;
+        assertEquals(1.00, sum, 0.0001);
+    }
+}

--- a/argus-frontend/src/main/resources/public/index.html
+++ b/argus-frontend/src/main/resources/public/index.html
@@ -187,6 +187,17 @@
                 </div>
             </section>
 
+            <!-- Per-Collector Breakdown (G1 / ZGC slicing) — hidden until data arrives -->
+            <section class="content-section" id="gc-collector-section" hidden>
+                <div class="section-header">
+                    <h3>Per-Collector Breakdown</h3>
+                    <p class="section-desc">GC pause time and event count sliced by collector and cause. Surfaces G1 Mixed vs Young vs Full and ZGC Major vs Minor.</p>
+                </div>
+                <div id="gc-collector-breakdown" class="data-table">
+                    <div class="empty-state">Waiting for collector data...</div>
+                </div>
+            </section>
+
             <!-- CPU -->
             <section class="content-section">
                 <div class="section-header">

--- a/argus-frontend/src/main/resources/public/js/app.js
+++ b/argus-frontend/src/main/resources/public/js/app.js
@@ -540,6 +540,33 @@ function updateGCDisplay(data) {
         elements.gcType.textContent = names.length > 0 ? names.join(', ') : '—';
     }
     renderGCCauses(data);
+    renderCollectorBreakdown(data);
+}
+
+function renderCollectorBreakdown(data) {
+    const section = document.getElementById('gc-collector-section');
+    const list = document.getElementById('gc-collector-breakdown');
+    if (!section || !list) return;
+    const rows = (data.collectorBreakdown || []).slice();
+    if (rows.length === 0) {
+        section.hidden = true;
+        return;
+    }
+    section.hidden = false;
+    rows.sort((a, b) => (b.pauseMs || 0) - (a.pauseMs || 0));
+    const totalPause = rows.reduce((s, r) => s + (r.pauseMs || 0), 0);
+    const tbody = rows.map(r => {
+        const pause = parseFloat(r.pauseMs) || 0;
+        const share = totalPause > 0 ? (pause / totalPause * 100).toFixed(1) : '0.0';
+        const name = escapeHtml(r.gcName || 'Unknown');
+        const cause = escapeHtml(r.gcCause || 'Unknown');
+        const isG1Concern = (r.gcName && r.gcName.includes('Old Generation') && r.count > 0)
+                || (r.gcCause && r.gcCause.includes('Humongous'));
+        const rowClass = isG1Concern ? ' class="warn-row"' : '';
+        return `<tr${rowClass}><td class="mono">${name}</td><td class="mono">${cause}</td><td class="mono right">${formatNumber(r.count || 0)}</td><td class="mono right">${pause.toFixed(1)}ms</td><td class="mono right">${share}%</td></tr>`;
+    }).join('');
+    list.innerHTML = '<table class="simple-table"><thead><tr><th>Collector</th><th>Cause</th><th>Count</th><th>Pause</th><th>Share</th></tr></thead><tbody>'
+            + tbody + '</tbody></table>';
 }
 
 function renderGCCauses(data) {

--- a/argus-server/src/main/java/io/argus/server/analysis/GCAnalyzer.java
+++ b/argus-server/src/main/java/io/argus/server/analysis/GCAnalyzer.java
@@ -27,6 +27,11 @@ public final class GCAnalyzer {
     private final Map<String, AtomicLong> causeDistribution = new ConcurrentHashMap<>();
     private final List<GCSummary> recentGCs = new CopyOnWriteArrayList<>();
 
+    /** Cumulative pause-time aggregates keyed by {@code gcName + "|" + gcCause}. */
+    private final Map<String, AtomicLong> pauseTimeNanosByCollectorAndCause = new ConcurrentHashMap<>();
+    /** Cumulative event counts keyed by {@code gcName + "|" + gcCause}. */
+    private final Map<String, AtomicLong> eventCountByCollectorAndCause   = new ConcurrentHashMap<>();
+
     // Latest heap state
     private volatile long lastHeapUsed = 0;
     private volatile long lastHeapCommitted = 0;
@@ -58,6 +63,17 @@ public final class GCAnalyzer {
         if (event.gcCause() != null) {
             causeDistribution.computeIfAbsent(event.gcCause(), k -> new AtomicLong())
                     .incrementAndGet();
+        }
+
+        // Track per-collector × per-cause aggregates (separate from cause-only distribution)
+        String gcName = event.gcName() != null ? event.gcName() : "Unknown";
+        String gcCause = event.gcCause() != null ? event.gcCause() : "Unknown";
+        String key = gcName + "|" + gcCause;
+        eventCountByCollectorAndCause
+                .computeIfAbsent(key, k -> new AtomicLong()).incrementAndGet();
+        if (event.duration() > 0) {
+            pauseTimeNanosByCollectorAndCause
+                    .computeIfAbsent(key, k -> new AtomicLong()).addAndGet(event.duration());
         }
 
         // Update heap state
@@ -194,12 +210,34 @@ public final class GCAnalyzer {
     /**
      * Clears all recorded data.
      */
+    /**
+     * Returns cumulative pause time (in nanoseconds) keyed by
+     * {@code gcName + "|" + gcCause}. Used by the Prometheus exporter to emit
+     * per-collector labels. Returns an unmodifiable snapshot.
+     */
+    public Map<String, Long> getPauseBreakdownNanos() {
+        Map<String, Long> out = new java.util.HashMap<>();
+        pauseTimeNanosByCollectorAndCause.forEach((k, v) -> out.put(k, v.get()));
+        return Map.copyOf(out);
+    }
+
+    /**
+     * Returns cumulative event count keyed by {@code gcName + "|" + gcCause}.
+     */
+    public Map<String, Long> getEventBreakdown() {
+        Map<String, Long> out = new java.util.HashMap<>();
+        eventCountByCollectorAndCause.forEach((k, v) -> out.put(k, v.get()));
+        return Map.copyOf(out);
+    }
+
     public void clear() {
         totalGCEvents.set(0);
         totalPauseTimeNanos.set(0);
         maxPauseTimeNanos.set(0);
         causeDistribution.clear();
         recentGCs.clear();
+        pauseTimeNanosByCollectorAndCause.clear();
+        eventCountByCollectorAndCause.clear();
         lastHeapUsed = 0;
         lastHeapCommitted = 0;
         lastGCTime = null;

--- a/argus-server/src/main/java/io/argus/server/handler/ArgusChannelHandler.java
+++ b/argus-server/src/main/java/io/argus/server/handler/ArgusChannelHandler.java
@@ -604,6 +604,28 @@ public final class ArgusChannelHandler extends SimpleChannelInboundHandler<Objec
             sb.append("\"memoryReclaimed\":").append(gc.memoryReclaimed());
             sb.append("}");
         }
+        sb.append("],");
+
+        // Per-collector × per-cause breakdown — used by the frontend G1/ZGC widgets.
+        var pauseBreakdown = gcAnalyzer.getPauseBreakdownNanos();
+        var eventBreakdown = gcAnalyzer.getEventBreakdown();
+        sb.append("\"collectorBreakdown\":[");
+        boolean firstBd = true;
+        for (var entry : pauseBreakdown.entrySet()) {
+            if (!firstBd) sb.append(",");
+            firstBd = false;
+            String[] parts = entry.getKey().split("\\|", 2);
+            String gcName  = parts.length > 0 ? parts[0] : "Unknown";
+            String gcCause = parts.length > 1 ? parts[1] : "Unknown";
+            long count = eventBreakdown.getOrDefault(entry.getKey(), 0L);
+            double pauseMs = entry.getValue() / 1_000_000.0;
+            sb.append("{");
+            sb.append("\"gcName\":\"").append(escapeJson(gcName)).append("\",");
+            sb.append("\"gcCause\":\"").append(escapeJson(gcCause)).append("\",");
+            sb.append("\"pauseMs\":").append(String.format("%.2f", pauseMs)).append(",");
+            sb.append("\"count\":").append(count);
+            sb.append("}");
+        }
         sb.append("]");
 
         sb.append("}");

--- a/argus-server/src/main/java/io/argus/server/metrics/PrometheusMetricsCollector.java
+++ b/argus-server/src/main/java/io/argus/server/metrics/PrometheusMetricsCollector.java
@@ -206,6 +206,48 @@ public final class PrometheusMetricsCollector {
                 "Heap usage ratio (used/committed)",
                 analysis.currentHeapCommitted() > 0
                         ? (double) analysis.currentHeapUsed() / analysis.currentHeapCommitted() : 0);
+
+        // Per-collector × per-cause breakdown. Enables Grafana dashboards to slice
+        // by collector (G1 Young vs G1 Old vs ZGC Major) and by cause (G1 Evacuation Pause,
+        // Humongous Allocation, Allocation Failure, …).
+        var pauseBreakdown = gcAnalyzer.getPauseBreakdownNanos();
+        var eventBreakdown = gcAnalyzer.getEventBreakdown();
+        if (!pauseBreakdown.isEmpty()) {
+            sb.append("# HELP argus_gc_pause_breakdown_seconds_total ")
+                    .append("Cumulative GC pause time per collector and cause\n");
+            sb.append("# TYPE argus_gc_pause_breakdown_seconds_total counter\n");
+            for (var entry : pauseBreakdown.entrySet()) {
+                String[] parts = entry.getKey().split("\\|", 2);
+                String gcName  = parts.length > 0 ? parts[0] : "Unknown";
+                String gcCause = parts.length > 1 ? parts[1] : "Unknown";
+                String labels = KubernetesLabels.mergeLabels(
+                        "{gc_name=\"" + escapeLabel(gcName)
+                                + "\",gc_cause=\"" + escapeLabel(gcCause) + "\"}");
+                sb.append("argus_gc_pause_breakdown_seconds_total")
+                        .append(labels)
+                        .append(' ')
+                        .append(String.format("%.6f", entry.getValue() / 1_000_000_000.0))
+                        .append('\n');
+            }
+        }
+        if (!eventBreakdown.isEmpty()) {
+            sb.append("# HELP argus_gc_events_breakdown_total ")
+                    .append("Cumulative GC event count per collector and cause\n");
+            sb.append("# TYPE argus_gc_events_breakdown_total counter\n");
+            for (var entry : eventBreakdown.entrySet()) {
+                String[] parts = entry.getKey().split("\\|", 2);
+                String gcName  = parts.length > 0 ? parts[0] : "Unknown";
+                String gcCause = parts.length > 1 ? parts[1] : "Unknown";
+                String labels = KubernetesLabels.mergeLabels(
+                        "{gc_name=\"" + escapeLabel(gcName)
+                                + "\",gc_cause=\"" + escapeLabel(gcCause) + "\"}");
+                sb.append("argus_gc_events_breakdown_total")
+                        .append(labels)
+                        .append(' ')
+                        .append(entry.getValue())
+                        .append('\n');
+            }
+        }
     }
 
     private void appendCPUMetrics(StringBuilder sb) {

--- a/deploy/sdkman/argus-candidate.json
+++ b/deploy/sdkman/argus-candidate.json
@@ -1,7 +1,7 @@
 {
   "candidate": "argus",
   "name": "Argus JVM Diagnostic Toolkit",
-  "description": "68 CLI commands for JVM diagnostics — health diagnosis, GC analysis, flame graphs, interactive TUI",
+  "description": "69 CLI commands for JVM diagnostics — health diagnosis, GC analysis, flame graphs, interactive TUI",
   "websiteUrl": "https://github.com/rlaope/Argus",
   "distribution": "PLATFORM_SPECIFIC",
   "platform": {

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,7 +9,7 @@ Welcome to the Project Argus documentation.
 
 ## Reference
 
-- [CLI Command Reference](cli-commands.md) — Index of all 68 commands with category navigation and A–Z lookup
+- [CLI Command Reference](cli-commands.md) — Index of all 69 commands with category navigation and A–Z lookup
   - [commands/monitoring.md](commands/monitoring.md) — ps, info, env, top, watch, report, diff, alert, cluster, perfcounter, tui
   - [commands/memory-gc.md](commands/memory-gc.md) — gc, heap, histo, nmt, buffers, metaspace, gclog, gcscore, zgc, and more
   - [commands/profiling-tracing.md](commands/profiling-tracing.md) — profile, flame, jfr, jfranalyze, slowlog, trace, benchmark

--- a/docs/cli-commands.md
+++ b/docs/cli-commands.md
@@ -1,6 +1,6 @@
 # Argus CLI Command Reference
 
-Complete reference for all 68 Argus CLI commands. Commands are organized into five categories. Each category page contains full synopses, option tables, and output samples. Use the alphabetical index at the bottom to jump directly to any command.
+Complete reference for all 69 Argus CLI commands. Commands are organized into five categories. Each category page contains full synopses, option tables, and output samples. Use the alphabetical index at the bottom to jump directly to any command.
 
 ## Global Options
 
@@ -88,6 +88,7 @@ Heap inspection, GC statistics, NIO buffers, metaspace, classloader leaks, GC lo
 - `argus gcwhy` — narrate the worst GC pause in plain English
 - `argus gcprofile` — JFR-based allocation profiling
 - `argus heapanalyze` — offline HPROF analysis (MAT alternative)
+- `argus g1` — G1GC live health verdict (HEALTHY/WARNING/UNHEALTHY)
 - `argus zgc` — ZGC live health verdict (HEALTHY/WARNING/UNHEALTHY)
 
 ---
@@ -172,6 +173,7 @@ Thread state summaries, full thread dumps, deadlock detection, and thread pool d
 | `argus explain` | [Runtime & JVM Internals](commands/runtime-internals.md#argus-explain-term) |
 | `argus finalizer` | [Memory & GC](commands/memory-gc.md#argus-finalizer-pid) |
 | `argus flame` | [Profiling & Tracing](commands/profiling-tracing.md#argus-flame-pid) |
+| `argus g1` | [Memory & GC](commands/memory-gc.md#argus-g1-pid) |
 | `argus gc` | [Memory & GC](commands/memory-gc.md#argus-gc-pid) |
 | `argus gccause` | [Memory & GC](commands/memory-gc.md#argus-gccause-pid) |
 | `argus gclog` | [Memory & GC](commands/memory-gc.md#argus-gclog) |

--- a/docs/commands/memory-gc.md
+++ b/docs/commands/memory-gc.md
@@ -678,11 +678,16 @@ The diff classifies each row as INFO / WARN / REGRESSION. Newly-present Full GC,
 
 **Companion doctor rules** (run via `argus doctor <PID>`):
 
-| Rule | Severity | Fires when |
-|------|----------|-----------|
-| G1FullGcRule | CRITICAL | `G1 Old Generation` collector count > 0 |
-| G1RegionSizeRule | WARNING | Heap > 32 GB without `-XX:G1HeapRegionSize`, or tiny explicit region on a non-tiny heap |
-| G1IhopConfigurationRule | WARNING | `-XX:-G1UseAdaptiveIHOP` with manual IHOP ≥ 70% |
+| Rule | Severity | Fires when | Source |
+|------|----------|-----------|--------|
+| G1FullGcRule | CRITICAL | `G1 Old Generation` collector count > 0 | MXBean |
+| G1RegionSizeRule | WARNING | Heap > 32 GB without `-XX:G1HeapRegionSize`, or tiny explicit region on a non-tiny heap | VM flags + heap |
+| G1IhopConfigurationRule | WARNING | `-XX:-G1UseAdaptiveIHOP` with manual IHOP ≥ 70% | VM flags |
+| G1EvacuationFailureRule | CRITICAL | "To-space exhausted" / "Evacuation Failure" in GC log | GC log |
+| G1MixedStarvationRule | WARNING | ≥ 2 concurrent mark cycles complete with no Mixed pause | GC log |
+| G1HumongousPressureRule | WARNING | ≥ 3 humongous-allocation cycles, or peak ≥ 10 humongous regions with default region size | GC log |
+
+The last three rules consume `G1Stats` parsed by `JvmSnapshotCollector` from the file referenced by `-Xlog:gc:file=<path>` (max 10 MB). Without that flag the rules stay silent.
 
 ---
 

--- a/docs/commands/memory-gc.md
+++ b/docs/commands/memory-gc.md
@@ -24,6 +24,7 @@ Commands for inspecting heap memory, garbage collection activity, and memory lea
 - [argus gcwhy](#argus-gcwhy)
 - [argus gcprofile](#argus-gcprofile)
 - [argus heapanalyze \<file.hprof\>](#argus-heapanalyze-filehprof)
+- [argus g1 \<pid\>](#argus-g1-pid)
 - [argus zgc \<pid\>](#argus-zgc-pid)
 
 ---
@@ -603,6 +604,85 @@ Options:
 - `--format=json` — JSON output
 
 Exit codes: `0` = success, `2` = parse error.
+
+---
+
+## argus g1 \<pid\>
+
+One-shot G1GC health verdict from a live JFR capture. Pre-checks via JMX that the target JVM is using G1, then starts a `JFR.start` recording with `settings=profile`, waits for the capture window, dumps and parses the recording, and prints a structured report with a HEALTHY / WARNING / UNHEALTHY verdict.
+
+```
+argus g1 <PID> [--duration=N] [--save=PATH] [--diff=PATH] [--watch[=N]] [--interval=N]
+```
+
+```bash
+$ argus g1 <PID>
+$ argus g1 <PID> --duration=60    # extend capture to 60s (5–120 range)
+$ argus g1 <PID> --save=/tmp/g1-baseline.txt
+$ argus g1 <PID> --diff=/tmp/g1-baseline.txt
+$ argus g1 <PID> --watch --interval=60
+$ argus g1 <PID> --watch=10 --interval=60
+```
+
+**Sample output (WARNING with humongous pressure):**
+
+```
+G1 Diagnosis (PID 18420, JDK 21, Adaptive IHOP)
+═══════════════════════════════════════════════
+  Config     target 200ms · region 8MB · IHOP 45%
+  Heap         committed 4.0 GiB / max 8.0 GiB
+  Regions      eden 200 · survivor 12 · old 320 · humongous 18 / total 1024
+  Cycles       42 young, 5 mixed, 2 concurrent, 0 full (avg young 38.2ms, avg mixed 92.1ms, max 184.5ms)
+  Evacuation   ✓ no failures · young 1.8 GB · old 240 MB
+  MMU          min 88.3%, avg 95.1%
+  IHOP         predicted 45.0% / actual 46.2%
+  Humongous    ⚠ 3 cycle(s) triggered by humongous allocation
+               Top humongous-class alloc sites during capture (n=512 events)
+                1. com.example.report.ReportBuilder.buildPdf(ReportBuilder.java:88)   (210 allocs, max 12 MB)
+                2. com.example.cache.LocalCache.preload(LocalCache.java:42)           (180 allocs, max 8.4 MB)
+
+Verdict: WARNING  — humongous allocation cycles observed.
+Recommend:
+  • Raise -XX:G1HeapRegionSize=16m so humongous threshold rises above common allocations
+```
+
+**Verdict table:**
+
+| Verdict | Condition |
+|---------|-----------|
+| UNHEALTHY | Full GC observed **or** evacuation failure ("to-space exhausted") |
+| WARNING | Mixed-cycle starvation, IHOP timing off, humongous allocation cycles, **or** max pause > 2 × target |
+| HEALTHY | None of the above |
+
+**Options:**
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `--duration=N` | 30 | JFR capture window in seconds (clamped to 5–120) |
+| `--save=PATH` | | Capture once, render normally, and persist a baseline to PATH |
+| `--diff=PATH` | | Capture once, compare against baseline at PATH, render diff table (suppresses normal verdict) |
+| `--watch[=N]` | | Loop indefinitely (`--watch`) or for N iterations (`--watch=N`). Each iteration captures using `--interval`, prints a 1-line summary. Every 5th iteration prints the full diagnosis table. Ctrl-C prints a final summary and cleans up JFR. |
+| `--interval=N` | 30 | JFR capture duration and watch loop period in seconds (clamped to 10–300) |
+
+**Subscribed JFR events:** `jdk.G1GarbageCollection` (cycle type), `jdk.G1HeapSummary` (region counts), `jdk.G1EvacuationYoungStatistics` / `jdk.G1EvacuationOldStatistics` (evac bytes + failure flag), `jdk.G1MMU` (mutator utilization), `jdk.G1AdaptiveIHOP` (predicted vs. actual threshold), `jdk.GarbageCollection` (Full GC + Mixed labels for older JDKs), `jdk.ObjectAllocationOutsideTLAB` (humongous-class hotspots, gated on `bytes ≥ regionSize/2`).
+
+**Trend tracking:**
+
+```bash
+argus g1 12345 --save=/tmp/g1-baseline.txt
+# … later, after deploy or config change …
+argus g1 12345 --diff=/tmp/g1-baseline.txt
+```
+
+The diff classifies each row as INFO / WARN / REGRESSION. Newly-present Full GC, evacuation failure, or mixed starvation are REGRESSION. Max-pause increases > 50% and MMU drops > 20% are REGRESSION.
+
+**Companion doctor rules** (run via `argus doctor <PID>`):
+
+| Rule | Severity | Fires when |
+|------|----------|-----------|
+| G1FullGcRule | CRITICAL | `G1 Old Generation` collector count > 0 |
+| G1RegionSizeRule | WARNING | Heap > 32 GB without `-XX:G1HeapRegionSize`, or tiny explicit region on a non-tiny heap |
+| G1IhopConfigurationRule | WARNING | `-XX:-G1UseAdaptiveIHOP` with manual IHOP ≥ 70% |
 
 ---
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -365,7 +365,7 @@ try (var executor = Executors.newVirtualThreadPerTaskExecutor()) {
 
 | Feature | Java 11+ | Java 17+ | Java 21+ |
 |---------|:--------:|:--------:|:--------:|
-| CLI (68 commands) | ✅ | ✅ | ✅ |
+| CLI (69 commands) | ✅ | ✅ | ✅ |
 | Dashboard & Web UI | — | ✅ | ✅ |
 | GC Analysis | CLI only | ✅ MXBean | ✅ JFR |
 | Virtual Thread Monitoring | — | — | ✅ JFR |

--- a/site/commands.html
+++ b/site/commands.html
@@ -91,7 +91,7 @@ argus histo 12345</code></pre>
                 <p class="video-caption">Argus CLI in action — diagnosing a running JVM process</p>
 
                 <span class="section-anchor" id="command-reference"></span>
-                <h3>All 68 Commands</h3>
+                <h3>All 69 Commands</h3>
 
                 <p>Every command follows the same pattern: <code>argus &lt;command&gt; &lt;pid&gt;</code>. All commands support <code>--format=json</code> for scripting and <code>--source=auto|agent|jdk</code> to control the data source.</p>
 

--- a/site/index.html
+++ b/site/index.html
@@ -67,7 +67,7 @@
                         <span class="badge green">Java 11+ CLI</span>
                         <span class="badge green">Java 17+ Dashboard</span>
                         <span class="badge green">Java 21+ Full Features</span>
-                        <span class="badge">68 Commands</span>
+                        <span class="badge">69 Commands</span>
                         <span class="badge">Zero Dependencies</span>
                         <span class="badge green">v1.4.0</span>
                     </div>
@@ -75,7 +75,7 @@
 
                 <p>Argus gives you two tools for JVM diagnostics:</p>
                 <ul>
-                    <li><strong>Argus CLI</strong> — 68 diagnostic commands that work on any running JVM. No agent, no restart, no configuration. Point at a PID and get answers in seconds.</li>
+                    <li><strong>Argus CLI</strong> — 69 diagnostic commands that work on any running JVM. No agent, no restart, no configuration. Point at a PID and get answers in seconds.</li>
                     <li><strong>Argus Agent</strong> — Attach as a Java agent and get a live web dashboard with GC timelines, CPU graphs, heap usage, flame graphs, and thread analysis, all streaming in real time.</li>
                 </ul>
 
@@ -98,7 +98,7 @@
                 <div class="feature-grid">
                     <div class="feature-card">
                         <h4>Instant CLI Diagnostics</h4>
-                        <p>68 commands that work on any running JVM. No agent, no restart, no configuration. Just point at a PID and get answers in seconds.</p>
+                        <p>69 commands that work on any running JVM. No agent, no restart, no configuration. Just point at a PID and get answers in seconds.</p>
                     </div>
                     <div class="feature-card">
                         <h4>Real-time Dashboard</h4>

--- a/site/reference.html
+++ b/site/reference.html
@@ -65,7 +65,7 @@
                             <tr><th>Feature</th><th>Java 11+</th><th>Java 17+</th><th>Java 21+</th></tr>
                         </thead>
                         <tbody>
-                            <tr><td>CLI (68 commands)</td><td>Yes</td><td>Yes</td><td>Yes</td></tr>
+                            <tr><td>CLI (69 commands)</td><td>Yes</td><td>Yes</td><td>Yes</td></tr>
                             <tr><td>Dashboard &amp; Web UI</td><td>—</td><td>Yes (MXBean)</td><td>Yes (JFR)</td></tr>
                             <tr><td>GC / CPU / Memory</td><td>CLI only</td><td>Yes</td><td>Yes</td></tr>
                             <tr><td>Allocation Tracking</td><td>—</td><td>—</td><td>Yes</td></tr>
@@ -100,7 +100,7 @@
                             <tr><td><code>argus-agent</code></td><td>Java agent entry point, JFR streaming engine, MXBean polling engine</td></tr>
                             <tr><td><code>argus-server</code></td><td>Netty HTTP/WebSocket server, 10 analyzers, metrics export</td></tr>
                             <tr><td><code>argus-frontend</code></td><td>Dashboard web UI (vanilla JS, Chart.js, D3 flame graph)</td></tr>
-                            <tr><td><code>argus-cli</code></td><td>68 diagnostic commands using jcmd/jstat</td></tr>
+                            <tr><td><code>argus-cli</code></td><td>69 diagnostic commands using jcmd/jstat</td></tr>
                             <tr><td><code>argus-micrometer</code></td><td>Framework-agnostic Micrometer MeterBinder</td></tr>
                             <tr><td><code>argus-spring-boot-starter</code></td><td>Spring Boot auto-configuration</td></tr>
                         </tbody>


### PR DESCRIPTION
## Summary

G1 parity-with-ZGC graduate **plus** every "Out of scope" follow-up folded in per user request. Two commits:

**Commit 1 — Core G1 parity (`14d2af1`)**
- `argus g1 <PID>` — new CLI command mirroring `argus zgc` (single-shot / `--save` / `--diff` / `--watch[=N]`) with HEALTHY / WARNING / UNHEALTHY verdict + G1-specific report sections.
- `diagnostics/g1/` package: `G1Diagnosis`, `G1JfrCollector` (7 G1-specific JFR events), `G1Baseline`.
- 3 snapshot-based doctor rules: `G1FullGcRule` (CRITICAL), `G1RegionSizeRule` (WARNING), `G1IhopConfigurationRule` (WARNING).
- `GcScoreCalculator` G1 branch — standard scorers, Full-GC weighted 0.25 (vs 0.15 standard), G1-specific hints.
- `GcLogPatterns` 5 G1 regexes, 52 i18n keys × 4 locales, SPI registration, command count 68 → 69.

**Commit 2 — Folded follow-ups (`4537d4b`)**
- **GC log parser G1Stats integration**: new `G1Stats` class, `ParseResult.g1Stats()`, `GcLogAnalysis.g1Stats()`, `GcLogAnalyzer.analyze(ParseResult)` overload. Patterns from Commit 1 are now actually consumed.
- **3 JFR/log-aware doctor rules**: `G1EvacuationFailureRule` (CRITICAL), `G1MixedStarvationRule` (WARNING), `G1HumongousPressureRule` (WARNING). Backed by `JvmSnapshot.g1Stats()` auto-populated by `JvmSnapshotCollector` from `-Xlog:gc*:file=<path>` (max 10 MB).
- **ZGC residual JFR events**: `ZgcJfrCollector` now handles `jdk.ZPageAllocation`, `jdk.ZUncommit`, and extracts Concurrent Mark / Concurrent Relocate phase totals from the label stream. 6 new informational fields on `ZgcDiagnosis`.
- **Prometheus per-collector labels**: `GCAnalyzer` aggregates pause time + event count by `(gcName, gcCause)`; emits `argus_gc_pause_breakdown_seconds_total` + `argus_gc_events_breakdown_total` with `gc_name` / `gc_cause` labels (K8s labels preserved).
- **Frontend G1 widget**: `/gc-analysis` response extended with `collectorBreakdown[]`. New "Per-Collector Breakdown" section in `index.html` (hidden until data arrives) renders G1 Old / G1 Young / G1 Mixed / ZGC Major / Minor with pause/count/share columns; humongous causes + G1 Old Gen with non-zero counts are flagged.

## Test plan

- [x] `./gradlew :argus-cli:fatJar :argus-diagnostics:test :argus-server:test :argus-cli:test` → BUILD SUCCESSFUL locally on both commits
- [x] 4-locale parity preserved at 650 keys / 52 g1 keys (no new keys added in commit 2)
- [x] Smoke: `argus --help` shows "69 commands" with `argus g1` entry
- [x] New tests:
  - Commit 1: `G1DiagnosisVerdictTest` (9), `G1BaselineTest` (5), `G1RulesTest` (11 across 3 snapshot rules), `GcScoreCalculatorG1Test` (6)
  - Commit 2: `G1JfrRulesTest` (11 across 3 JFR-aware rules), `G1StatsParserTest` (7 GC-log parse cases)
- [ ] CI: build (ubuntu/macos/windows × 21/22) + DCO + code-quality + runtime smoke (11/17/21)
- [ ] Manual end-to-end (post-merge):
  - `argus g1 <PID>` against a JVM with `-XX:+UseG1GC`
  - `argus doctor <PID>` with `-Xlog:gc:file=/tmp/gc.log` set — new JFR-aware rules light up
  - `curl http://<server>/prometheus | grep gc_pause_breakdown` — per-collector labels visible
  - Dashboard `/index.html` — "Per-Collector Breakdown" panel appears after first GC event

## Remaining out-of-scope (not in PR, deferred)

- `ZgcBaseline` roundtrip of the 6 new ZGC fields — `ZgcBaseline` is diff-focused; new fields are informational only.
- Grafana dashboard JSON template using the new per-collector labels — `deploy/grafana/` documentation artifact, not code.
- Generational ZGC remembered-set diagnostics — too JVM-internal for the operator surface.
- G1 remembered-set scrubbing analysis — same.