### PR TITLE
feat(metrics,profiling): Phase 1 — Prometheus→8 + continuous-profiling foundation

### DIFF
--- a/argus-aggregator/src/main/java/io/argus/aggregator/profile/ProfileStore.java
+++ b/argus-aggregator/src/main/java/io/argus/aggregator/profile/ProfileStore.java
@@ -1,0 +1,307 @@
+package io.argus.aggregator.profile;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.net.URLDecoder;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.DirectoryStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.locks.ReentrantLock;
+
+/**
+ * Disk-backed, append-only, time-windowed store of collapsed-stack profile
+ * samples — a Pyroscope-lite local profile store with no external TSDB.
+ *
+ * <p>Samples are keyed by {@code (podId, service, eventType, windowStart)} where
+ * {@code windowStart} is the epoch-millis floor of the sample timestamp to the
+ * configured window width (default 60s). Each window is a segment file holding
+ * {@code count\tstack} records; appending the same stack across appends or
+ * windows is summed by the {@link #merged} read path.
+ *
+ * <h2>Disk layout</h2>
+ * <pre>
+ *   &lt;baseDir&gt;/&lt;encodedKey&gt;/&lt;windowStartMillis&gt;.seg
+ * </pre>
+ * where {@code encodedKey} is {@code enc(podId)+'~'+enc(service)+'~'+enc(eventType)}
+ * (each field URL-encoded so it is filesystem-safe). Each segment file is
+ * self-describing: line 1 is a header
+ * {@code ARGUSPROF1 enc(podId) enc(service) enc(eventType) windowStartMillis};
+ * subsequent lines are {@code count\tstack} records appended on every
+ * {@link #append}. On construction the store re-indexes by scanning the base
+ * directory, so profiles survive a process restart.
+ *
+ * <h2>Thread-safety</h2>
+ * Append/evict/read are guarded so the background scrape loop can call
+ * {@link #append} from multiple threads safely. Per-window writes are serialized
+ * via a per-key lock; the segment index is a {@link ConcurrentHashMap}.
+ */
+public final class ProfileStore {
+
+    private static final System.Logger LOG = System.getLogger(ProfileStore.class.getName());
+
+    private static final String MAGIC = "ARGUSPROF1";
+    private static final String SEG_SUFFIX = ".seg";
+    private static final char KEY_SEP = '~';
+
+    private final ProfileStoreConfig config;
+    /** windowKey ("encodedKey/windowStartMillis") -> segment file path. */
+    private final Map<String, Path> segments = new ConcurrentHashMap<>();
+    /** Per-window write lock so concurrent appends to the same window serialize. */
+    private final Map<String, ReentrantLock> locks = new ConcurrentHashMap<>();
+
+    public ProfileStore(ProfileStoreConfig config) {
+        this.config = config;
+        try {
+            Files.createDirectories(config.baseDir());
+        } catch (IOException e) {
+            throw new UncheckedIOException("cannot create profile-store base dir " + config.baseDir(), e);
+        }
+        reindex();
+    }
+
+    public ProfileStoreConfig config() {
+        return config;
+    }
+
+    // ── Write path ───────────────────────────────────────────────────────────
+
+    /**
+     * Appends a set of collapsed stacks to the window covering {@code timestampMillis}.
+     *
+     * <p>The stacks are summed into the existing window on read; this method only
+     * appends new record lines, so it is O(stacks) and never rewrites the file.
+     *
+     * @param podId            originating pod id (non-null, non-blank)
+     * @param service          logical service name (may be empty)
+     * @param eventType        async-profiler event ("cpu", "alloc", "lock", …)
+     * @param timestampMillis  sample wall-clock time; floored to the window start
+     * @param collapsedCounts  {@code stack -> sampleCount} for this capture cycle
+     */
+    public void append(String podId, String service, String eventType,
+                        long timestampMillis, Map<String, Long> collapsedCounts) {
+        if (podId == null || podId.isBlank()) {
+            throw new IllegalArgumentException("podId must not be blank");
+        }
+        if (eventType == null || eventType.isBlank()) {
+            throw new IllegalArgumentException("eventType must not be blank");
+        }
+        if (collapsedCounts == null || collapsedCounts.isEmpty()) {
+            return;
+        }
+        String svc = service == null ? "" : service;
+        long windowStart = config.windowStartFor(timestampMillis);
+        String encodedKey = encodeKey(podId, svc, eventType);
+        String windowKey = encodedKey + '/' + windowStart;
+
+        ReentrantLock lock = locks.computeIfAbsent(windowKey, k -> new ReentrantLock());
+        lock.lock();
+        try {
+            Path seg = segments.get(windowKey);
+            StringBuilder sb = new StringBuilder();
+            if (seg == null) {
+                Path dir = config.baseDir().resolve(encodedKey);
+                Files.createDirectories(dir);
+                seg = dir.resolve(windowStart + SEG_SUFFIX);
+                if (!Files.exists(seg)) {
+                    sb.append(MAGIC).append(' ')
+                      .append(enc(podId)).append(' ')
+                      .append(enc(svc)).append(' ')
+                      .append(enc(eventType)).append(' ')
+                      .append(windowStart).append('\n');
+                }
+                segments.put(windowKey, seg);
+            }
+            for (Map.Entry<String, Long> e : collapsedCounts.entrySet()) {
+                long count = e.getValue() == null ? 0L : e.getValue();
+                if (count == 0L) {
+                    continue;
+                }
+                // Records are count<TAB>stack; stacks never contain a tab.
+                sb.append(count).append('\t').append(sanitizeStack(e.getKey())).append('\n');
+            }
+            Files.writeString(seg, sb.toString(), StandardCharsets.UTF_8,
+                    StandardOpenOption.CREATE, StandardOpenOption.APPEND);
+        } catch (IOException e) {
+            throw new UncheckedIOException("failed to append profile window " + windowKey, e);
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    // ── Retention ─────────────────────────────────────────────────────────────
+
+    /** Evicts (deletes) every window whose start is strictly before {@code cutoff}. */
+    public void evictOlderThan(Instant cutoff) {
+        long cutoffMillis = cutoff.toEpochMilli();
+        for (Map.Entry<String, Path> e : segments.entrySet()) {
+            long windowStart = windowStartOf(e.getKey());
+            if (windowStart < cutoffMillis) {
+                ReentrantLock lock = locks.computeIfAbsent(e.getKey(), k -> new ReentrantLock());
+                lock.lock();
+                try {
+                    Files.deleteIfExists(e.getValue());
+                    segments.remove(e.getKey());
+                } catch (IOException io) {
+                    LOG.log(System.Logger.Level.WARNING,
+                            "failed to evict profile window " + e.getKey(), io);
+                } finally {
+                    lock.unlock();
+                }
+            }
+        }
+    }
+
+    /** Evicts windows older than the configured retention relative to now. */
+    public void evictExpired() {
+        evictOlderThan(Instant.now().minus(config.retention()));
+    }
+
+    // ── Read path (the seam the later query API calls) ─────────────────────────
+
+    /**
+     * Merges all windows for {@code (podId, eventType)} whose window-start falls in
+     * {@code [from, to)} into a single {@code stack -> totalCount} map, summing
+     * counts across windows and across services for that pod.
+     *
+     * <p>This is the read seam the Phase-2 query API will build a flamegraph from.
+     * It is cheap: it streams each matching segment file and sums in memory.
+     */
+    public Map<String, Long> merged(String podId, String eventType, Instant from, Instant to) {
+        long fromMillis = from.toEpochMilli();
+        long toMillis = to.toEpochMilli();
+        Map<String, Long> out = new HashMap<>();
+        for (Map.Entry<String, Path> e : segments.entrySet()) {
+            long windowStart = windowStartOf(e.getKey());
+            if (windowStart < fromMillis || windowStart >= toMillis) {
+                continue;
+            }
+            Header header = readHeader(e.getValue());
+            if (header == null) {
+                continue;
+            }
+            if (!header.podId.equals(podId) || !header.eventType.equals(eventType)) {
+                continue;
+            }
+            sumRecords(e.getValue(), out);
+        }
+        return out;
+    }
+
+    // ── Re-index on boot ────────────────────────────────────────────────────────
+
+    /** Scans the base dir and rebuilds the in-memory segment index. */
+    private void reindex() {
+        segments.clear();
+        if (!Files.isDirectory(config.baseDir())) {
+            return;
+        }
+        try (DirectoryStream<Path> keyDirs = Files.newDirectoryStream(config.baseDir())) {
+            for (Path keyDir : keyDirs) {
+                if (!Files.isDirectory(keyDir)) {
+                    continue;
+                }
+                String encodedKey = keyDir.getFileName().toString();
+                try (DirectoryStream<Path> segFiles = Files.newDirectoryStream(keyDir, "*" + SEG_SUFFIX)) {
+                    for (Path seg : segFiles) {
+                        String fileName = seg.getFileName().toString();
+                        String windowStartStr = fileName.substring(0, fileName.length() - SEG_SUFFIX.length());
+                        try {
+                            Long.parseLong(windowStartStr); // validate
+                            segments.put(encodedKey + '/' + windowStartStr, seg);
+                        } catch (NumberFormatException ignored) {
+                            // not a window segment; skip
+                        }
+                    }
+                }
+            }
+        } catch (IOException e) {
+            LOG.log(System.Logger.Level.WARNING, "profile-store reindex failed", e);
+        }
+    }
+
+    // ── Helpers ──────────────────────────────────────────────────────────────
+
+    private static long windowStartOf(String windowKey) {
+        int slash = windowKey.lastIndexOf('/');
+        return Long.parseLong(windowKey.substring(slash + 1));
+    }
+
+    private static void sumRecords(Path seg, Map<String, Long> out) {
+        try {
+            boolean first = true;
+            for (String line : Files.readAllLines(seg, StandardCharsets.UTF_8)) {
+                if (first) {
+                    first = false;
+                    continue; // header
+                }
+                if (line.isEmpty()) {
+                    continue;
+                }
+                int tab = line.indexOf('\t');
+                if (tab < 0) {
+                    continue;
+                }
+                long count;
+                try {
+                    count = Long.parseLong(line.substring(0, tab));
+                } catch (NumberFormatException e) {
+                    continue;
+                }
+                String stack = line.substring(tab + 1);
+                out.merge(stack, count, Long::sum);
+            }
+        } catch (IOException e) {
+            LOG.log(System.Logger.Level.WARNING, "failed to read profile segment " + seg, e);
+        }
+    }
+
+    private static Header readHeader(Path seg) {
+        try {
+            for (String line : Files.readAllLines(seg, StandardCharsets.UTF_8)) {
+                if (line.startsWith(MAGIC + " ")) {
+                    String[] parts = line.split(" ");
+                    if (parts.length >= 5) {
+                        return new Header(dec(parts[1]), dec(parts[2]), dec(parts[3]));
+                    }
+                }
+                return null; // header must be line 1
+            }
+        } catch (IOException e) {
+            LOG.log(System.Logger.Level.WARNING, "failed to read profile header " + seg, e);
+        }
+        return null;
+    }
+
+    private static String encodeKey(String podId, String service, String eventType) {
+        return enc(podId) + KEY_SEP + enc(service) + KEY_SEP + enc(eventType);
+    }
+
+    private static String enc(String s) {
+        return URLEncoder.encode(s, StandardCharsets.UTF_8);
+    }
+
+    private static String dec(String s) {
+        return URLDecoder.decode(s, StandardCharsets.UTF_8);
+    }
+
+    /** Strips any tab / newline so a stack stays a single record line. */
+    private static String sanitizeStack(String stack) {
+        if (stack == null) {
+            return "";
+        }
+        if (stack.indexOf('\t') < 0 && stack.indexOf('\n') < 0 && stack.indexOf('\r') < 0) {
+            return stack;
+        }
+        return stack.replace('\t', ' ').replace('\n', ' ').replace('\r', ' ');
+    }
+
+    /** Decoded segment header fields. */
+    private record Header(String podId, String service, String eventType) {}
+}

--- a/argus-aggregator/src/main/java/io/argus/aggregator/profile/ProfileStore.java
+++ b/argus-aggregator/src/main/java/io/argus/aggregator/profile/ProfileStore.java
@@ -176,10 +176,16 @@ public final class ProfileStore {
     public Map<String, Long> merged(String podId, String eventType, Instant from, Instant to) {
         long fromMillis = from.toEpochMilli();
         long toMillis = to.toEpochMilli();
+        long windowMillis = config.windowMillis();
         Map<String, Long> out = new HashMap<>();
         for (Map.Entry<String, Path> e : segments.entrySet()) {
             long windowStart = windowStartOf(e.getKey());
-            if (windowStart < fromMillis || windowStart >= toMillis) {
+            // A window [windowStart, windowStart+windowMillis) overlaps the query
+            // [fromMillis, toMillis) iff it starts before `to` AND ends after `from`.
+            // Filtering on windowStart alone dropped windows that begin before `from`
+            // but still hold in-range samples (sub-window-aligned queries).
+            long windowEnd = windowStart + windowMillis;
+            if (windowStart >= toMillis || windowEnd <= fromMillis) {
                 continue;
             }
             Header header = readHeader(e.getValue());

--- a/argus-aggregator/src/main/java/io/argus/aggregator/profile/ProfileStoreConfig.java
+++ b/argus-aggregator/src/main/java/io/argus/aggregator/profile/ProfileStoreConfig.java
@@ -1,0 +1,78 @@
+package io.argus.aggregator.profile;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.time.Duration;
+
+/**
+ * Configuration for {@link ProfileStore}: where profiles live on disk, how wide
+ * each time window is, and how long windows are retained.
+ *
+ * <p>Defaults follow the W1 continuous-profiling roadmap: a 60s window cadence
+ * and a 24h ring retention, stored under {@code ~/.argus/profile-store/}.
+ * No external configuration framework is needed — construct via the static
+ * factories or the all-args constructor.
+ */
+public final class ProfileStoreConfig {
+
+    /** Default base directory: {@code ~/.argus/profile-store/}. */
+    public static final Path DEFAULT_BASE_DIR =
+            Paths.get(System.getProperty("user.home"), ".argus", "profile-store");
+
+    /** Default window width: 60 seconds. */
+    public static final Duration DEFAULT_WINDOW = Duration.ofSeconds(60);
+
+    /** Default ring retention: 24 hours. */
+    public static final Duration DEFAULT_RETENTION = Duration.ofHours(24);
+
+    private final Path baseDir;
+    private final Duration window;
+    private final Duration retention;
+
+    public ProfileStoreConfig(Path baseDir, Duration window, Duration retention) {
+        if (baseDir == null) {
+            throw new IllegalArgumentException("baseDir must not be null");
+        }
+        if (window == null || window.isZero() || window.isNegative()) {
+            throw new IllegalArgumentException("window must be positive");
+        }
+        if (retention == null || retention.isZero() || retention.isNegative()) {
+            throw new IllegalArgumentException("retention must be positive");
+        }
+        this.baseDir = baseDir;
+        this.window = window;
+        this.retention = retention;
+    }
+
+    /** Returns the canonical defaults (24h retention, 60s window, {@code ~/.argus/profile-store}). */
+    public static ProfileStoreConfig defaults() {
+        return new ProfileStoreConfig(DEFAULT_BASE_DIR, DEFAULT_WINDOW, DEFAULT_RETENTION);
+    }
+
+    /** Returns defaults rooted at a caller-supplied base directory (handy for tests). */
+    public static ProfileStoreConfig at(Path baseDir) {
+        return new ProfileStoreConfig(baseDir, DEFAULT_WINDOW, DEFAULT_RETENTION);
+    }
+
+    public Path baseDir() {
+        return baseDir;
+    }
+
+    public Duration window() {
+        return window;
+    }
+
+    public Duration retention() {
+        return retention;
+    }
+
+    public long windowMillis() {
+        return window.toMillis();
+    }
+
+    /** Floors a timestamp to the start of its window (epoch millis). */
+    public long windowStartFor(long timestampMillis) {
+        long w = windowMillis();
+        return (timestampMillis / w) * w;
+    }
+}

--- a/argus-aggregator/src/test/java/io/argus/aggregator/ProfileStoreTest.java
+++ b/argus-aggregator/src/test/java/io/argus/aggregator/ProfileStoreTest.java
@@ -1,0 +1,114 @@
+package io.argus.aggregator;
+
+import io.argus.aggregator.profile.ProfileStore;
+import io.argus.aggregator.profile.ProfileStoreConfig;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Path;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ProfileStoreTest {
+
+    private static ProfileStoreConfig config(Path dir) {
+        // 60s window, 24h retention — defaults rooted at the temp dir.
+        return ProfileStoreConfig.at(dir);
+    }
+
+    @Test
+    void mergeSumsAcrossWindowsInRange(@TempDir Path dir) {
+        ProfileStore store = new ProfileStore(config(dir));
+        long t0 = Instant.parse("2026-05-28T00:00:00Z").toEpochMilli();
+        long t1 = t0 + Duration.ofSeconds(90).toMillis(); // next window
+
+        store.append("pod-a", "svc", "cpu", t0, Map.of("main;a;b", 10L, "main;c", 5L));
+        store.append("pod-a", "svc", "cpu", t1, Map.of("main;a;b", 3L, "main;d", 7L));
+
+        Map<String, Long> merged = store.merged("pod-a", "cpu",
+                Instant.ofEpochMilli(t0), Instant.ofEpochMilli(t1 + 60_000));
+
+        assertEquals(13L, merged.get("main;a;b"), "same stack across windows sums");
+        assertEquals(5L, merged.get("main;c"));
+        assertEquals(7L, merged.get("main;d"));
+    }
+
+    @Test
+    void mergeSumsRepeatedAppendsWithinSameWindow(@TempDir Path dir) {
+        ProfileStore store = new ProfileStore(config(dir));
+        long t = Instant.parse("2026-05-28T00:00:00Z").toEpochMilli();
+
+        store.append("pod-a", "svc", "cpu", t, Map.of("main;x", 4L));
+        store.append("pod-a", "svc", "cpu", t + 1000, Map.of("main;x", 6L)); // same 60s window
+
+        Map<String, Long> merged = store.merged("pod-a", "cpu",
+                Instant.ofEpochMilli(t), Instant.ofEpochMilli(t + 60_000));
+        assertEquals(10L, merged.get("main;x"));
+    }
+
+    @Test
+    void mergeFiltersByPodAndEventAndRange(@TempDir Path dir) {
+        ProfileStore store = new ProfileStore(config(dir));
+        long t = Instant.parse("2026-05-28T00:00:00Z").toEpochMilli();
+
+        store.append("pod-a", "svc", "cpu", t, Map.of("s", 1L));
+        store.append("pod-b", "svc", "cpu", t, Map.of("s", 2L));   // other pod
+        store.append("pod-a", "svc", "alloc", t, Map.of("s", 4L)); // other event
+        long far = t + Duration.ofHours(2).toMillis();
+        store.append("pod-a", "svc", "cpu", far, Map.of("s", 8L)); // out of range
+
+        Map<String, Long> merged = store.merged("pod-a", "cpu",
+                Instant.ofEpochMilli(t), Instant.ofEpochMilli(t + 60_000));
+        assertEquals(1L, merged.get("s"), "only pod-a/cpu in-range counted");
+    }
+
+    @Test
+    void evictOlderThanRemovesOldWindows(@TempDir Path dir) {
+        ProfileStore store = new ProfileStore(config(dir));
+        long oldT = Instant.parse("2026-05-28T00:00:00Z").toEpochMilli();
+        long newT = oldT + Duration.ofHours(3).toMillis();
+
+        store.append("pod-a", "svc", "cpu", oldT, Map.of("old", 1L));
+        store.append("pod-a", "svc", "cpu", newT, Map.of("new", 2L));
+
+        store.evictOlderThan(Instant.ofEpochMilli(oldT + Duration.ofHours(1).toMillis()));
+
+        Map<String, Long> all = store.merged("pod-a", "cpu",
+                Instant.ofEpochMilli(oldT), Instant.ofEpochMilli(newT + 60_000));
+        assertNull(all.get("old"), "old window evicted");
+        assertEquals(2L, all.get("new"), "new window retained");
+    }
+
+    @Test
+    void survivesRestartByReindexingFromDisk(@TempDir Path dir) {
+        long t = Instant.parse("2026-05-28T00:00:00Z").toEpochMilli();
+        ProfileStore first = new ProfileStore(config(dir));
+        first.append("pod-a", "svc", "cpu", t, Map.of("main;a;b", 11L, "main;c", 22L));
+
+        // Simulate process restart: brand-new store over the same dir.
+        ProfileStore reloaded = new ProfileStore(config(dir));
+        Map<String, Long> merged = reloaded.merged("pod-a", "cpu",
+                Instant.ofEpochMilli(t), Instant.ofEpochMilli(t + 60_000));
+
+        assertEquals(11L, merged.get("main;a;b"));
+        assertEquals(22L, merged.get("main;c"));
+    }
+
+    @Test
+    void roundTripsSpecialCharsInPodAndStack(@TempDir Path dir) {
+        ProfileStore store = new ProfileStore(config(dir));
+        long t = Instant.parse("2026-05-28T00:00:00Z").toEpochMilli();
+        String pod = "ns/pod with space~tilde";
+        String stack = "Main.run;com.x.Y.<init>;a/b";
+
+        store.append(pod, "my svc", "cpu", t, Map.of(stack, 9L));
+
+        ProfileStore reloaded = new ProfileStore(config(dir));
+        Map<String, Long> merged = reloaded.merged(pod, "cpu",
+                Instant.ofEpochMilli(t), Instant.ofEpochMilli(t + 60_000));
+        assertEquals(9L, merged.get(stack));
+    }
+}

--- a/argus-cli/src/main/java/io/argus/cli/provider/jdk/AsProfLoopCapture.java
+++ b/argus-cli/src/main/java/io/argus/cli/provider/jdk/AsProfLoopCapture.java
@@ -67,6 +67,14 @@ public final class AsProfLoopCapture {
         if (cadenceSeconds <= 0) {
             throw new IllegalArgumentException("cadenceSeconds must be positive");
         }
+        // Each cycle profiles for captureSeconds; the loop fires every cadenceSeconds.
+        // If cadence < capture, scheduleAtFixedRate queues runs back-to-back with no
+        // idle gap, pinning the target JVM under perpetual profiler attach.
+        if (cadenceSeconds < captureSeconds) {
+            throw new IllegalArgumentException(
+                    "cadenceSeconds (" + cadenceSeconds + ") must be >= captureSeconds ("
+                            + captureSeconds + ") so capture cycles do not overlap");
+        }
         this.pid = pid;
         this.eventType = eventType;
         this.captureSeconds = captureSeconds;

--- a/argus-cli/src/main/java/io/argus/cli/provider/jdk/AsProfLoopCapture.java
+++ b/argus-cli/src/main/java/io/argus/cli/provider/jdk/AsProfLoopCapture.java
@@ -1,0 +1,183 @@
+package io.argus.cli.provider.jdk;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.BiConsumer;
+
+/**
+ * Agent-side continuous (loop) capture mode for async-profiler.
+ *
+ * <p>Runs async-profiler on a fixed cadence, parsing each collapsed-output cycle
+ * into a {@code stack -> sampleCount} map and handing it (with the capture
+ * timestamp) to a {@link Cycle} callback. The callback is the seam the W1 profile
+ * store hooks into to persist continuous per-pod profiles.
+ *
+ * <h2>Default-off</h2>
+ * Construction never starts the loop. {@link #start()} is a no-op unless
+ * {@code continuousEnabled} was passed {@code true} to the constructor — so the
+ * roadmap's "continuous capture defaults OFF" requirement holds even if a caller
+ * wires {@link #start()} unconditionally.
+ *
+ * <p>Each cycle profiles for {@code captureSeconds} and the loop fires every
+ * {@code cadenceSeconds}; {@code cadence >= capture} is expected so cycles do not
+ * overlap. The captured event is parsed via {@link #parseCollapsedCounts}.
+ */
+public final class AsProfLoopCapture {
+
+    /** Receives one parsed capture cycle. */
+    @FunctionalInterface
+    public interface Cycle extends BiConsumer<Map<String, Long>, Long> {
+        /**
+         * @param collapsedCounts {@code stack -> sampleCount} for this cycle (never null)
+         * @param timestampMillis wall-clock time the cycle finished
+         */
+        @Override
+        void accept(Map<String, Long> collapsedCounts, Long timestampMillis);
+    }
+
+    private final long pid;
+    private final String eventType;
+    private final int captureSeconds;
+    private final long cadenceSeconds;
+    private final boolean continuousEnabled;
+    private final Cycle callback;
+
+    private final AtomicBoolean running = new AtomicBoolean(false);
+    private ScheduledExecutorService scheduler;
+    private ScheduledFuture<?> task;
+
+    /**
+     * @param pid               target JVM pid
+     * @param eventType         async-profiler event ("cpu", "alloc", "lock", …)
+     * @param captureSeconds    profiling duration per cycle
+     * @param cadenceSeconds    seconds between cycle starts (default cadence is 60s)
+     * @param continuousEnabled gate — when {@code false}, {@link #start()} is a no-op
+     * @param callback          invoked once per cycle with parsed counts + timestamp
+     */
+    public AsProfLoopCapture(long pid, String eventType, int captureSeconds,
+                             long cadenceSeconds, boolean continuousEnabled, Cycle callback) {
+        if (captureSeconds <= 0) {
+            throw new IllegalArgumentException("captureSeconds must be positive");
+        }
+        if (cadenceSeconds <= 0) {
+            throw new IllegalArgumentException("cadenceSeconds must be positive");
+        }
+        this.pid = pid;
+        this.eventType = eventType;
+        this.captureSeconds = captureSeconds;
+        this.cadenceSeconds = cadenceSeconds;
+        this.continuousEnabled = continuousEnabled;
+        this.callback = callback;
+    }
+
+    public boolean isContinuousEnabled() {
+        return continuousEnabled;
+    }
+
+    public boolean isRunning() {
+        return running.get();
+    }
+
+    /**
+     * Starts the repeating capture loop on a daemon scheduler.
+     *
+     * <p>No-op (returns {@code false}) when {@code continuousEnabled} is false or the
+     * loop is already running. Auto-start is therefore never possible without an
+     * explicit opt-in.
+     */
+    public boolean start() {
+        if (!continuousEnabled) {
+            return false;
+        }
+        if (!running.compareAndSet(false, true)) {
+            return false;
+        }
+        scheduler = Executors.newSingleThreadScheduledExecutor(r -> {
+            Thread t = new Thread(r, "asprof-loop-capture");
+            t.setDaemon(true);
+            return t;
+        });
+        task = scheduler.scheduleAtFixedRate(this::captureOnce, 0, cadenceSeconds, TimeUnit.SECONDS);
+        return true;
+    }
+
+    /** Stops the loop and shuts down the scheduler. Idempotent. */
+    public void stop() {
+        if (!running.compareAndSet(true, false)) {
+            return;
+        }
+        if (task != null) {
+            task.cancel(false);
+        }
+        if (scheduler != null) {
+            scheduler.shutdownNow();
+        }
+    }
+
+    /** Runs one capture cycle and dispatches the parsed counts. Swallows errors so the loop survives. */
+    private void captureOnce() {
+        try {
+            String asProfPath = AsProfDownloader.asProfPath();
+            String[] command = new String[]{
+                asProfPath,
+                "-d", String.valueOf(captureSeconds),
+                "-o", "collapsed",
+                "-e", eventType,
+                String.valueOf(pid)
+            };
+            AsProfExecutor.Result result =
+                    AsProfExecutor.execute(command, captureSeconds + 30, null);
+            if (result.exitCode() != 0) {
+                return;
+            }
+            Map<String, Long> counts = parseCollapsedCounts(result.stdout());
+            if (!counts.isEmpty() && callback != null) {
+                callback.accept(counts, System.currentTimeMillis());
+            }
+        } catch (RuntimeException ignored) {
+            // never let one bad cycle kill the loop
+        }
+    }
+
+    /**
+     * Parses async-profiler collapsed output into a {@code stack -> sampleCount} map.
+     *
+     * <p>Collapsed format is one record per line: {@code frame1;frame2;…;leaf count}
+     * where the count is the trailing space-separated token. Blank lines are skipped,
+     * malformed lines are skipped, and duplicate stacks are summed. Semicolons inside
+     * frames are preserved as part of the stack key (the split is on the last space).
+     */
+    public static Map<String, Long> parseCollapsedCounts(String output) {
+        Map<String, Long> counts = new HashMap<>();
+        if (output == null || output.isEmpty()) {
+            return counts;
+        }
+        for (String line : output.split("\n")) {
+            if (line.isEmpty()) {
+                continue;
+            }
+            int lastSpace = line.lastIndexOf(' ');
+            if (lastSpace < 0) {
+                continue;
+            }
+            String stack = line.substring(0, lastSpace);
+            String countStr = line.substring(lastSpace + 1).trim();
+            if (stack.isEmpty() || countStr.isEmpty()) {
+                continue;
+            }
+            long count;
+            try {
+                count = Long.parseLong(countStr);
+            } catch (NumberFormatException e) {
+                continue;
+            }
+            counts.merge(stack, count, Long::sum);
+        }
+        return counts;
+    }
+}

--- a/argus-cli/src/main/java/io/argus/cli/provider/jdk/AsProfProvider.java
+++ b/argus-cli/src/main/java/io/argus/cli/provider/jdk/AsProfProvider.java
@@ -88,6 +88,23 @@ public final class AsProfProvider implements ProfileProvider {
         return flameGraph(pid, type, durationSec, outputFile, null);
     }
 
+    /**
+     * Builds a continuous (loop) capture for this provider's backing async-profiler.
+     *
+     * <p>Profiles {@code pid} for {@code captureSeconds} every {@code cadenceSeconds},
+     * parses each collapsed cycle to a {@code stack -> count} map and hands it to
+     * {@code callback}. The returned capture does NOT start automatically: it only
+     * runs when {@code continuousEnabled} is {@code true} <em>and</em> {@link
+     * AsProfLoopCapture#start()} is called, satisfying the W1 "continuous capture
+     * defaults OFF" requirement.
+     */
+    public AsProfLoopCapture continuousCapture(long pid, String type, int captureSeconds,
+                                               long cadenceSeconds, boolean continuousEnabled,
+                                               AsProfLoopCapture.Cycle callback) {
+        return new AsProfLoopCapture(pid, type, captureSeconds, cadenceSeconds,
+                continuousEnabled, callback);
+    }
+
     @Override
     public ProfileResult start(long pid, String type) {
         AsProfPermissionCheck.Result preflight = AsProfPermissionCheck.validate(pid);

--- a/argus-cli/src/test/java/io/argus/cli/provider/jdk/AsProfLoopCaptureTest.java
+++ b/argus-cli/src/test/java/io/argus/cli/provider/jdk/AsProfLoopCaptureTest.java
@@ -65,4 +65,14 @@ class AsProfLoopCaptureTest {
         assertThrows(IllegalArgumentException.class,
                 () -> new AsProfLoopCapture(1L, "cpu", 10, 0, true, (c, t) -> {}));
     }
+
+    @Test
+    void rejectsCadenceSmallerThanCapture() {
+        // cadence (5s) < capture (30s) would queue overlapping captures — must be rejected.
+        assertThrows(IllegalArgumentException.class,
+                () -> new AsProfLoopCapture(1L, "cpu", 30, 5, true, (c, t) -> {}));
+        // cadence == capture is allowed (boundary).
+        assertDoesNotThrow(
+                () -> new AsProfLoopCapture(1L, "cpu", 30, 30, false, (c, t) -> {}));
+    }
 }

--- a/argus-cli/src/test/java/io/argus/cli/provider/jdk/AsProfLoopCaptureTest.java
+++ b/argus-cli/src/test/java/io/argus/cli/provider/jdk/AsProfLoopCaptureTest.java
@@ -1,0 +1,68 @@
+package io.argus.cli.provider.jdk;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class AsProfLoopCaptureTest {
+
+    @Test
+    void parsesMultiLineCollapsedToStackCounts() {
+        String collapsed = String.join("\n",
+                "main;a;b 10",
+                "main;c 5",
+                "main;a;b 3");
+        Map<String, Long> counts = AsProfLoopCapture.parseCollapsedCounts(collapsed);
+        assertEquals(13L, counts.get("main;a;b"), "duplicate stacks sum");
+        assertEquals(5L, counts.get("main;c"));
+        assertEquals(2, counts.size());
+    }
+
+    @Test
+    void skipsBlankAndMalformedLines() {
+        String collapsed = String.join("\n",
+                "",
+                "main;x 7",
+                "no-count-here",
+                "main;y notanumber",
+                "   ",
+                "main;z 4");
+        Map<String, Long> counts = AsProfLoopCapture.parseCollapsedCounts(collapsed);
+        assertEquals(7L, counts.get("main;x"));
+        assertEquals(4L, counts.get("main;z"));
+        assertEquals(2, counts.size(), "blank/malformed lines dropped");
+    }
+
+    @Test
+    void preservesSemicolonsInFrames() {
+        String collapsed = "java/lang/Thread.run;com.x.Foo.<init>;com.x.Bar.handle 42";
+        Map<String, Long> counts = AsProfLoopCapture.parseCollapsedCounts(collapsed);
+        assertEquals(42L, counts.get("java/lang/Thread.run;com.x.Foo.<init>;com.x.Bar.handle"));
+        assertEquals(1, counts.size());
+    }
+
+    @Test
+    void emptyOrNullOutputYieldsEmptyMap() {
+        assertTrue(AsProfLoopCapture.parseCollapsedCounts(null).isEmpty());
+        assertTrue(AsProfLoopCapture.parseCollapsedCounts("").isEmpty());
+    }
+
+    @Test
+    void continuousDisabledNeverStarts() {
+        AsProfLoopCapture cap = new AsProfLoopCapture(
+                1234L, "cpu", 10, 60, false, (counts, ts) -> {});
+        assertFalse(cap.isContinuousEnabled());
+        assertFalse(cap.start(), "start() must be a no-op when disabled");
+        assertFalse(cap.isRunning());
+    }
+
+    @Test
+    void rejectsNonPositiveTimings() {
+        assertThrows(IllegalArgumentException.class,
+                () -> new AsProfLoopCapture(1L, "cpu", 0, 60, true, (c, t) -> {}));
+        assertThrows(IllegalArgumentException.class,
+                () -> new AsProfLoopCapture(1L, "cpu", 10, 0, true, (c, t) -> {}));
+    }
+}

--- a/argus-server/src/main/java/io/argus/server/analysis/GCAnalyzer.java
+++ b/argus-server/src/main/java/io/argus/server/analysis/GCAnalyzer.java
@@ -234,18 +234,14 @@ public final class GCAnalyzer {
     private void recordPauseHistogram(long durationNanos) {
         double seconds = durationNanos / 1_000_000_000.0;
         pauseHistogramSumMicros.addAndGet(durationNanos / 1_000); // store as micros to stay integral
-        // Cumulative: increment every bucket whose upper bound is >= this pause.
-        boolean placed = false;
+        // Cumulative: increment every finite bucket whose upper bound is >= this pause.
         for (int i = 0; i < PAUSE_BUCKETS_SECONDS.length; i++) {
             if (seconds <= PAUSE_BUCKETS_SECONDS[i]) {
                 pauseBucketCounts[i].incrementAndGet();
-                placed = true;
             }
         }
-        // +Inf bucket always counts every observation.
+        // +Inf bucket always counts every observation (including pauses larger than the biggest finite bucket).
         pauseBucketCounts[pauseBucketCounts.length - 1].incrementAndGet();
-        // If the pause exceeded the largest finite bucket, `placed` is false and only +Inf grew — correct.
-        if (placed) { /* already counted into finite buckets above */ }
     }
 
     /** Immutable snapshot of the GC pause-time histogram for Prometheus export. */

--- a/argus-server/src/main/java/io/argus/server/analysis/GCAnalyzer.java
+++ b/argus-server/src/main/java/io/argus/server/analysis/GCAnalyzer.java
@@ -32,6 +32,24 @@ public final class GCAnalyzer {
     /** Cumulative event counts keyed by {@code gcName + "|" + gcCause}. */
     private final Map<String, AtomicLong> eventCountByCollectorAndCause   = new ConcurrentHashMap<>();
 
+    /**
+     * Classic histogram bucket upper bounds (seconds) for the GC pause-time
+     * distribution. Text exposition can't carry native histograms (those are
+     * protobuf-only), so we expose a standard {@code _bucket}/{@code _sum}/
+     * {@code _count} histogram that promtool accepts and Grafana renders.
+     */
+    static final double[] PAUSE_BUCKETS_SECONDS = {
+            0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0
+    };
+    /** Cumulative count per bucket (index i = count of pauses ≤ PAUSE_BUCKETS_SECONDS[i]); last slot = +Inf. */
+    private final AtomicLong[] pauseBucketCounts =
+            new AtomicLong[PAUSE_BUCKETS_SECONDS.length + 1];
+    private final AtomicLong pauseHistogramSumMicros = new AtomicLong(0);
+
+    {
+        for (int i = 0; i < pauseBucketCounts.length; i++) pauseBucketCounts[i] = new AtomicLong(0);
+    }
+
     // Latest heap state
     private volatile long lastHeapUsed = 0;
     private volatile long lastHeapCommitted = 0;
@@ -57,6 +75,9 @@ public final class GCAnalyzer {
 
             // Update GC overhead calculation
             updateGCOverhead(event.duration());
+
+            // Update pause-time histogram (cumulative buckets).
+            recordPauseHistogram(event.duration());
         }
 
         // Track cause distribution
@@ -210,6 +231,52 @@ public final class GCAnalyzer {
     /**
      * Clears all recorded data.
      */
+    private void recordPauseHistogram(long durationNanos) {
+        double seconds = durationNanos / 1_000_000_000.0;
+        pauseHistogramSumMicros.addAndGet(durationNanos / 1_000); // store as micros to stay integral
+        // Cumulative: increment every bucket whose upper bound is >= this pause.
+        boolean placed = false;
+        for (int i = 0; i < PAUSE_BUCKETS_SECONDS.length; i++) {
+            if (seconds <= PAUSE_BUCKETS_SECONDS[i]) {
+                pauseBucketCounts[i].incrementAndGet();
+                placed = true;
+            }
+        }
+        // +Inf bucket always counts every observation.
+        pauseBucketCounts[pauseBucketCounts.length - 1].incrementAndGet();
+        // If the pause exceeded the largest finite bucket, `placed` is false and only +Inf grew — correct.
+        if (placed) { /* already counted into finite buckets above */ }
+    }
+
+    /** Immutable snapshot of the GC pause-time histogram for Prometheus export. */
+    public static final class PauseHistogram {
+        private final double[] upperBounds;   // finite bucket bounds (seconds)
+        private final long[] cumulativeCounts; // length = upperBounds.length + 1 (last = +Inf)
+        private final double sumSeconds;
+        private final long count;
+
+        public PauseHistogram(double[] upperBounds, long[] cumulativeCounts, double sumSeconds, long count) {
+            this.upperBounds = upperBounds;
+            this.cumulativeCounts = cumulativeCounts;
+            this.sumSeconds = sumSeconds;
+            this.count = count;
+        }
+
+        public double[] upperBounds() { return upperBounds; }
+        public long[] cumulativeCounts() { return cumulativeCounts; }
+        public double sumSeconds() { return sumSeconds; }
+        public long count() { return count; }
+    }
+
+    /** Returns a consistent snapshot of the GC pause-time histogram. */
+    public PauseHistogram getPauseHistogram() {
+        long[] counts = new long[pauseBucketCounts.length];
+        for (int i = 0; i < counts.length; i++) counts[i] = pauseBucketCounts[i].get();
+        double sumSeconds = pauseHistogramSumMicros.get() / 1_000_000.0;
+        long count = counts[counts.length - 1]; // +Inf bucket == total observations
+        return new PauseHistogram(PAUSE_BUCKETS_SECONDS, counts, sumSeconds, count);
+    }
+
     /**
      * Returns cumulative pause time (in nanoseconds) keyed by
      * {@code gcName + "|" + gcCause}. Used by the Prometheus exporter to emit
@@ -238,6 +305,8 @@ public final class GCAnalyzer {
         recentGCs.clear();
         pauseTimeNanosByCollectorAndCause.clear();
         eventCountByCollectorAndCause.clear();
+        for (AtomicLong b : pauseBucketCounts) b.set(0);
+        pauseHistogramSumMicros.set(0);
         lastHeapUsed = 0;
         lastHeapCommitted = 0;
         lastGCTime = null;

--- a/argus-server/src/main/java/io/argus/server/handler/ArgusChannelHandler.java
+++ b/argus-server/src/main/java/io/argus/server/handler/ArgusChannelHandler.java
@@ -379,7 +379,18 @@ public final class ArgusChannelHandler extends SimpleChannelInboundHandler<Objec
             return;
         }
 
-        HttpResponseHelper.sendPrometheus(ctx, request, prometheusCollector.collectMetrics());
+        // Content negotiation: serve OpenMetrics when the scraper asks for it
+        // (Prometheus sends Accept: application/openmetrics-text). Default to the
+        // classic 0.0.4 text exposition so existing scrapers are unaffected.
+        String accept = request.headers().get(HttpHeaderNames.ACCEPT);
+        boolean wantsOpenMetrics = accept != null
+                && accept.toLowerCase(java.util.Locale.ROOT).contains("application/openmetrics-text");
+
+        if (wantsOpenMetrics) {
+            HttpResponseHelper.sendOpenMetrics(ctx, request, prometheusCollector.collectMetrics(true));
+        } else {
+            HttpResponseHelper.sendPrometheus(ctx, request, prometheusCollector.collectMetrics(false));
+        }
     }
 
     private String serializeActiveThreads() {

--- a/argus-server/src/main/java/io/argus/server/http/HttpResponseHelper.java
+++ b/argus-server/src/main/java/io/argus/server/http/HttpResponseHelper.java
@@ -93,6 +93,12 @@ public final class HttpResponseHelper {
         send(ctx, request, HttpResponseStatus.OK, content, "text/plain; version=0.0.4; charset=utf-8");
     }
 
+    /** OpenMetrics 1.0.0 exposition response (served on Accept: application/openmetrics-text). */
+    public static void sendOpenMetrics(ChannelHandlerContext ctx, FullHttpRequest request, String content) {
+        send(ctx, request, HttpResponseStatus.OK, content,
+                "application/openmetrics-text; version=1.0.0; charset=utf-8");
+    }
+
     /**
      * Sends a downloadable file response.
      *

--- a/argus-server/src/main/java/io/argus/server/metrics/OtlpJsonBuilder.java
+++ b/argus-server/src/main/java/io/argus/server/metrics/OtlpJsonBuilder.java
@@ -106,7 +106,7 @@ public final class OtlpJsonBuilder {
                 "Unique pinning stack traces", nowNano, pinAnalysis.uniqueStackTraces());
 
         var carrierAnalysis = carrierAnalyzer.getAnalysis();
-        first = appendGauge(sb, first, "argus_carrier_threads_total",
+        first = appendGauge(sb, first, "argus_carrier_threads",
                 "Total carrier threads", nowNano, carrierAnalysis.totalCarriers());
         first = appendGaugeDouble(sb, first, "argus_carrier_threads_avg_per_carrier",
                 "Average virtual threads per carrier", nowNano, carrierAnalysis.avgVirtualThreadsPerCarrier());

--- a/argus-server/src/main/java/io/argus/server/metrics/PrometheusMetricsCollector.java
+++ b/argus-server/src/main/java/io/argus/server/metrics/PrometheusMetricsCollector.java
@@ -36,6 +36,17 @@ public final class PrometheusMetricsCollector {
     private final ContentionAnalyzer contentionAnalyzer;
 
     /**
+     * Exemplar source: returns the current W3C trace id, or {@code null} when no
+     * trace context is active. Defaults to a no-op until the tracing-correlation
+     * workstream (W4) wires real context capture. Exemplars are only emitted in
+     * OpenMetrics output.
+     */
+    private volatile java.util.function.Supplier<String> traceIdSupplier = () -> null;
+
+    /** Set per-collection by {@link #collectMetrics(boolean)}; controls EOF marker + exemplars. */
+    private boolean openMetrics = false;
+
+    /**
      * Creates a new Prometheus metrics collector.
      *
      * @param config                 the agent configuration
@@ -76,15 +87,28 @@ public final class PrometheusMetricsCollector {
     }
 
     /**
-     * Collects all enabled metrics and formats them as Prometheus exposition text.
-     * Includes {@code argus_scrape_duration_seconds} as the final metric, timing
-     * the collection itself.
-     *
-     * @return Prometheus text format string
+     * Sets the exemplar trace-id source. Wired by the tracing-correlation
+     * workstream; until then the default supplier returns {@code null} and no
+     * exemplars are emitted.
      */
+    public void setTraceIdSupplier(java.util.function.Supplier<String> supplier) {
+        this.traceIdSupplier = supplier != null ? supplier : () -> null;
+    }
+
+    /** Classic Prometheus 0.0.4 text exposition (no {@code # EOF}, no exemplars). */
     public String collectMetrics() {
+        return collectMetrics(false);
+    }
+
+    /**
+     * Collects all enabled metrics. When {@code openMetrics} is true, emits
+     * OpenMetrics 1.0.0 text: terminated with {@code # EOF} and carrying
+     * exemplars on the GC pause histogram when a trace id is available.
+     */
+    public String collectMetrics(boolean openMetrics) {
         long startNanos = System.nanoTime();
         StringBuilder sb = new StringBuilder(4096);
+        this.openMetrics = openMetrics;
 
         appendVirtualThreadMetrics(sb);
         appendPinningMetrics(sb);
@@ -120,8 +144,13 @@ public final class PrometheusMetricsCollector {
         sb.append("# HELP argus_scrape_duration_seconds Time taken to collect metrics\n");
         sb.append("# TYPE argus_scrape_duration_seconds gauge\n");
         sb.append("argus_scrape_duration_seconds ")
-                .append(String.format("%.6f", durationSeconds))
+                .append(String.format(java.util.Locale.ROOT, "%.6f", durationSeconds))
                 .append('\n');
+
+        // OpenMetrics requires an explicit end-of-stream marker. Classic 0.0.4 omits it.
+        if (openMetrics) {
+            sb.append("# EOF\n");
+        }
 
         return sb.toString();
     }
@@ -153,7 +182,7 @@ public final class PrometheusMetricsCollector {
 
     private void appendCarrierThreadMetrics(StringBuilder sb) {
         var analysis = carrierAnalyzer.getAnalysis();
-        appendGauge(sb, "argus_carrier_threads_total",
+        appendGauge(sb, "argus_carrier_threads",
                 "Total number of carrier threads",
                 analysis.totalCarriers());
         appendCounter(sb, "argus_carrier_threads_virtual_handled_total",
@@ -247,6 +276,82 @@ public final class PrometheusMetricsCollector {
                         .append(entry.getValue())
                         .append('\n');
             }
+        }
+
+        appendPauseHistogram(sb);
+    }
+
+    /**
+     * Emits the GC pause-time distribution as a classic Prometheus histogram
+     * (`_bucket`/`_sum`/`_count`). In OpenMetrics mode, attaches a trace-id
+     * exemplar to the +Inf bucket when a trace context is available.
+     */
+    private void appendPauseHistogram(StringBuilder sb) {
+        var hist = gcAnalyzer.getPauseHistogram();
+        if (hist.count() == 0) return;
+
+        sb.append("# HELP argus_gc_pause_seconds GC pause time distribution\n");
+        sb.append("# TYPE argus_gc_pause_seconds histogram\n");
+
+        String baseLabels = KubernetesLabels.prometheusLabelSuffix(); // "" or "{k=v,...}"
+        double[] bounds = hist.upperBounds();
+        long[] counts = hist.cumulativeCounts();
+        String traceId = openMetrics ? safeTraceId() : null;
+
+        for (int i = 0; i < bounds.length; i++) {
+            sb.append("argus_gc_pause_seconds_bucket")
+                    .append(bucketLabels(baseLabels, formatBound(bounds[i])))
+                    .append(' ')
+                    .append(counts[i])
+                    .append('\n');
+        }
+        // +Inf bucket
+        sb.append("argus_gc_pause_seconds_bucket")
+                .append(bucketLabels(baseLabels, "+Inf"))
+                .append(' ')
+                .append(counts[counts.length - 1]);
+        if (traceId != null) {
+            // OpenMetrics exemplar: "# {trace_id="..."} <value> <timestamp>"
+            sb.append(" # {trace_id=\"").append(escapeLabel(traceId)).append("\"} ")
+                    .append(hist.sumSeconds() / Math.max(1, hist.count()));
+        }
+        sb.append('\n');
+
+        sb.append("argus_gc_pause_seconds_sum")
+                .append(baseLabels).append(' ')
+                .append(String.format(java.util.Locale.ROOT, "%.6f", hist.sumSeconds()))
+                .append('\n');
+        sb.append("argus_gc_pause_seconds_count")
+                .append(baseLabels).append(' ')
+                .append(hist.count())
+                .append('\n');
+    }
+
+    /** Merge the {@code le} label into the base K8s label set for a histogram bucket line. */
+    private static String bucketLabels(String baseLabels, String le) {
+        String leLabel = "le=\"" + le + "\"";
+        if (baseLabels == null || baseLabels.isEmpty()) {
+            return "{" + leLabel + "}";
+        }
+        // baseLabels looks like "{k=v,...}" — insert le before the closing brace.
+        return baseLabels.substring(0, baseLabels.length() - 1) + "," + leLabel + "}";
+    }
+
+    private static String formatBound(double bound) {
+        // Render bucket bounds without locale-dependent separators.
+        if (bound == Math.floor(bound)) {
+            return String.format(java.util.Locale.ROOT, "%.1f", bound);
+        }
+        return String.format(java.util.Locale.ROOT, "%s",
+                java.math.BigDecimal.valueOf(bound).stripTrailingZeros().toPlainString());
+    }
+
+    private String safeTraceId() {
+        try {
+            String id = traceIdSupplier.get();
+            return (id == null || id.isBlank()) ? null : id;
+        } catch (Exception e) {
+            return null;
         }
     }
 

--- a/argus-server/src/main/java/io/argus/server/metrics/PrometheusMetricsCollector.java
+++ b/argus-server/src/main/java/io/argus/server/metrics/PrometheusMetricsCollector.java
@@ -43,9 +43,6 @@ public final class PrometheusMetricsCollector {
      */
     private volatile java.util.function.Supplier<String> traceIdSupplier = () -> null;
 
-    /** Set per-collection by {@link #collectMetrics(boolean)}; controls EOF marker + exemplars. */
-    private boolean openMetrics = false;
-
     /**
      * Creates a new Prometheus metrics collector.
      *
@@ -108,14 +105,13 @@ public final class PrometheusMetricsCollector {
     public String collectMetrics(boolean openMetrics) {
         long startNanos = System.nanoTime();
         StringBuilder sb = new StringBuilder(4096);
-        this.openMetrics = openMetrics;
 
         appendVirtualThreadMetrics(sb);
         appendPinningMetrics(sb);
         appendCarrierThreadMetrics(sb);
 
         if (config.isGcEnabled()) {
-            appendGCMetrics(sb);
+            appendGCMetrics(sb, openMetrics);
         }
 
         if (config.isCpuEnabled()) {
@@ -193,7 +189,7 @@ public final class PrometheusMetricsCollector {
                 analysis.avgVirtualThreadsPerCarrier());
     }
 
-    private void appendGCMetrics(StringBuilder sb) {
+    private void appendGCMetrics(StringBuilder sb, boolean openMetrics) {
         var analysis = gcAnalyzer.getAnalysis();
         appendCounter(sb, "argus_gc_events_total",
                 "Total number of GC events",
@@ -278,7 +274,7 @@ public final class PrometheusMetricsCollector {
             }
         }
 
-        appendPauseHistogram(sb);
+        appendPauseHistogram(sb, openMetrics);
     }
 
     /**
@@ -286,7 +282,7 @@ public final class PrometheusMetricsCollector {
      * (`_bucket`/`_sum`/`_count`). In OpenMetrics mode, attaches a trace-id
      * exemplar to the +Inf bucket when a trace context is available.
      */
-    private void appendPauseHistogram(StringBuilder sb) {
+    private void appendPauseHistogram(StringBuilder sb, boolean openMetrics) {
         var hist = gcAnalyzer.getPauseHistogram();
         if (hist.count() == 0) return;
 
@@ -346,10 +342,15 @@ public final class PrometheusMetricsCollector {
                 java.math.BigDecimal.valueOf(bound).stripTrailingZeros().toPlainString());
     }
 
+    /** OpenMetrics caps an exemplar's label set at 128 UTF-8 bytes; keep trace ids well under it. */
+    private static final int MAX_TRACE_ID_LEN = 64;
+
     private String safeTraceId() {
         try {
             String id = traceIdSupplier.get();
-            return (id == null || id.isBlank()) ? null : id;
+            if (id == null || id.isBlank()) return null;
+            id = id.trim();
+            return id.length() > MAX_TRACE_ID_LEN ? id.substring(0, MAX_TRACE_ID_LEN) : id;
         } catch (Exception e) {
             return null;
         }

--- a/argus-server/src/test/java/io/argus/server/analysis/GCAnalyzerPauseHistogramTest.java
+++ b/argus-server/src/test/java/io/argus/server/analysis/GCAnalyzerPauseHistogramTest.java
@@ -1,0 +1,102 @@
+package io.argus.server.analysis;
+
+import io.argus.core.event.GCEvent;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests the GC pause-time histogram added for the Prometheus OpenMetrics export.
+ *
+ * <p>Buckets are cumulative (a pause ≤ bound counts in that bucket and every
+ * larger one), the +Inf bucket equals the total observation count, and
+ * {@code clear()} resets all histogram state.
+ */
+class GCAnalyzerPauseHistogramTest {
+
+    private static GCEvent pause(double seconds) {
+        long nanos = (long) (seconds * 1_000_000_000.0);
+        return GCEvent.pause(Instant.now(), nanos, "G1 Young Generation", "G1 Evacuation Pause");
+    }
+
+    @Test
+    void empty_histogram_has_zero_count() {
+        GCAnalyzer a = new GCAnalyzer();
+        GCAnalyzer.PauseHistogram h = a.getPauseHistogram();
+        assertEquals(0, h.count());
+        assertEquals(0.0, h.sumSeconds(), 1e-9);
+    }
+
+    @Test
+    void cumulative_buckets_and_count() {
+        GCAnalyzer a = new GCAnalyzer();
+        // bounds include 0.01, 0.05, 0.1, 0.25 ...
+        a.recordGCEvent(pause(0.008)); // ≤ 0.01
+        a.recordGCEvent(pause(0.04));  // ≤ 0.05
+        a.recordGCEvent(pause(0.2));   // ≤ 0.25
+        a.recordGCEvent(pause(7.0));   // > 5.0 → only +Inf
+
+        GCAnalyzer.PauseHistogram h = a.getPauseHistogram();
+        double[] bounds = h.upperBounds();
+        long[] counts = h.cumulativeCounts();
+
+        // total observations
+        assertEquals(4, h.count());
+        assertEquals(counts[counts.length - 1], h.count(), "+Inf bucket == total count");
+
+        // bucket for le=0.01 should include only the 0.008 pause
+        int idx001 = indexOf(bounds, 0.01);
+        assertEquals(1, counts[idx001]);
+
+        // bucket for le=0.05 cumulative includes 0.008 and 0.04
+        int idx005 = indexOf(bounds, 0.05);
+        assertEquals(2, counts[idx005]);
+
+        // bucket for le=0.25 cumulative includes 0.008, 0.04, 0.2
+        int idx025 = indexOf(bounds, 0.25);
+        assertEquals(3, counts[idx025]);
+
+        // bucket for le=5.0 cumulative still 3 (the 7.0s pause exceeds it)
+        int idx5 = indexOf(bounds, 5.0);
+        assertEquals(3, counts[idx5]);
+
+        // sum ≈ 0.008 + 0.04 + 0.2 + 7.0
+        assertEquals(7.248, h.sumSeconds(), 1e-3);
+    }
+
+    @Test
+    void monotonic_non_decreasing_buckets() {
+        GCAnalyzer a = new GCAnalyzer();
+        for (double s : new double[]{0.002, 0.03, 0.07, 0.4, 1.5, 3.0}) {
+            a.recordGCEvent(pause(s));
+        }
+        long[] counts = a.getPauseHistogram().cumulativeCounts();
+        for (int i = 1; i < counts.length; i++) {
+            assertTrue(counts[i] >= counts[i - 1],
+                    "cumulative buckets must be non-decreasing at index " + i);
+        }
+    }
+
+    @Test
+    void clear_resets_histogram() {
+        GCAnalyzer a = new GCAnalyzer();
+        a.recordGCEvent(pause(0.05));
+        a.recordGCEvent(pause(0.5));
+        assertEquals(2, a.getPauseHistogram().count());
+
+        a.clear();
+        GCAnalyzer.PauseHistogram h = a.getPauseHistogram();
+        assertEquals(0, h.count());
+        assertEquals(0.0, h.sumSeconds(), 1e-9);
+        for (long c : h.cumulativeCounts()) assertEquals(0, c);
+    }
+
+    private static int indexOf(double[] bounds, double value) {
+        for (int i = 0; i < bounds.length; i++) {
+            if (Math.abs(bounds[i] - value) < 1e-9) return i;
+        }
+        throw new AssertionError("bucket bound not found: " + value);
+    }
+}

--- a/argus-server/src/test/java/io/argus/server/metrics/PrometheusMetricsCollectorOpenMetricsTest.java
+++ b/argus-server/src/test/java/io/argus/server/metrics/PrometheusMetricsCollectorOpenMetricsTest.java
@@ -1,0 +1,103 @@
+package io.argus.server.metrics;
+
+import io.argus.core.config.AgentConfig;
+import io.argus.core.event.GCEvent;
+import io.argus.server.analysis.CPUAnalyzer;
+import io.argus.server.analysis.CarrierThreadAnalyzer;
+import io.argus.server.analysis.GCAnalyzer;
+import io.argus.server.analysis.PinningAnalyzer;
+import io.argus.server.state.ActiveThreadsRegistry;
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Instant;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Validates the OpenMetrics / histogram additions to the Prometheus exporter:
+ * the GC pause histogram structure, the {@code # EOF} marker in OpenMetrics
+ * mode (and its absence in classic mode), and exemplar plumbing.
+ *
+ * <p>Also dumps a sample exposition to {@code build/openmetrics-sample.txt} so
+ * it can be validated externally with {@code promtool check metrics}.
+ */
+class PrometheusMetricsCollectorOpenMetricsTest {
+
+    private PrometheusMetricsCollector collector(GCAnalyzer gc) {
+        return new PrometheusMetricsCollector(
+                AgentConfig.defaults(),
+                new ServerMetrics(),
+                new ActiveThreadsRegistry(),
+                new PinningAnalyzer(),
+                new CarrierThreadAnalyzer(),
+                gc,
+                new CPUAnalyzer(),
+                null, null, null, null);
+    }
+
+    private GCAnalyzer gcWithPauses() {
+        GCAnalyzer gc = new GCAnalyzer();
+        for (double s : new double[]{0.008, 0.04, 0.2, 1.5}) {
+            gc.recordGCEvent(GCEvent.pause(Instant.now(),
+                    (long) (s * 1_000_000_000L), "G1 Young Generation", "G1 Evacuation Pause"));
+        }
+        return gc;
+    }
+
+    @Test
+    void openmetrics_has_eof_marker_classic_does_not() {
+        PrometheusMetricsCollector c = collector(gcWithPauses());
+        String om = c.collectMetrics(true);
+        String classic = c.collectMetrics(false);
+        assertTrue(om.endsWith("# EOF\n"), "OpenMetrics output must end with # EOF");
+        assertFalse(classic.contains("# EOF"), "classic 0.0.4 must not contain # EOF");
+    }
+
+    @Test
+    void histogram_emitted_with_buckets_sum_count() {
+        String out = collector(gcWithPauses()).collectMetrics(false);
+        assertTrue(out.contains("# TYPE argus_gc_pause_seconds histogram"));
+        assertTrue(out.contains("argus_gc_pause_seconds_bucket{le=\"+Inf\"}"),
+                "must emit the +Inf bucket");
+        assertTrue(out.contains("argus_gc_pause_seconds_sum"));
+        assertTrue(out.contains("argus_gc_pause_seconds_count"));
+    }
+
+    @Test
+    void histogram_buckets_are_cumulative_non_decreasing() {
+        String out = collector(gcWithPauses()).collectMetrics(false);
+        long prev = -1;
+        for (String line : out.split("\n")) {
+            if (!line.startsWith("argus_gc_pause_seconds_bucket")) continue;
+            long v = Long.parseLong(line.substring(line.lastIndexOf(' ') + 1).trim());
+            assertTrue(v >= prev, "bucket counts must be non-decreasing: " + line);
+            prev = v;
+        }
+        assertTrue(prev > 0, "expected at least one observation in the +Inf bucket");
+    }
+
+    @Test
+    void exemplar_present_only_when_trace_id_supplied_and_openmetrics() {
+        PrometheusMetricsCollector c = collector(gcWithPauses());
+        // no supplier → no exemplar even in OpenMetrics mode
+        assertFalse(c.collectMetrics(true).contains("# {trace_id="),
+                "no exemplar without a trace id");
+        // supplier present → exemplar on +Inf bucket in OpenMetrics mode only
+        c.setTraceIdSupplier(() -> "abc123def456");
+        assertTrue(c.collectMetrics(true).contains("# {trace_id=\"abc123def456\"}"),
+                "exemplar must appear in OpenMetrics mode when trace id is present");
+        assertFalse(c.collectMetrics(false).contains("# {trace_id="),
+                "exemplars must not appear in classic 0.0.4 output");
+    }
+
+    @Test
+    void dumps_sample_for_promtool() throws Exception {
+        String om = collector(gcWithPauses()).collectMetrics(true);
+        Path out = Path.of("build", "openmetrics-sample.txt");
+        Files.createDirectories(out.getParent());
+        Files.writeString(out, om);
+        assertTrue(Files.size(out) > 0);
+    }
+}

--- a/charts/argus/dashboards/argus-gc-collectors.json
+++ b/charts/argus/dashboards/argus-gc-collectors.json
@@ -1,0 +1,120 @@
+{
+  "annotations": { "list": [] },
+  "editable": true,
+  "graphTooltip": 1,
+  "schemaVersion": 39,
+  "title": "Argus — GC Collector Breakdown",
+  "tags": ["argus", "jvm", "gc"],
+  "time": { "from": "now-1h", "to": "now" },
+  "templating": {
+    "list": [
+      {
+        "name": "instance",
+        "type": "query",
+        "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+        "query": "label_values(argus_gc_overhead_ratio, instance)",
+        "refresh": 2,
+        "includeAll": true,
+        "multi": true
+      }
+    ]
+  },
+  "panels": [
+    {
+      "id": 1,
+      "title": "GC pause p99 (from histogram)",
+      "type": "timeseries",
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 0 },
+      "fieldConfig": { "defaults": { "unit": "s" }, "overrides": [] },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "histogram_quantile(0.99, sum(rate(argus_gc_pause_seconds_bucket{instance=~\"$instance\"}[5m])) by (le))",
+          "legendFormat": "p99"
+        },
+        {
+          "refId": "B",
+          "expr": "histogram_quantile(0.50, sum(rate(argus_gc_pause_seconds_bucket{instance=~\"$instance\"}[5m])) by (le))",
+          "legendFormat": "p50"
+        }
+      ]
+    },
+    {
+      "id": 2,
+      "title": "GC overhead ratio",
+      "type": "timeseries",
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 0 },
+      "fieldConfig": { "defaults": { "unit": "percentunit", "max": 1 }, "overrides": [] },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "argus_gc_overhead_ratio{instance=~\"$instance\"}",
+          "legendFormat": "{{instance}}"
+        }
+      ]
+    },
+    {
+      "id": 3,
+      "title": "Pause time by collector & cause (rate)",
+      "type": "timeseries",
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 8 },
+      "fieldConfig": { "defaults": { "unit": "s" }, "overrides": [] },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum(rate(argus_gc_pause_breakdown_seconds_total{instance=~\"$instance\"}[5m])) by (gc_name, gc_cause)",
+          "legendFormat": "{{gc_name}} / {{gc_cause}}"
+        }
+      ]
+    },
+    {
+      "id": 4,
+      "title": "GC event rate by collector & cause",
+      "type": "timeseries",
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 8 },
+      "fieldConfig": { "defaults": { "unit": "ops" }, "overrides": [] },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum(rate(argus_gc_events_breakdown_total{instance=~\"$instance\"}[5m])) by (gc_name, gc_cause)",
+          "legendFormat": "{{gc_name}} / {{gc_cause}}"
+        }
+      ]
+    },
+    {
+      "id": 5,
+      "title": "GC pause distribution (heatmap)",
+      "type": "heatmap",
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 16 },
+      "options": { "calculate": false, "cellGap": 1, "yAxis": { "unit": "s" } },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum(rate(argus_gc_pause_seconds_bucket{instance=~\"$instance\"}[5m])) by (le)",
+          "format": "heatmap",
+          "legendFormat": "{{le}}"
+        }
+      ]
+    },
+    {
+      "id": 6,
+      "title": "Heap usage ratio",
+      "type": "timeseries",
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 16 },
+      "fieldConfig": { "defaults": { "unit": "percentunit", "max": 1 }, "overrides": [] },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "argus_heap_usage_ratio{instance=~\"$instance\"}",
+          "legendFormat": "{{instance}}"
+        }
+      ]
+    }
+  ]
+}

--- a/charts/argus/dashboards/argus-jvm-observability.json
+++ b/charts/argus/dashboards/argus-jvm-observability.json
@@ -1153,7 +1153,7 @@
       "type": "timeseries",
       "targets": [
         {
-          "expr": "argus_carrier_threads_total",
+          "expr": "argus_carrier_threads",
           "legendFormat": "Carrier Count"
         },
         {

--- a/charts/argus/templates/grafana-dashboard-cm.yaml
+++ b/charts/argus/templates/grafana-dashboard-cm.yaml
@@ -12,4 +12,6 @@ metadata:
 data:
   argus-jvm-observability.json: |-
     {{ .Files.Get "dashboards/argus-jvm-observability.json" | nindent 4 }}
+  argus-gc-collectors.json: |-
+    {{ .Files.Get "dashboards/argus-gc-collectors.json" | nindent 4 }}
 {{- end }}

--- a/charts/argus/templates/prometheusrule.yaml
+++ b/charts/argus/templates/prometheusrule.yaml
@@ -55,7 +55,8 @@ spec:
         {{- end }}
         {{- if .Values.prometheusRule.rules.gcPauseP99.enabled }}
         - alert: ArgusGCPauseP99High
-          expr: argus:gc_pause:p99_5m > {{ .Values.prometheusRule.rules.gcPauseP99.threshold }}
+          # Inlined histogram_quantile so the alert works even when recording rules are disabled.
+          expr: histogram_quantile(0.99, sum(rate(argus_gc_pause_seconds_bucket[5m])) by (le, instance)) > {{ .Values.prometheusRule.rules.gcPauseP99.threshold }}
           for: {{ .Values.prometheusRule.rules.gcPauseP99.duration }}
           labels:
             severity: {{ .Values.prometheusRule.rules.gcPauseP99.severity }}

--- a/charts/argus/templates/prometheusrule.yaml
+++ b/charts/argus/templates/prometheusrule.yaml
@@ -53,4 +53,30 @@ spec:
               {{ .Values.prometheusRule.rules.highCpu.threshold | mul 100 }}% threshold
               for {{ .Values.prometheusRule.rules.highCpu.duration }}.
         {{- end }}
+        {{- if .Values.prometheusRule.rules.gcPauseP99.enabled }}
+        - alert: ArgusGCPauseP99High
+          expr: argus:gc_pause:p99_5m > {{ .Values.prometheusRule.rules.gcPauseP99.threshold }}
+          for: {{ .Values.prometheusRule.rules.gcPauseP99.duration }}
+          labels:
+            severity: {{ .Values.prometheusRule.rules.gcPauseP99.severity }}
+          annotations:
+            summary: "High GC pause p99 on {{ "{{" }} $labels.instance {{ "}}" }}"
+            description: >-
+              The 5m p99 GC pause is {{ "{{" }} $value | humanizeDuration {{ "}}" }} on
+              {{ "{{" }} $labels.instance {{ "}}" }}, exceeding the
+              {{ .Values.prometheusRule.rules.gcPauseP99.threshold }}s threshold
+              for {{ .Values.prometheusRule.rules.gcPauseP99.duration }}.
+        {{- end }}
+    {{- if .Values.prometheusRule.recordingRules.enabled }}
+    - name: argus.recording
+      rules:
+        - record: argus:gc_pause:p99_5m
+          expr: histogram_quantile(0.99, sum(rate(argus_gc_pause_seconds_bucket[5m])) by (le, instance))
+        - record: argus:gc_pause:p50_5m
+          expr: histogram_quantile(0.50, sum(rate(argus_gc_pause_seconds_bucket[5m])) by (le, instance))
+        - record: argus:gc_pause_breakdown:rate5m
+          expr: sum(rate(argus_gc_pause_breakdown_seconds_total[5m])) by (instance, gc_name, gc_cause)
+        - record: argus:gc_events_breakdown:rate5m
+          expr: sum(rate(argus_gc_events_breakdown_total[5m])) by (instance, gc_name, gc_cause)
+    {{- end }}
 {{- end }}

--- a/charts/argus/values.yaml
+++ b/charts/argus/values.yaml
@@ -60,6 +60,15 @@ prometheusRule:
       threshold: 0.80
       duration: 5m
       severity: warning
+    gcPauseP99:
+      enabled: true
+      # seconds — alert when the 5m p99 GC pause exceeds this
+      threshold: 0.5
+      duration: 5m
+      severity: warning
+  # Prometheus recording rules (pre-computed series for dashboards/alerts)
+  recordingRules:
+    enabled: true
 
 # Grafana dashboard
 grafana:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -514,6 +514,20 @@ All 30+ metrics available via Prometheus are also exported via OTLP:
 |------|----------|
 | Gauge | `argus_virtual_threads_active`, `argus_cpu_jvm_percent`, `argus_heap_used_bytes` |
 | Sum (monotonic) | `argus_virtual_threads_started_total`, `argus_gc_pause_time_seconds_total` |
+| Histogram | `argus_gc_pause_seconds` (`_bucket`/`_sum`/`_count`) — GC pause-time distribution |
+| Per-collector counter | `argus_gc_pause_breakdown_seconds_total{gc_name,gc_cause}`, `argus_gc_events_breakdown_total{gc_name,gc_cause}` |
+
+### OpenMetrics exposition
+
+The `/prometheus` endpoint negotiates format by `Accept` header:
+
+- Default (`Accept: text/plain` or absent) → Prometheus 0.0.4 text exposition.
+- `Accept: application/openmetrics-text` → OpenMetrics 1.0.0 (terminated with `# EOF`),
+  with trace-id **exemplars** on the GC pause histogram when a trace context is
+  active (exemplars are populated once tracing correlation is wired; the plumbing
+  ships now and is a no-op until then).
+
+The OpenMetrics output passes `promtool check metrics`.
 
 ## CLI Configuration
 

--- a/docs/grafana-dashboard.json
+++ b/docs/grafana-dashboard.json
@@ -1153,7 +1153,7 @@
       "type": "timeseries",
       "targets": [
         {
-          "expr": "argus_carrier_threads_total",
+          "expr": "argus_carrier_threads",
           "legendFormat": "Carrier Count"
         },
         {


### PR DESCRIPTION
## Summary

Roadmap **Phase 1** of `.omc/plans/jvm-oss-parity-roadmap.md` (bringing JVM-OSS scorecard dimensions to ≥8). Two workstreams, disjoint files.

**W6 — Prometheus / metrics (7 → 8)**
- OpenMetrics 1.0.0 via `Accept` content negotiation on `/prometheus` (`# EOF` terminator); classic 0.0.4 stays the default.
- `argus_gc_pause_seconds` classic histogram (`_bucket`/`_sum`/`_count`, cumulative, monotonic). Native histograms are protobuf-only → classic histogram is the correct text-exposition choice.
- Exemplar plumbing (`setTraceIdSupplier`) → `# {trace_id=...}` on the +Inf bucket in OpenMetrics mode; no-op until W4 (Phase 3) wires trace context.
- New Grafana dashboard `argus-gc-collectors.json` (p99/p50 from histogram, per-collector pause/event rate, pause heatmap) wired into the dashboard ConfigMap.
- PrometheusRule: 4 recording rules + `ArgusGCPauseP99High` alert.
- **Breaking rename**: gauge `argus_carrier_threads_total` → `argus_carrier_threads` (gauges must not carry `_total`); all 4 real refs updated. This is what makes `promtool check metrics` pass with zero errors.

**W1.1 — continuous-profiling foundation** (query API + frontend = Phase 2)
- `argus-aggregator` `ProfileStore` + `ProfileStoreConfig`: disk-backed, append-only, time-windowed collapsed-stack store; ring retention; re-indexes on restart; zero external deps. `merged(pod,event,from,to)` read seam for the Phase-2 query API.
- `argus-cli` `AsProfLoopCapture` + `AsProfProvider.continuousCapture`: repeating async-profiler capture loop, gated `continuousEnabled` (default OFF).

## Test plan
- [x] `./gradlew :argus-server:test :argus-aggregator:test :argus-cli:compileJava :argus-diagnostics:compileJava` → BUILD SUCCESSFUL
- [x] New tests: `GCAnalyzerPauseHistogramTest` (4), `PrometheusMetricsCollectorOpenMetricsTest` (5), `ProfileStoreTest` (6), `AsProfLoopCaptureTest` (6)
- [x] `promtool check rules` on rendered PrometheusRule → SUCCESS, 8 rules
- [x] `promtool check metrics` on real collector OpenMetrics output → exit 0 (zero errors)
- [x] `helm lint charts/argus` → 0 failures; `helm template` renders new rules + dashboard key
- [ ] CI (build matrix + DCO + code-quality + runtime smoke)
- [ ] Live QA — deferred to maintainer post-merge (per request)

## Deferred (later phases)
- ProfileStore → scrape-loop wiring + query API + frontend diff view (W1.2 / Phase 2)
- Exemplar population (W4 / Phase 3)

🤖 Phase 1 of the JVM-OSS parity roadmap.