### PR TITLE
feat(heap,profiling): Phase 2 — MAT-class heap analysis + continuous-profiling query/diff/UI

### DIFF
--- a/argus-aggregator/src/main/java/io/argus/aggregator/ArgusAggregator.java
+++ b/argus-aggregator/src/main/java/io/argus/aggregator/ArgusAggregator.java
@@ -3,7 +3,10 @@ package io.argus.aggregator;
 import io.argus.aggregator.alert.FleetAlertEvaluator;
 import io.argus.aggregator.http.AggregatorChannelHandler;
 import io.argus.aggregator.http.FleetController;
+import io.argus.aggregator.http.ProfileController;
 import io.argus.aggregator.http.PrometheusMetricsExporter;
+import io.argus.aggregator.profile.ProfileStore;
+import io.argus.aggregator.profile.ProfileStoreConfig;
 import io.argus.aggregator.scrape.RemoteWriteSink;
 import io.argus.aggregator.scrape.ScrapeLoop;
 import io.argus.aggregator.store.FleetRegistry;
@@ -19,8 +22,12 @@ import io.netty.channel.socket.nio.NioServerSocketChannel;
 import io.netty.handler.codec.http.HttpObjectAggregator;
 import io.netty.handler.codec.http.HttpServerCodec;
 
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
@@ -70,12 +77,14 @@ public final class ArgusAggregator {
     private final FleetAlertEvaluator alertEvaluator;
     private final RemoteWriteSink remoteWrite;
     private final PrometheusMetricsExporter prometheus;
+    private final ProfileStore profileStore;
     private final FleetController controller;
     private final AtomicBoolean running = new AtomicBoolean(false);
 
     private EventLoopGroup bossGroup;
     private EventLoopGroup workerGroup;
     private Channel serverChannel;
+    private ScheduledExecutorService profileEvictor;
 
     public ArgusAggregator(Config config) {
         this(config, List.of());
@@ -93,8 +102,19 @@ public final class ArgusAggregator {
             }
         });
         this.prometheus = new PrometheusMetricsExporter(registry, scrapeLoop);
-        this.controller = new FleetController(registry, prometheus);
+        // Continuous-profiling store (W1). Always constructed — the store is
+        // cheap when empty — and re-indexes existing windows from disk on boot
+        // so profiles survive an aggregator restart. Base dir is overridable via
+        // --profile-dir / -Dargus.aggregator.profile.dir.
+        ProfileStoreConfig profileConfig = config.profileStoreDir == null
+                ? ProfileStoreConfig.defaults()
+                : ProfileStoreConfig.at(Path.of(config.profileStoreDir));
+        this.profileStore = new ProfileStore(profileConfig);
+        this.controller = new FleetController(registry, prometheus,
+                new ProfileController(profileStore));
     }
+
+    public ProfileStore profileStore() { return profileStore; }
 
     public FleetRegistry registry() { return registry; }
     public ScrapeLoop scrapeLoop() { return scrapeLoop; }
@@ -115,7 +135,9 @@ public final class ArgusAggregator {
                     protected void initChannel(SocketChannel ch) {
                         ch.pipeline()
                                 .addLast(new HttpServerCodec())
-                                .addLast(new HttpObjectAggregator(1024 * 1024))
+                                // 16 MB cap accommodates large /profile/ingest collapsed-stack
+                                // payloads from busy pods; metrics/fleet bodies are far smaller.
+                                .addLast(new HttpObjectAggregator(16 * 1024 * 1024))
                                 .addLast(new AggregatorChannelHandler(controller));
                     }
                 })
@@ -126,6 +148,20 @@ public final class ArgusAggregator {
 
         scrapeLoop.start();
         remoteWrite.start();
+
+        // Evict expired profile windows once a minute (ring retention).
+        profileEvictor = Executors.newSingleThreadScheduledExecutor(r -> {
+            Thread t = new Thread(r, "argus-profile-evictor");
+            t.setDaemon(true);
+            return t;
+        });
+        profileEvictor.scheduleWithFixedDelay(() -> {
+            try {
+                profileStore.evictExpired();
+            } catch (RuntimeException e) {
+                LOG.log(System.Logger.Level.WARNING, "profile eviction failed", e);
+            }
+        }, 1, 1, TimeUnit.MINUTES);
 
         LOG.log(System.Logger.Level.INFO, "argus-aggregator listening on "
                 + config.bindAddress + ":" + config.port);
@@ -138,6 +174,7 @@ public final class ArgusAggregator {
         if (!running.compareAndSet(true, false)) return;
         scrapeLoop.stop();
         remoteWrite.stop();
+        if (profileEvictor != null) profileEvictor.shutdownNow();
         if (serverChannel != null) serverChannel.close();
         if (bossGroup != null) bossGroup.shutdownGracefully();
         if (workerGroup != null) workerGroup.shutdownGracefully();
@@ -165,14 +202,22 @@ public final class ArgusAggregator {
         public final long scrapeIntervalSeconds;
         public final long retentionSeconds;
         public final String remoteWriteUrl;
+        /** Override for the continuous-profiling store base dir; null uses defaults. */
+        public final String profileStoreDir;
 
         public Config(int port, String bindAddress, long scrapeIntervalSeconds,
                       long retentionSeconds, String remoteWriteUrl) {
+            this(port, bindAddress, scrapeIntervalSeconds, retentionSeconds, remoteWriteUrl, null);
+        }
+
+        public Config(int port, String bindAddress, long scrapeIntervalSeconds,
+                      long retentionSeconds, String remoteWriteUrl, String profileStoreDir) {
             this.port = port;
             this.bindAddress = bindAddress;
             this.scrapeIntervalSeconds = scrapeIntervalSeconds;
             this.retentionSeconds = retentionSeconds;
             this.remoteWriteUrl = remoteWriteUrl;
+            this.profileStoreDir = profileStoreDir;
         }
 
         public static Config parse(String[] args) {
@@ -183,6 +228,7 @@ public final class ArgusAggregator {
             long retention = Long.getLong("argus.aggregator.retention.seconds",
                     DEFAULT_RETENTION_SECONDS);
             String remoteWrite = System.getProperty("argus.aggregator.remote.write.url", "");
+            String profileDir = System.getProperty("argus.aggregator.profile.dir", null);
 
             List<String> extra = new ArrayList<>();
             for (String arg : args) {
@@ -196,6 +242,8 @@ public final class ArgusAggregator {
                     retention = Long.parseLong(arg.substring("--retention=".length()));
                 } else if (arg.startsWith("--remote-write=")) {
                     remoteWrite = arg.substring("--remote-write=".length());
+                } else if (arg.startsWith("--profile-dir=")) {
+                    profileDir = arg.substring("--profile-dir=".length());
                 } else {
                     extra.add(arg);
                 }
@@ -203,7 +251,7 @@ public final class ArgusAggregator {
             if (!extra.isEmpty()) {
                 System.err.println("[argus-aggregator] ignoring unknown args: " + extra);
             }
-            return new Config(port, bind, interval, retention, remoteWrite);
+            return new Config(port, bind, interval, retention, remoteWrite, profileDir);
         }
     }
 }

--- a/argus-aggregator/src/main/java/io/argus/aggregator/http/FleetController.java
+++ b/argus-aggregator/src/main/java/io/argus/aggregator/http/FleetController.java
@@ -19,19 +19,11 @@ import io.argus.aggregator.store.FleetRegistry;
 import io.argus.aggregator.store.PodRingBuffer;
 import io.argus.core.net.HostAllowlist;
 
-import io.netty.buffer.ByteBuf;
-import io.netty.buffer.Unpooled;
-import io.netty.channel.ChannelFuture;
-import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandlerContext;
-import io.netty.handler.codec.http.DefaultFullHttpResponse;
 import io.netty.handler.codec.http.FullHttpRequest;
-import io.netty.handler.codec.http.FullHttpResponse;
 import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.HttpMethod;
 import io.netty.handler.codec.http.HttpResponseStatus;
-import io.netty.handler.codec.http.HttpUtil;
-import io.netty.handler.codec.http.HttpVersion;
 import io.netty.handler.codec.http.QueryStringDecoder;
 import io.netty.util.CharsetUtil;
 
@@ -87,16 +79,28 @@ public final class FleetController {
     private final FleetRegistry registry;
     private final PrometheusMetricsExporter prometheus;
     private final PodHttpClient podClient;
+    private final ProfileController profile;
 
     public FleetController(FleetRegistry registry, PrometheusMetricsExporter prometheus) {
-        this(registry, prometheus, new PodHttpClient());
+        this(registry, prometheus, new PodHttpClient(), null);
     }
 
     public FleetController(FleetRegistry registry, PrometheusMetricsExporter prometheus,
                            PodHttpClient podClient) {
+        this(registry, prometheus, podClient, null);
+    }
+
+    public FleetController(FleetRegistry registry, PrometheusMetricsExporter prometheus,
+                           ProfileController profile) {
+        this(registry, prometheus, new PodHttpClient(), profile);
+    }
+
+    public FleetController(FleetRegistry registry, PrometheusMetricsExporter prometheus,
+                           PodHttpClient podClient, ProfileController profile) {
         this.registry = registry;
         this.prometheus = prometheus;
         this.podClient = podClient;
+        this.profile = profile;
     }
 
     /** Returns true if the request was handled. */
@@ -106,6 +110,10 @@ public final class FleetController {
         HttpMethod method = request.method();
 
         try {
+            // ── Continuous-profiling routes (W1) ─────────────────────────────
+            if (profile != null && profile.dispatch(ctx, request, path, method, decoder)) {
+                return true;
+            }
             if (HttpMethod.GET.equals(method) && path.equals("/fleet/list")) {
                 handleFleetList(ctx, request, decoder.parameters());
                 return true;
@@ -581,42 +589,26 @@ public final class FleetController {
 
     private static void sendJson(ChannelHandlerContext ctx, FullHttpRequest request,
                                  HttpResponseStatus status, String json) {
-        sendText(ctx, request, status, json, "application/json");
+        HttpResponses.sendJson(ctx, request, status, json);
     }
 
     private static void sendPlain(ChannelHandlerContext ctx, FullHttpRequest request,
                                   HttpResponseStatus status, String content) {
-        sendText(ctx, request, status, content, "text/plain; charset=utf-8");
+        HttpResponses.sendPlain(ctx, request, status, content);
     }
 
     private static void sendText(ChannelHandlerContext ctx, FullHttpRequest request,
                                  HttpResponseStatus status, String content, String contentType) {
-        ByteBuf buf = Unpooled.copiedBuffer(content, CharsetUtil.UTF_8);
-        FullHttpResponse response = new DefaultFullHttpResponse(
-                HttpVersion.HTTP_1_1, status, buf);
-        response.headers()
-                .set(HttpHeaderNames.CONTENT_TYPE, contentType)
-                .setInt(HttpHeaderNames.CONTENT_LENGTH, buf.readableBytes());
-        ChannelFuture future = ctx.writeAndFlush(response);
-        if (!HttpUtil.isKeepAlive(request)) {
-            future.addListener(ChannelFutureListener.CLOSE);
-        }
+        HttpResponses.sendText(ctx, request, status, content, contentType);
     }
 
     private static void sendNoContent(ChannelHandlerContext ctx, FullHttpRequest request) {
-        FullHttpResponse response = new DefaultFullHttpResponse(
-                HttpVersion.HTTP_1_1, HttpResponseStatus.NO_CONTENT, Unpooled.EMPTY_BUFFER);
-        response.headers().setInt(HttpHeaderNames.CONTENT_LENGTH, 0);
-        ChannelFuture future = ctx.writeAndFlush(response);
-        if (!HttpUtil.isKeepAlive(request)) {
-            future.addListener(ChannelFutureListener.CLOSE);
-        }
+        HttpResponses.sendNoContent(ctx, request);
     }
 
     private static void sendError(ChannelHandlerContext ctx, FullHttpRequest request,
                                   int code, String message) {
-        HttpResponseStatus status = HttpResponseStatus.valueOf(code);
-        sendJson(ctx, request, status, JsonWriter.error(code, message));
+        HttpResponses.sendError(ctx, request, code, message);
     }
 
     private static String firstParam(Map<String, List<String>> params, String name) {

--- a/argus-aggregator/src/main/java/io/argus/aggregator/http/HttpResponses.java
+++ b/argus-aggregator/src/main/java/io/argus/aggregator/http/HttpResponses.java
@@ -1,0 +1,65 @@
+package io.argus.aggregator.http;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelFutureListener;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.handler.codec.http.DefaultFullHttpResponse;
+import io.netty.handler.codec.http.FullHttpRequest;
+import io.netty.handler.codec.http.FullHttpResponse;
+import io.netty.handler.codec.http.HttpHeaderNames;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import io.netty.handler.codec.http.HttpUtil;
+import io.netty.handler.codec.http.HttpVersion;
+import io.netty.util.CharsetUtil;
+
+/**
+ * Shared HTTP response writers for the aggregator's Netty controllers. Keeps the
+ * keep-alive handling and hand-built JSON error envelope in one place so
+ * {@link FleetController} and {@link ProfileController} stay consistent.
+ */
+final class HttpResponses {
+
+    private HttpResponses() {}
+
+    static void sendJson(ChannelHandlerContext ctx, FullHttpRequest request,
+                         HttpResponseStatus status, String json) {
+        sendText(ctx, request, status, json, "application/json");
+    }
+
+    static void sendPlain(ChannelHandlerContext ctx, FullHttpRequest request,
+                          HttpResponseStatus status, String content) {
+        sendText(ctx, request, status, content, "text/plain; charset=utf-8");
+    }
+
+    static void sendText(ChannelHandlerContext ctx, FullHttpRequest request,
+                         HttpResponseStatus status, String content, String contentType) {
+        ByteBuf buf = Unpooled.copiedBuffer(content, CharsetUtil.UTF_8);
+        FullHttpResponse response = new DefaultFullHttpResponse(
+                HttpVersion.HTTP_1_1, status, buf);
+        response.headers()
+                .set(HttpHeaderNames.CONTENT_TYPE, contentType)
+                .setInt(HttpHeaderNames.CONTENT_LENGTH, buf.readableBytes());
+        ChannelFuture future = ctx.writeAndFlush(response);
+        if (!HttpUtil.isKeepAlive(request)) {
+            future.addListener(ChannelFutureListener.CLOSE);
+        }
+    }
+
+    static void sendNoContent(ChannelHandlerContext ctx, FullHttpRequest request) {
+        FullHttpResponse response = new DefaultFullHttpResponse(
+                HttpVersion.HTTP_1_1, HttpResponseStatus.NO_CONTENT, Unpooled.EMPTY_BUFFER);
+        response.headers().setInt(HttpHeaderNames.CONTENT_LENGTH, 0);
+        ChannelFuture future = ctx.writeAndFlush(response);
+        if (!HttpUtil.isKeepAlive(request)) {
+            future.addListener(ChannelFutureListener.CLOSE);
+        }
+    }
+
+    static void sendError(ChannelHandlerContext ctx, FullHttpRequest request,
+                          int code, String message) {
+        HttpResponseStatus status = HttpResponseStatus.valueOf(code);
+        sendJson(ctx, request, status, JsonWriter.error(code, message));
+    }
+}

--- a/argus-aggregator/src/main/java/io/argus/aggregator/http/ProfileController.java
+++ b/argus-aggregator/src/main/java/io/argus/aggregator/http/ProfileController.java
@@ -1,0 +1,256 @@
+package io.argus.aggregator.http;
+
+// SECURITY: like the rest of the aggregator HTTP surface, the profile
+// endpoints are unauthenticated by design (alpha). They are reachable only
+// over the in-cluster Service; agents push collapsed-stack samples to
+// /profile/ingest and the frontend reads /profile/query + /profile/diff.
+// DO NOT expose this port to untrusted callers. See FleetController's header.
+
+import io.argus.aggregator.profile.FlameTree;
+import io.argus.aggregator.profile.ProfileStore;
+
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.handler.codec.http.FullHttpRequest;
+import io.netty.handler.codec.http.HttpMethod;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import io.netty.handler.codec.http.QueryStringDecoder;
+import io.netty.util.CharsetUtil;
+
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * HTTP routes for the continuous-profiling (W1) store:
+ *
+ * <ul>
+ *   <li>{@code POST /profile/ingest} — accepts a flat JSON body
+ *       {@code {"pod","service","event","timestamp","collapsed"}} where
+ *       {@code collapsed} is async-profiler collapsed text ({@code "frame;frame N\n…"}),
+ *       parses it to a {@code stack -> count} map and appends to the store.</li>
+ *   <li>{@code GET /profile/query?pod=&event=&from=&to=} — merged flamegraph JSON
+ *       built server-side from the merged collapsed map.</li>
+ *   <li>{@code GET /profile/diff?pod=&event=&baseFrom=&baseTo=&headFrom=&headTo=} —
+ *       differential flamegraph with a per-frame {@code delta = head - base}.</li>
+ * </ul>
+ *
+ * <p>Hand-built JSON throughout (no Jackson), matching the aggregator's style.
+ * Timestamps are epoch-millis (longs); {@code from}/{@code to} may be omitted and
+ * default to a trailing 1h window ending now.
+ */
+public final class ProfileController {
+
+    /** Cap on a single ingest body — 8 MB of collapsed text is generous. */
+    private static final int MAX_COLLAPSED_BYTES = 8 * 1024 * 1024;
+    /** Default query window when from/to are omitted: trailing 1 hour. */
+    private static final long DEFAULT_WINDOW_MILLIS = 3_600_000L;
+
+    private final ProfileStore store;
+
+    public ProfileController(ProfileStore store) {
+        this.store = store;
+    }
+
+    /** Returns true if the request matched a profile route and was handled. */
+    public boolean dispatch(ChannelHandlerContext ctx, FullHttpRequest request,
+                            String path, HttpMethod method, QueryStringDecoder decoder) {
+        if (HttpMethod.POST.equals(method) && path.equals("/profile/ingest")) {
+            handleIngest(ctx, request);
+            return true;
+        }
+        if (HttpMethod.GET.equals(method) && path.equals("/profile/query")) {
+            handleQuery(ctx, request, decoder.parameters());
+            return true;
+        }
+        if (HttpMethod.GET.equals(method) && path.equals("/profile/diff")) {
+            handleDiff(ctx, request, decoder.parameters());
+            return true;
+        }
+        return false;
+    }
+
+    // ── Ingest ────────────────────────────────────────────────────────────────
+
+    private void handleIngest(ChannelHandlerContext ctx, FullHttpRequest request) {
+        String body = request.content().toString(CharsetUtil.UTF_8);
+        if (body.length() > MAX_COLLAPSED_BYTES) {
+            HttpResponses.sendError(ctx, request, 413, "body too large");
+            return;
+        }
+        Map<String, String> parsed = JsonReader.parseFlatObject(body);
+        if (parsed == null) {
+            HttpResponses.sendError(ctx, request, 400, "invalid JSON body");
+            return;
+        }
+        String pod = parsed.get("pod");
+        String service = parsed.getOrDefault("service", "");
+        String event = parsed.get("event");
+        String collapsed = parsed.get("collapsed");
+        if (pod == null || pod.isBlank()) {
+            HttpResponses.sendError(ctx, request, 400, "missing 'pod'");
+            return;
+        }
+        if (event == null || event.isBlank()) {
+            HttpResponses.sendError(ctx, request, 400, "missing 'event'");
+            return;
+        }
+        long timestamp;
+        String ts = parsed.get("timestamp");
+        if (ts == null || ts.isBlank()) {
+            timestamp = System.currentTimeMillis();
+        } else {
+            try {
+                timestamp = Long.parseLong(ts.trim());
+            } catch (NumberFormatException e) {
+                HttpResponses.sendError(ctx, request, 400, "invalid 'timestamp'");
+                return;
+            }
+        }
+        Map<String, Long> counts = parseCollapsed(collapsed);
+        if (counts.isEmpty()) {
+            HttpResponses.sendError(ctx, request, 400, "no collapsed samples");
+            return;
+        }
+        store.append(pod, service, event, timestamp, counts);
+        long total = 0L;
+        for (long v : counts.values()) {
+            total += v;
+        }
+        String json = "{\"accepted\":true,\"stacks\":" + counts.size()
+                + ",\"samples\":" + total + "}";
+        HttpResponses.sendJson(ctx, request, HttpResponseStatus.OK, json);
+    }
+
+    /**
+     * Parses async-profiler collapsed text into a {@code stack -> count} map.
+     * Each non-blank line is {@code "frame;frame;… <count>"} — the count is the
+     * last whitespace-delimited token; the rest (with internal spaces preserved)
+     * is the stack. Repeated stacks within the body are summed. Malformed lines
+     * are skipped rather than failing the whole ingest.
+     */
+    static Map<String, Long> parseCollapsed(String collapsed) {
+        Map<String, Long> out = new HashMap<>();
+        if (collapsed == null || collapsed.isEmpty()) {
+            return out;
+        }
+        for (String rawLine : collapsed.split("\n")) {
+            String line = rawLine.strip();
+            if (line.isEmpty()) {
+                continue;
+            }
+            int sp = line.lastIndexOf(' ');
+            if (sp <= 0 || sp == line.length() - 1) {
+                continue;
+            }
+            String stack = line.substring(0, sp).strip();
+            String countStr = line.substring(sp + 1).strip();
+            if (stack.isEmpty()) {
+                continue;
+            }
+            long count;
+            try {
+                count = Long.parseLong(countStr);
+            } catch (NumberFormatException e) {
+                continue;
+            }
+            if (count <= 0L) {
+                continue;
+            }
+            out.merge(stack, count, Long::sum);
+        }
+        return out;
+    }
+
+    // ── Query ─────────────────────────────────────────────────────────────────
+
+    private void handleQuery(ChannelHandlerContext ctx, FullHttpRequest request,
+                             Map<String, List<String>> params) {
+        String pod = firstParam(params, "pod");
+        String event = firstParam(params, "event");
+        if (pod == null || event == null) {
+            HttpResponses.sendError(ctx, request, 400, "missing 'pod' or 'event'");
+            return;
+        }
+        long now = System.currentTimeMillis();
+        Long to = parseMillis(params, "to", now);
+        if (to == null) {
+            HttpResponses.sendError(ctx, request, 400, "invalid 'to'");
+            return;
+        }
+        Long from = parseMillis(params, "from", to - DEFAULT_WINDOW_MILLIS);
+        if (from == null) {
+            HttpResponses.sendError(ctx, request, 400, "invalid 'from'");
+            return;
+        }
+        Map<String, Long> merged = store.merged(pod, event,
+                Instant.ofEpochMilli(from), Instant.ofEpochMilli(to));
+        String tree = FlameTree.toJson(merged);
+        String json = "{\"pod\":\"" + JsonWriter.escape(pod) + "\","
+                + "\"event\":\"" + JsonWriter.escape(event) + "\","
+                + "\"from\":" + from + ",\"to\":" + to + ","
+                + "\"flamegraph\":" + tree + "}";
+        HttpResponses.sendJson(ctx, request, HttpResponseStatus.OK, json);
+    }
+
+    // ── Diff ──────────────────────────────────────────────────────────────────
+
+    private void handleDiff(ChannelHandlerContext ctx, FullHttpRequest request,
+                            Map<String, List<String>> params) {
+        String pod = firstParam(params, "pod");
+        String event = firstParam(params, "event");
+        if (pod == null || event == null) {
+            HttpResponses.sendError(ctx, request, 400, "missing 'pod' or 'event'");
+            return;
+        }
+        Long baseFrom = parseMillis(params, "baseFrom", null);
+        Long baseTo = parseMillis(params, "baseTo", null);
+        Long headFrom = parseMillis(params, "headFrom", null);
+        Long headTo = parseMillis(params, "headTo", null);
+        if (baseFrom == null || baseTo == null || headFrom == null || headTo == null) {
+            HttpResponses.sendError(ctx, request, 400,
+                    "missing/invalid baseFrom,baseTo,headFrom,headTo");
+            return;
+        }
+        Map<String, Long> base = store.merged(pod, event,
+                Instant.ofEpochMilli(baseFrom), Instant.ofEpochMilli(baseTo));
+        Map<String, Long> head = store.merged(pod, event,
+                Instant.ofEpochMilli(headFrom), Instant.ofEpochMilli(headTo));
+        String tree = FlameTree.diffToJson(base, head);
+        String json = "{\"pod\":\"" + JsonWriter.escape(pod) + "\","
+                + "\"event\":\"" + JsonWriter.escape(event) + "\","
+                + "\"baseFrom\":" + baseFrom + ",\"baseTo\":" + baseTo + ","
+                + "\"headFrom\":" + headFrom + ",\"headTo\":" + headTo + ","
+                + "\"flamegraph\":" + tree + "}";
+        HttpResponses.sendJson(ctx, request, HttpResponseStatus.OK, json);
+    }
+
+    // ── Param helpers ───────────────────────────────────────────────────────────
+
+    private static String firstParam(Map<String, List<String>> params, String name) {
+        List<String> values = params.get(name);
+        if (values == null || values.isEmpty()) {
+            return null;
+        }
+        String v = values.get(0);
+        return (v == null || v.isEmpty()) ? null : v;
+    }
+
+    /**
+     * Parses a millis param. Returns {@code fallback} when the param is absent,
+     * the parsed long when present and valid, or {@code null} when present but
+     * unparseable (so the caller can 400). When {@code fallback} is {@code null}
+     * an absent param also yields {@code null}.
+     */
+    private static Long parseMillis(Map<String, List<String>> params, String name, Long fallback) {
+        String v = firstParam(params, name);
+        if (v == null) {
+            return fallback;
+        }
+        try {
+            return Long.parseLong(v.trim());
+        } catch (NumberFormatException e) {
+            return null;
+        }
+    }
+}

--- a/argus-aggregator/src/main/java/io/argus/aggregator/profile/FlameTree.java
+++ b/argus-aggregator/src/main/java/io/argus/aggregator/profile/FlameTree.java
@@ -1,0 +1,202 @@
+package io.argus.aggregator.profile;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Builds a hierarchical flamegraph tree from collapsed-stack {@code stack -> count}
+ * maps and renders it to the JSON shape a d3-flamegraph component expects.
+ *
+ * <p>Collapsed stacks are semicolon-delimited frames, leaf last
+ * ({@code "root;a;b" -> count}), exactly as async-profiler emits and as
+ * {@link ProfileStore#merged} returns. A single map may contain multiple
+ * distinct roots; they are gathered under a synthetic {@code "root"} node so the
+ * output is always a single tree (what the renderer wants).
+ *
+ * <h2>Output shapes</h2>
+ * <p>{@link #toJson} — a plain flamegraph node:
+ * <pre>{@code {"name":"root","value":N,"children":[{"name":"a","value":..,"children":[...]}]}}</pre>
+ * where {@code value} is the inclusive sample count (sum of the subtree).
+ *
+ * <p>{@link #diffToJson} — a differential node carrying head/base counts and a
+ * signed delta per frame so the frontend can color grown (+) / shrunk (−) frames:
+ * <pre>{@code {"name":"a","value":head,"base":B,"head":H,"delta":H-B,"children":[...]}}</pre>
+ *
+ * <p>Pure, allocation-bounded by the number of distinct frames — no Jackson, no
+ * external deps. Java-17 safe.
+ */
+public final class FlameTree {
+
+    private FlameTree() {}
+
+    private static final String ROOT = "root";
+
+    /** A mutable tree node accumulated while inserting collapsed stacks. */
+    private static final class Node {
+        final String name;
+        long value;          // inclusive count for the plain tree
+        long head;           // inclusive head count for the diff tree
+        long base;           // inclusive base count for the diff tree
+        // LinkedHashMap keeps first-seen child order stable for deterministic output.
+        final Map<String, Node> children = new LinkedHashMap<>();
+
+        Node(String name) {
+            this.name = name;
+        }
+
+        Node child(String frame) {
+            return children.computeIfAbsent(frame, Node::new);
+        }
+    }
+
+    // ── Plain flamegraph ──────────────────────────────────────────────────────
+
+    /**
+     * Builds the flamegraph tree for one merged {@code stack -> count} map and
+     * returns it as d3-flamegraph JSON. Each node's {@code value} is the
+     * inclusive sample count of its subtree.
+     */
+    public static String toJson(Map<String, Long> collapsed) {
+        Node root = new Node(ROOT);
+        if (collapsed != null) {
+            for (Map.Entry<String, Long> e : collapsed.entrySet()) {
+                long count = e.getValue() == null ? 0L : e.getValue();
+                if (count <= 0L) {
+                    continue;
+                }
+                insert(root, e.getKey(), count);
+            }
+        }
+        StringBuilder sb = new StringBuilder(256);
+        appendPlain(sb, root);
+        return sb.toString();
+    }
+
+    private static void insert(Node root, String stack, long count) {
+        root.value += count;
+        Node cur = root;
+        for (String frame : splitFrames(stack)) {
+            cur = cur.child(frame);
+            cur.value += count;
+        }
+    }
+
+    private static void appendPlain(StringBuilder sb, Node node) {
+        sb.append("{\"name\":\"").append(escape(node.name)).append("\",")
+          .append("\"value\":").append(node.value)
+          .append(",\"children\":[");
+        boolean first = true;
+        for (Node c : node.children.values()) {
+            if (!first) sb.append(',');
+            first = false;
+            appendPlain(sb, c);
+        }
+        sb.append("]}");
+    }
+
+    // ── Differential flamegraph ────────────────────────────────────────────────
+
+    /**
+     * Builds a differential flamegraph from a {@code base} window and a
+     * {@code head} window. Each node carries inclusive {@code head} / {@code base}
+     * counts and a signed {@code delta = head - base}; {@code value} is the head
+     * count (so the rendered width tracks the current profile). Frames present
+     * only in head have {@code base == 0} (positive delta); frames present only in
+     * base have {@code head == 0} (negative delta).
+     */
+    public static String diffToJson(Map<String, Long> base, Map<String, Long> head) {
+        Node root = new Node(ROOT);
+        accumulate(root, head, true);
+        accumulate(root, base, false);
+        StringBuilder sb = new StringBuilder(256);
+        appendDiff(sb, root);
+        return sb.toString();
+    }
+
+    private static void accumulate(Node root, Map<String, Long> collapsed, boolean isHead) {
+        if (collapsed == null) {
+            return;
+        }
+        for (Map.Entry<String, Long> e : collapsed.entrySet()) {
+            long count = e.getValue() == null ? 0L : e.getValue();
+            if (count <= 0L) {
+                continue;
+            }
+            if (isHead) root.head += count; else root.base += count;
+            Node cur = root;
+            for (String frame : splitFrames(e.getKey())) {
+                cur = cur.child(frame);
+                if (isHead) cur.head += count; else cur.base += count;
+            }
+        }
+    }
+
+    private static void appendDiff(StringBuilder sb, Node node) {
+        long delta = node.head - node.base;
+        sb.append("{\"name\":\"").append(escape(node.name)).append("\",")
+          .append("\"value\":").append(node.head)
+          .append(",\"head\":").append(node.head)
+          .append(",\"base\":").append(node.base)
+          .append(",\"delta\":").append(delta)
+          .append(",\"children\":[");
+        boolean first = true;
+        for (Node c : node.children.values()) {
+            if (!first) sb.append(',');
+            first = false;
+            appendDiff(sb, c);
+        }
+        sb.append("]}");
+    }
+
+    // ── Helpers ────────────────────────────────────────────────────────────────
+
+    /** Splits a collapsed stack into frames, dropping empty segments. */
+    private static List<String> splitFrames(String stack) {
+        List<String> out = new ArrayList<>();
+        if (stack == null || stack.isEmpty()) {
+            return out;
+        }
+        int start = 0;
+        for (int i = 0; i < stack.length(); i++) {
+            if (stack.charAt(i) == ';') {
+                if (i > start) {
+                    out.add(stack.substring(start, i));
+                }
+                start = i + 1;
+            }
+        }
+        if (start < stack.length()) {
+            out.add(stack.substring(start));
+        }
+        return out;
+    }
+
+    /** Minimal JSON string escaper (frame names rarely need it, but be safe). */
+    static String escape(String s) {
+        if (s == null) {
+            return "";
+        }
+        StringBuilder sb = new StringBuilder(s.length() + 8);
+        for (int i = 0; i < s.length(); i++) {
+            char c = s.charAt(i);
+            switch (c) {
+                case '\\': sb.append("\\\\"); break;
+                case '"':  sb.append("\\\""); break;
+                case '\n': sb.append("\\n"); break;
+                case '\r': sb.append("\\r"); break;
+                case '\t': sb.append("\\t"); break;
+                case '\b': sb.append("\\b"); break;
+                case '\f': sb.append("\\f"); break;
+                default:
+                    if (c < 0x20) {
+                        sb.append(String.format("\\u%04x", (int) c));
+                    } else {
+                        sb.append(c);
+                    }
+            }
+        }
+        return sb.toString();
+    }
+}

--- a/argus-aggregator/src/test/java/io/argus/aggregator/FlameTreeTest.java
+++ b/argus-aggregator/src/test/java/io/argus/aggregator/FlameTreeTest.java
@@ -1,0 +1,82 @@
+package io.argus.aggregator;
+
+import io.argus.aggregator.profile.FlameTree;
+import org.junit.jupiter.api.Test;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Unit tests for the collapsed-stack → flamegraph-tree builder.
+ *
+ * <p>Asserts inclusive leaf/branch counts and the multi-root → single synthetic
+ * root behaviour, plus the differential builder's per-frame signed deltas. Tree
+ * inspection is done with lightweight substring assertions on the hand-built
+ * JSON — enough to pin the shape without pulling in a JSON parser.
+ */
+class FlameTreeTest {
+
+    @Test
+    void buildsTreeFromSemicolonStacksAndSumsInclusiveCounts() {
+        Map<String, Long> collapsed = new LinkedHashMap<>();
+        collapsed.put("main;a;b", 10L);
+        collapsed.put("main;a;c", 5L);
+        collapsed.put("main;d", 3L);
+
+        String json = FlameTree.toJson(collapsed);
+
+        // Root is the synthetic "root" with the grand total (10+5+3 = 18).
+        assertTrue(json.startsWith("{\"name\":\"root\",\"value\":18,"), json);
+        // "main" is inclusive of everything under it (still 18).
+        assertTrue(json.contains("{\"name\":\"main\",\"value\":18,"), json);
+        // "a" is inclusive of b + c = 15.
+        assertTrue(json.contains("{\"name\":\"a\",\"value\":15,"), json);
+        // Leaves carry their own counts.
+        assertTrue(json.contains("{\"name\":\"b\",\"value\":10,\"children\":[]}"), json);
+        assertTrue(json.contains("{\"name\":\"c\",\"value\":5,\"children\":[]}"), json);
+        assertTrue(json.contains("{\"name\":\"d\",\"value\":3,\"children\":[]}"), json);
+    }
+
+    @Test
+    void gathersMultipleRootsUnderSyntheticRoot() {
+        Map<String, Long> collapsed = new LinkedHashMap<>();
+        collapsed.put("rootA;x", 4L);
+        collapsed.put("rootB;y", 6L);
+
+        String json = FlameTree.toJson(collapsed);
+
+        assertTrue(json.startsWith("{\"name\":\"root\",\"value\":10,"), json);
+        assertTrue(json.contains("{\"name\":\"rootA\",\"value\":4,"), json);
+        assertTrue(json.contains("{\"name\":\"rootB\",\"value\":6,"), json);
+    }
+
+    @Test
+    void emptyMapYieldsZeroValueRoot() {
+        String json = FlameTree.toJson(Map.of());
+        assertEquals("{\"name\":\"root\",\"value\":0,\"children\":[]}", json);
+    }
+
+    @Test
+    void diffCarriesSignedPerFrameDeltas() {
+        Map<String, Long> base = new LinkedHashMap<>();
+        base.put("main;a", 10L);   // shrinks to 6
+        base.put("main;gone", 5L); // removed in head -> negative delta
+
+        Map<String, Long> head = new LinkedHashMap<>();
+        head.put("main;a", 6L);
+        head.put("main;new", 8L);  // only in head -> positive delta
+
+        String json = FlameTree.diffToJson(base, head);
+
+        // Root: head total 14, base total 15, delta -1.
+        assertTrue(json.startsWith("{\"name\":\"root\",\"value\":14,\"head\":14,\"base\":15,\"delta\":-1,"), json);
+        // Frame "a" grew? base 10, head 6 -> delta -4.
+        assertTrue(json.contains("{\"name\":\"a\",\"value\":6,\"head\":6,\"base\":10,\"delta\":-4,"), json);
+        // Frame only in head.
+        assertTrue(json.contains("{\"name\":\"new\",\"value\":8,\"head\":8,\"base\":0,\"delta\":8,"), json);
+        // Frame only in base: head 0, base 5, delta -5.
+        assertTrue(json.contains("{\"name\":\"gone\",\"value\":0,\"head\":0,\"base\":5,\"delta\":-5,"), json);
+    }
+}

--- a/argus-aggregator/src/test/java/io/argus/aggregator/ProfileControllerTest.java
+++ b/argus-aggregator/src/test/java/io/argus/aggregator/ProfileControllerTest.java
@@ -1,0 +1,171 @@
+package io.argus.aggregator;
+
+import io.argus.aggregator.http.AggregatorChannelHandler;
+import io.argus.aggregator.http.FleetController;
+import io.argus.aggregator.http.ProfileController;
+import io.argus.aggregator.http.PrometheusMetricsExporter;
+import io.argus.aggregator.profile.ProfileStore;
+import io.argus.aggregator.profile.ProfileStoreConfig;
+import io.argus.aggregator.scrape.ScrapeLoop;
+import io.argus.aggregator.store.FleetRegistry;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.embedded.EmbeddedChannel;
+import io.netty.handler.codec.http.DefaultFullHttpRequest;
+import io.netty.handler.codec.http.FullHttpRequest;
+import io.netty.handler.codec.http.FullHttpResponse;
+import io.netty.handler.codec.http.HttpMethod;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import io.netty.handler.codec.http.HttpVersion;
+import io.netty.util.CharsetUtil;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Path;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Drives {@link ProfileController} through a real {@link AggregatorChannelHandler}
+ * on an {@link EmbeddedChannel} (same harness as {@code FleetControllerValidationTest})
+ * over a {@link ProfileStore} rooted at a {@link TempDir}.
+ *
+ * <p>Covers the ingest → query roundtrip (leaf counts sum to ingested totals) and
+ * the differential flamegraph (per-frame deltas, including head-only and base-only
+ * frames). JSON is inspected with substring / regex assertions rather than a parser
+ * to stay dependency-free, matching the aggregator's hand-built JSON ethos.
+ */
+class ProfileControllerTest {
+
+    private static EmbeddedChannel newChannel(Path dir) {
+        FleetRegistry registry = new FleetRegistry(60);
+        ScrapeLoop loop = new ScrapeLoop(registry, 5, r -> {});
+        PrometheusMetricsExporter prom = new PrometheusMetricsExporter(registry, loop);
+        ProfileStore store = new ProfileStore(ProfileStoreConfig.at(dir));
+        FleetController controller = new FleetController(registry, prom, new ProfileController(store));
+        return new EmbeddedChannel(new AggregatorChannelHandler(controller));
+    }
+
+    private static FullHttpResponse send(EmbeddedChannel ch, FullHttpRequest req) {
+        ch.writeInbound(req);
+        FullHttpResponse resp = ch.readOutbound();
+        assertNotNull(resp, "no outbound response produced");
+        return resp;
+    }
+
+    private static FullHttpResponse post(EmbeddedChannel ch, String path, String body) {
+        return send(ch, new DefaultFullHttpRequest(
+                HttpVersion.HTTP_1_1, HttpMethod.POST, path,
+                Unpooled.copiedBuffer(body, CharsetUtil.UTF_8)));
+    }
+
+    private static FullHttpResponse get(EmbeddedChannel ch, String path) {
+        return send(ch, new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, path));
+    }
+
+    private static String bodyOf(FullHttpResponse resp) {
+        return resp.content().toString(CharsetUtil.UTF_8);
+    }
+
+    /** Extracts the synthetic-root inclusive value from a query flamegraph JSON. */
+    private static long rootValue(String json) {
+        Matcher m = Pattern.compile("\\{\"name\":\"root\",\"value\":(-?\\d+),").matcher(json);
+        assertTrue(m.find(), "no root node in: " + json);
+        return Long.parseLong(m.group(1));
+    }
+
+    @Test
+    void ingestThenQueryRoundtripSumsToIngestedTotals(@TempDir Path dir) {
+        EmbeddedChannel ch = newChannel(dir);
+        long ts = 1_716_854_400_000L; // fixed epoch millis (2024-05-28T00:00:00Z)
+
+        // collapsed text uses \n (JSON-escaped) between records.
+        String collapsed = "main;a;b 10\\nmain;a;c 5\\nmain;d 3";
+        FullHttpResponse ingest = post(ch, "/profile/ingest",
+                "{\"pod\":\"ns/pod-1\",\"service\":\"svc\",\"event\":\"cpu\","
+              + "\"timestamp\":\"" + ts + "\",\"collapsed\":\"" + collapsed + "\"}");
+        assertEquals(HttpResponseStatus.OK, ingest.status(), bodyOf(ingest));
+        assertTrue(bodyOf(ingest).contains("\"samples\":18"), bodyOf(ingest));
+
+        // Query a window covering ts.
+        long from = ts - 1000;
+        long to = ts + 60_000;
+        FullHttpResponse query = get(ch,
+                "/profile/query?pod=" + enc("ns/pod-1") + "&event=cpu&from=" + from + "&to=" + to);
+        assertEquals(HttpResponseStatus.OK, query.status(), bodyOf(query));
+        String json = bodyOf(query);
+
+        // The synthetic root's inclusive value equals the ingested total (18).
+        assertEquals(18L, rootValue(json), json);
+        // Leaf counts present.
+        assertTrue(json.contains("{\"name\":\"b\",\"value\":10,\"children\":[]}"), json);
+        assertTrue(json.contains("{\"name\":\"c\",\"value\":5,\"children\":[]}"), json);
+        assertTrue(json.contains("{\"name\":\"d\",\"value\":3,\"children\":[]}"), json);
+    }
+
+    @Test
+    void queryEmptyWindowYieldsZeroRoot(@TempDir Path dir) {
+        EmbeddedChannel ch = newChannel(dir);
+        FullHttpResponse query = get(ch,
+                "/profile/query?pod=" + enc("ns/pod-1") + "&event=cpu&from=0&to=1000");
+        assertEquals(HttpResponseStatus.OK, query.status());
+        assertEquals(0L, rootValue(bodyOf(query)));
+    }
+
+    @Test
+    void diffComputesPerFrameDeltasAcrossWindows(@TempDir Path dir) {
+        EmbeddedChannel ch = newChannel(dir);
+        long baseTs = 1_716_854_400_000L;             // base window
+        long headTs = baseTs + 3_600_000L;            // head window, 1h later
+
+        // Base: main;a=10, main;gone=5
+        post(ch, "/profile/ingest",
+                "{\"pod\":\"ns/pod-1\",\"event\":\"cpu\",\"timestamp\":\"" + baseTs + "\","
+              + "\"collapsed\":\"main;a 10\\nmain;gone 5\"}");
+        // Head: main;a=6, main;new=8
+        post(ch, "/profile/ingest",
+                "{\"pod\":\"ns/pod-1\",\"event\":\"cpu\",\"timestamp\":\"" + headTs + "\","
+              + "\"collapsed\":\"main;a 6\\nmain;new 8\"}");
+
+        String q = "/profile/diff?pod=" + enc("ns/pod-1") + "&event=cpu"
+                + "&baseFrom=" + (baseTs - 1000) + "&baseTo=" + (baseTs + 60_000)
+                + "&headFrom=" + (headTs - 1000) + "&headTo=" + (headTs + 60_000);
+        FullHttpResponse diff = get(ch, q);
+        assertEquals(HttpResponseStatus.OK, diff.status(), bodyOf(diff));
+        String json = bodyOf(diff);
+
+        // Root: head=14, base=15, delta=-1.
+        assertTrue(json.contains("\"name\":\"root\",\"value\":14,\"head\":14,\"base\":15,\"delta\":-1,"), json);
+        // a shrank: base 10 -> head 6 (delta -4).
+        assertTrue(json.contains("{\"name\":\"a\",\"value\":6,\"head\":6,\"base\":10,\"delta\":-4,"), json);
+        // new only in head (delta +8).
+        assertTrue(json.contains("{\"name\":\"new\",\"value\":8,\"head\":8,\"base\":0,\"delta\":8,"), json);
+        // gone only in base (delta -5).
+        assertTrue(json.contains("{\"name\":\"gone\",\"value\":0,\"head\":0,\"base\":5,\"delta\":-5,"), json);
+    }
+
+    @Test
+    void ingestRejectsMissingPodOrEvent(@TempDir Path dir) {
+        EmbeddedChannel ch = newChannel(dir);
+        FullHttpResponse r1 = post(ch, "/profile/ingest",
+                "{\"event\":\"cpu\",\"collapsed\":\"a 1\"}");
+        assertEquals(HttpResponseStatus.BAD_REQUEST, r1.status());
+
+        EmbeddedChannel ch2 = newChannel(dir);
+        FullHttpResponse r2 = post(ch2, "/profile/ingest",
+                "{\"pod\":\"ns/pod-1\",\"collapsed\":\"a 1\"}");
+        assertEquals(HttpResponseStatus.BAD_REQUEST, r2.status());
+    }
+
+    @Test
+    void queryRejectsMissingParams(@TempDir Path dir) {
+        EmbeddedChannel ch = newChannel(dir);
+        FullHttpResponse resp = get(ch, "/profile/query?pod=" + enc("ns/pod-1"));
+        assertEquals(HttpResponseStatus.BAD_REQUEST, resp.status());
+    }
+
+    private static String enc(String s) {
+        return java.net.URLEncoder.encode(s, java.nio.charset.StandardCharsets.UTF_8);
+    }
+}

--- a/argus-cli/src/main/java/io/argus/cli/command/HeapAnalyzeCommand.java
+++ b/argus-cli/src/main/java/io/argus/cli/command/HeapAnalyzeCommand.java
@@ -8,6 +8,11 @@ import io.argus.cli.provider.ProviderRegistry;
 import io.argus.cli.render.AnsiStyle;
 import io.argus.cli.render.RichRenderer;
 import io.argus.core.command.CommandGroup;
+import io.argus.diagnostics.heapgraph.ArrayObjectGraph;
+import io.argus.diagnostics.heapgraph.DominatorTree;
+import io.argus.diagnostics.heapgraph.HeapGraphAnalysis;
+import io.argus.diagnostics.heapgraph.HprofGraphBuilder;
+import io.argus.diagnostics.heapgraph.LeakSuspect;
 
 import java.io.File;
 import java.util.List;
@@ -48,6 +53,8 @@ public final class HeapAnalyzeCommand implements Command {
     public void execute(String[] args, CliConfig config, ProviderRegistry registry, Messages messages) {
         if (args.length == 0) {
             System.err.println("Usage: argus heapanalyze <file.hprof> [--top N] [--sort size|count] [--format=json]");
+            System.err.println("  Deep triage (MAT-class): [--leak-suspects] [--dominators=N] "
+                    + "[--path-to-root=<class>] [--retained=<class>]");
             return;
         }
 
@@ -56,6 +63,12 @@ public final class HeapAnalyzeCommand implements Command {
         String sortBy = "size";
         boolean json = "json".equals(config.format());
         boolean useColor = config.color();
+
+        // W2 deep-analysis flags
+        boolean leakSuspects = false;
+        int dominators = -1;
+        String pathToRoot = null;
+        String retainedClass = null;
 
         for (int i = 0; i < args.length; i++) {
             String arg = args[i];
@@ -67,6 +80,17 @@ public final class HeapAnalyzeCommand implements Command {
                 sortBy = arg.substring(7);
             } else if (arg.equals("--format=json")) {
                 json = true;
+            } else if (arg.equals("--leak-suspects")) {
+                leakSuspects = true;
+            } else if (arg.startsWith("--dominators=")) {
+                try { dominators = Integer.parseInt(arg.substring(13)); } catch (NumberFormatException ignored) { dominators = 20; }
+                if (dominators < 0) dominators = 20; // negative would silently disable deep analysis
+            } else if (arg.equals("--dominators")) {
+                dominators = 20;
+            } else if (arg.startsWith("--path-to-root=")) {
+                pathToRoot = arg.substring(15);
+            } else if (arg.startsWith("--retained=")) {
+                retainedClass = arg.substring(11);
             } else if (!arg.startsWith("--")) {
                 filePath = arg;
             }
@@ -87,7 +111,13 @@ public final class HeapAnalyzeCommand implements Command {
             return;
         }
 
-        // Parse
+        boolean deep = leakSuspects || dominators >= 0 || pathToRoot != null || retainedClass != null;
+        if (deep) {
+            runDeepAnalysis(file, useColor, leakSuspects, dominators, pathToRoot, retainedClass);
+            return;
+        }
+
+        // Parse (default: streaming histogram)
         long startTime = System.currentTimeMillis();
         HprofSummary summary;
         try {
@@ -105,6 +135,171 @@ public final class HeapAnalyzeCommand implements Command {
         }
 
         printRich(summary, topN, sortBy, useColor, elapsed);
+    }
+
+    /**
+     * Deep MAT-class triage: builds the full object graph (reference edges +
+     * GC roots), computes the dominator tree and retained sizes, and renders the
+     * requested view(s): leak suspects, top dominators, path-to-root, retained.
+     */
+    private void runDeepAnalysis(File file, boolean c, boolean leakSuspects, int dominators,
+                                 String pathToRoot, String retainedClass) {
+        long startTime = System.currentTimeMillis();
+        ArrayObjectGraph graph;
+        try {
+            System.err.println("Building object graph for " + file.getName()
+                    + " (" + RichRenderer.formatBytes(file.length()) + ")...");
+            graph = HprofGraphBuilder.build(file);
+        } catch (Exception e) {
+            System.err.println("Error building object graph: " + e.getMessage());
+            return;
+        }
+        HeapGraphAnalysis analysis = HeapGraphAnalysis.analyze(graph);
+        DominatorTree dom = analysis.dominators();
+        long elapsed = System.currentTimeMillis() - startTime;
+
+        System.out.print(RichRenderer.brandedHeader(c, "heapanalyze",
+                "Heap dump triage — dominators, retained sizes, leak suspects"));
+        System.out.println(RichRenderer.boxHeader(c, "Heap Triage", WIDTH,
+                file.getName(), RichRenderer.formatBytes(file.length())));
+        System.out.println(RichRenderer.emptyLine(WIDTH));
+        System.out.println(RichRenderer.boxLine(String.format(
+                "  Objects: %,d  |  Reachable: %,d  |  Reachable heap: %s  |  %,dms",
+                graph.objectCount(), dom.reachableCount(),
+                RichRenderer.formatBytes(analysis.totalReachableBytes()), elapsed), WIDTH));
+        System.out.println(RichRenderer.emptyLine(WIDTH));
+
+        if (leakSuspects) {
+            renderLeakSuspects(analysis, c);
+        }
+        if (dominators >= 0) {
+            renderDominators(analysis, dom, dominators == 0 ? 20 : dominators, c);
+        }
+        if (retainedClass != null) {
+            renderRetained(analysis, retainedClass, c);
+        }
+        if (pathToRoot != null) {
+            renderPathToRoot(analysis, graph, pathToRoot, c);
+        }
+
+        System.out.println(RichRenderer.boxFooter(c, String.format(
+                "%,d reachable objects, %s reachable",
+                dom.reachableCount(), RichRenderer.formatBytes(analysis.totalReachableBytes())), WIDTH));
+    }
+
+    private void renderLeakSuspects(HeapGraphAnalysis analysis, boolean c) {
+        System.out.println(RichRenderer.boxSeparator(WIDTH));
+        System.out.println(RichRenderer.emptyLine(WIDTH));
+        System.out.println(RichRenderer.boxLine(
+                "  " + AnsiStyle.style(c, AnsiStyle.BOLD, AnsiStyle.CYAN) + "Leak Suspects"
+                        + AnsiStyle.style(c, AnsiStyle.RESET), WIDTH));
+        System.out.println(RichRenderer.emptyLine(WIDTH));
+
+        List<LeakSuspect> suspects = analysis.leakSuspects(5, 10.0);
+        if (suspects.isEmpty()) {
+            System.out.println(RichRenderer.boxLine(
+                    "  " + AnsiStyle.style(c, AnsiStyle.GREEN) + "✔ No dominant accumulation point detected"
+                            + AnsiStyle.style(c, AnsiStyle.RESET), WIDTH));
+        }
+        for (int i = 0; i < suspects.size(); i++) {
+            LeakSuspect s = suspects.get(i);
+            String sev = s.heapPercent() >= 10.0
+                    ? AnsiStyle.style(c, AnsiStyle.RED, AnsiStyle.BOLD) + "⚠ SUSPECT"
+                    : AnsiStyle.style(c, AnsiStyle.YELLOW) + "  candidate";
+            System.out.println(RichRenderer.boxLine("  " + sev + AnsiStyle.style(c, AnsiStyle.RESET)
+                    + "  " + AnsiStyle.style(c, AnsiStyle.GREEN)
+                    + RichRenderer.humanClassName(s.className()) + AnsiStyle.style(c, AnsiStyle.RESET), WIDTH));
+            System.out.println(RichRenderer.boxLine(String.format(
+                    "      retains %s (%.1f%% of reachable heap), dominates %,d objects",
+                    RichRenderer.formatBytes(s.retainedBytes()), s.heapPercent(), s.dominatedCount()), WIDTH));
+        }
+        System.out.println(RichRenderer.emptyLine(WIDTH));
+    }
+
+    private void renderDominators(HeapGraphAnalysis analysis, DominatorTree dom, int n, boolean c) {
+        System.out.println(RichRenderer.boxSeparator(WIDTH));
+        System.out.println(RichRenderer.emptyLine(WIDTH));
+        System.out.println(RichRenderer.boxLine(
+                "  " + AnsiStyle.style(c, AnsiStyle.BOLD) + "Top " + n + " dominators by retained size"
+                        + AnsiStyle.style(c, AnsiStyle.RESET), WIDTH));
+        System.out.println(RichRenderer.emptyLine(WIDTH));
+        String hdr = AnsiStyle.style(c, AnsiStyle.BOLD)
+                + RichRenderer.padRight("#", 4)
+                + RichRenderer.padRight("Retained", 16)
+                + RichRenderer.padRight("Dominated", 12)
+                + "Class" + AnsiStyle.style(c, AnsiStyle.RESET);
+        System.out.println(RichRenderer.boxLine("  " + hdr, WIDTH));
+        System.out.println(RichRenderer.boxLine("  " + "─".repeat(Math.min(WIDTH - 6, 75)), WIDTH));
+
+        int[] top = analysis.topDominators(n);
+        long total = analysis.totalReachableBytes() > 0 ? analysis.totalReachableBytes() : 1;
+        for (int i = 0; i < top.length; i++) {
+            int v = top[i];
+            long retained = dom.retainedSize(v);
+            double pct = retained * 100.0 / total;
+            String pctColor = pct > 10 ? AnsiStyle.style(c, AnsiStyle.RED, AnsiStyle.BOLD)
+                    : pct > 5 ? AnsiStyle.style(c, AnsiStyle.YELLOW) : AnsiStyle.style(c, AnsiStyle.DIM);
+            String line = RichRenderer.padRight(String.valueOf(i + 1), 4)
+                    + pctColor + RichRenderer.padRight(RichRenderer.formatBytes(retained), 16)
+                    + AnsiStyle.style(c, AnsiStyle.RESET)
+                    + RichRenderer.padRight(String.format("%,d", dom.subtreeSize(v)), 12)
+                    + AnsiStyle.style(c, AnsiStyle.GREEN)
+                    + RichRenderer.humanClassName(analysis.graph().className(analysis.graph().classOf(v)))
+                    + AnsiStyle.style(c, AnsiStyle.RESET);
+            System.out.println(RichRenderer.boxLine("  " + line, WIDTH));
+        }
+        System.out.println(RichRenderer.emptyLine(WIDTH));
+    }
+
+    private void renderRetained(HeapGraphAnalysis analysis, String className, boolean c) {
+        System.out.println(RichRenderer.boxSeparator(WIDTH));
+        System.out.println(RichRenderer.emptyLine(WIDTH));
+        long[] r = analysis.retainedForClass(className);
+        long total = analysis.totalReachableBytes() > 0 ? analysis.totalReachableBytes() : 1;
+        double pct = r[0] * 100.0 / total;
+        System.out.println(RichRenderer.boxLine(
+                "  " + AnsiStyle.style(c, AnsiStyle.BOLD) + "Retained size of " + className
+                        + AnsiStyle.style(c, AnsiStyle.RESET), WIDTH));
+        if (r[1] == 0) {
+            System.out.println(RichRenderer.boxLine(
+                    "  " + AnsiStyle.style(c, AnsiStyle.YELLOW)
+                            + "  no reachable instances found"
+                            + AnsiStyle.style(c, AnsiStyle.RESET), WIDTH));
+        } else {
+            System.out.println(RichRenderer.boxLine(String.format(
+                    "  %,d instances retain %s (%.1f%% of reachable heap)",
+                    r[1], RichRenderer.formatBytes(r[0]), pct), WIDTH));
+        }
+        System.out.println(RichRenderer.emptyLine(WIDTH));
+    }
+
+    private void renderPathToRoot(HeapGraphAnalysis analysis, ArrayObjectGraph graph,
+                                  String className, boolean c) {
+        System.out.println(RichRenderer.boxSeparator(WIDTH));
+        System.out.println(RichRenderer.emptyLine(WIDTH));
+        System.out.println(RichRenderer.boxLine(
+                "  " + AnsiStyle.style(c, AnsiStyle.BOLD) + "Shortest path to GC root: " + className
+                        + AnsiStyle.style(c, AnsiStyle.RESET), WIDTH));
+        System.out.println(RichRenderer.emptyLine(WIDTH));
+        int[] path = analysis.pathToRootForClass(className);
+        if (path.length == 0) {
+            System.out.println(RichRenderer.boxLine(
+                    "  " + AnsiStyle.style(c, AnsiStyle.YELLOW)
+                            + "  no reachable instance of " + className + " found"
+                            + AnsiStyle.style(c, AnsiStyle.RESET), WIDTH));
+        } else {
+            for (int i = 0; i < path.length; i++) {
+                int v = path[i];
+                String prefix = i == 0
+                        ? AnsiStyle.style(c, AnsiStyle.RED, AnsiStyle.BOLD) + "GC root → " + AnsiStyle.style(c, AnsiStyle.RESET)
+                        : "  " + "  ".repeat(Math.min(i, 6)) + "↳ ";
+                System.out.println(RichRenderer.boxLine("  " + prefix
+                        + AnsiStyle.style(c, AnsiStyle.GREEN)
+                        + RichRenderer.humanClassName(graph.className(graph.classOf(v)))
+                        + AnsiStyle.style(c, AnsiStyle.RESET), WIDTH));
+            }
+        }
+        System.out.println(RichRenderer.emptyLine(WIDTH));
     }
 
     private void printRich(HprofSummary s, int topN, String sortBy, boolean c, long elapsedMs) {

--- a/argus-diagnostics/src/main/java/io/argus/diagnostics/heapgraph/ArrayObjectGraph.java
+++ b/argus-diagnostics/src/main/java/io/argus/diagnostics/heapgraph/ArrayObjectGraph.java
@@ -1,0 +1,58 @@
+package io.argus.diagnostics.heapgraph;
+
+/**
+ * Primitive-array backed {@link ObjectGraph} in Compressed-Sparse-Row form.
+ *
+ * <p>Memory footprint per object is roughly {@code 16 bytes}
+ * ({@code long shallow} + {@code int class} + the CSR offset slot) plus
+ * {@code 4 bytes} per reference edge — no per-object Java objects. A heap with
+ * 50M objects and 100M edges fits in well under 2 GB, which is the analyzer
+ * budget required by the W2 acceptance criteria.
+ */
+public final class ArrayObjectGraph implements ObjectGraph {
+
+    private final long[] shallow;     // shallow size by object index
+    private final int[] classOf;      // class index by object index
+    private final int[] edgeOffsets;  // CSR offsets, length objectCount+1
+    private final int[] edges;        // CSR edge targets
+    private final int[] gcRoots;      // object indices that are GC roots
+    private final String[] classNames;
+
+    public ArrayObjectGraph(long[] shallow, int[] classOf, int[] edgeOffsets,
+                            int[] edges, int[] gcRoots, String[] classNames) {
+        if (edgeOffsets.length != shallow.length + 1) {
+            throw new IllegalArgumentException(
+                    "edgeOffsets length must be objectCount+1");
+        }
+        this.shallow = shallow;
+        this.classOf = classOf;
+        this.edgeOffsets = edgeOffsets;
+        this.edges = edges;
+        this.gcRoots = gcRoots;
+        this.classNames = classNames;
+    }
+
+    @Override public int objectCount() { return shallow.length; }
+    @Override public long shallowSize(int index) { return shallow[index]; }
+    @Override public int classOf(int index) { return classOf[index]; }
+    @Override public int classCount() { return classNames.length; }
+    @Override public String className(int classIndex) {
+        return classIndex >= 0 && classIndex < classNames.length
+                ? classNames[classIndex] : "<unknown>";
+    }
+    @Override public int[] gcRoots() { return gcRoots; }
+    @Override public int[] edges() { return edges; }
+    @Override public int[] edgeOffsets() { return edgeOffsets; }
+
+    @Override public int outDegree(int index) {
+        return edgeOffsets[index + 1] - edgeOffsets[index];
+    }
+
+    @Override public int[] outRefs(int index) {
+        // Returns the shared backing array; callers honor the CSR slice contract.
+        return edges;
+    }
+
+    /** Total number of reference edges. */
+    public int edgeCount() { return edges.length; }
+}

--- a/argus-diagnostics/src/main/java/io/argus/diagnostics/heapgraph/DominatorTree.java
+++ b/argus-diagnostics/src/main/java/io/argus/diagnostics/heapgraph/DominatorTree.java
@@ -1,0 +1,265 @@
+package io.argus.diagnostics.heapgraph;
+
+import java.util.Arrays;
+
+/**
+ * Dominator tree + retained sizes for an {@link ObjectGraph}, computed with the
+ * Lengauer–Tarjan algorithm — the same flow-based approach Eclipse MAT uses.
+ *
+ * <p>A synthetic super-root node (index {@code N == objectCount()}) is added
+ * with an edge to every GC root, so the flow graph has a single entry.
+ * Lengauer–Tarjan then yields the immediate dominator {@code idom[v]} of every
+ * reachable node. The <em>retained size</em> of an object is the sum of shallow
+ * sizes of all nodes it dominates (the heap that would be freed if that object
+ * became unreachable). Retained sizes are accumulated by walking nodes in
+ * reverse DFS order and adding each node's running retained total into its
+ * immediate dominator — an O(N) post-order over the dominator tree.
+ *
+ * <p>All state is primitive {@code int[]}/{@code long[]} keyed by object index;
+ * no per-node Java objects are allocated, so a multi-GB heap stays within the
+ * analyzer's 2 GB budget. Objects not reachable from any GC root have
+ * {@code idom == NONE} and a retained size of 0.
+ */
+public final class DominatorTree {
+
+    /** Sentinel for "no node" / unreachable. */
+    public static final int NONE = -1;
+
+    private final int n;            // real object count
+    private final int root;         // synthetic super-root index == n
+    private final int[] idom;       // immediate dominator (object-index space), length n
+    private final long[] retained;  // retained size by object index, length n
+    private final int[] subtree;    // dominator-subtree size by object index, length n
+    private final int reachableCount;
+
+    private DominatorTree(int n, int[] idom, long[] retained, int[] subtree,
+                          int reachableCount) {
+        this.n = n;
+        this.root = n;
+        this.idom = idom;
+        this.retained = retained;
+        this.subtree = subtree;
+        this.reachableCount = reachableCount;
+    }
+
+    /**
+     * Immediate dominator of object {@code v} in object-index space, or
+     * {@link #NONE} if {@code v} is unreachable from any GC root. A value equal
+     * to {@code objectCount()} means "dominated directly by the synthetic
+     * super-root" — i.e. a top-level retention point.
+     */
+    public int idom(int v) { return idom[v]; }
+
+    /** Retained size (bytes) of object {@code v}. */
+    public long retainedSize(int v) { return retained[v]; }
+
+    /** Number of objects in {@code v}'s dominator subtree (including {@code v}). */
+    public int subtreeSize(int v) { return subtree[v]; }
+
+    /** Number of objects reachable from any GC root. */
+    public int reachableCount() { return reachableCount; }
+
+    /** The synthetic super-root index ({@code == objectCount()}). */
+    public int superRoot() { return root; }
+
+    /** True if {@code v} is directly dominated by the synthetic super-root. */
+    public boolean isTopLevel(int v) { return idom[v] == root; }
+
+    /**
+     * Builds the dominator tree and retained sizes for the given graph.
+     */
+    public static DominatorTree compute(ObjectGraph graph) {
+        int n = graph.objectCount();
+        int root = n;
+        int size = n + 1;            // include synthetic super-root at index n
+
+        int[] edges = graph.edges();
+        int[] edgeOff = graph.edgeOffsets();
+        int[] gcRoots = graph.gcRoots();
+
+        // --- Build predecessor adjacency (flow graph incl. super-root) as CSR ---
+        // Edge count = real edges + one edge super-root -> each GC root.
+        int[] predOff = new int[size + 1];
+        for (int v = 0; v < n; v++) {
+            int from = edgeOff[v], to = edgeOff[v + 1];
+            for (int e = from; e < to; e++) {
+                int t = edges[e];
+                if (t >= 0) predOff[t + 1]++;
+            }
+        }
+        for (int r : gcRoots) predOff[r + 1]++;        // super-root -> r
+        for (int i = 0; i < size; i++) predOff[i + 1] += predOff[i];
+        int[] predFrom = new int[predOff[size]];
+        int[] cursor = Arrays.copyOf(predOff, size);
+        for (int v = 0; v < n; v++) {
+            int from = edgeOff[v], to = edgeOff[v + 1];
+            for (int e = from; e < to; e++) {
+                int t = edges[e];
+                if (t >= 0) predFrom[cursor[t]++] = v;
+            }
+        }
+        for (int r : gcRoots) predFrom[cursor[r]++] = root;
+
+        // --- Lengauer-Tarjan working arrays over [0, size) ---
+        int[] dfnum = new int[size];      // DFS number, 0 = unvisited
+        int[] vertex = new int[size + 1]; // vertex[i] = node with dfnum i (1-based)
+        int[] parent = new int[size];     // DFS-tree parent
+        int[] semi = new int[size];       // semidominator dfnum
+        int[] ancestor = new int[size];   // forest ancestor (path compression)
+        int[] label = new int[size];      // label for EVAL
+        int[] dom = new int[size];        // immediate dominator
+        Arrays.fill(ancestor, NONE);
+        Arrays.fill(dom, NONE);
+        int[] bucketHead = new int[size];
+        int[] bucketNext = new int[size];
+        Arrays.fill(bucketHead, NONE);
+        Arrays.fill(bucketNext, NONE);
+
+        // --- Iterative DFS from super-root assigns dfnum/parent/semi/label ---
+        int dfCounter = 0;
+        int[] stackNode = new int[size];
+        int[] stackCursor = new int[size];
+        int sp = 0;
+        stackNode[sp] = root;
+        stackCursor[sp] = -1;
+        sp++;
+        while (sp > 0) {
+            int top = sp - 1;
+            int v = stackNode[top];
+            if (stackCursor[top] == -1) {
+                dfCounter++;
+                dfnum[v] = dfCounter;
+                vertex[dfCounter] = v;
+                semi[v] = dfCounter;
+                label[v] = v;
+                stackCursor[top] = succStart(v, root, edgeOff);
+            }
+            int cur = stackCursor[top];
+            int end = succEnd(v, root, gcRoots, edgeOff);
+            boolean descended = false;
+            while (cur < end) {
+                int w = succAt(v, root, gcRoots, edges, cur);
+                cur++;
+                if (w < 0) continue;
+                if (dfnum[w] == 0) {
+                    parent[w] = v;
+                    stackCursor[top] = cur;
+                    stackNode[sp] = w;
+                    stackCursor[sp] = -1;
+                    sp++;
+                    descended = true;
+                    break;
+                }
+            }
+            if (!descended) {
+                stackCursor[top] = cur;
+                if (cur >= end) sp--;
+            }
+        }
+        int reachable = dfCounter; // including super-root
+
+        int[] compressPath = new int[64];
+
+        // --- Steps 2 & 3 ---
+        for (int i = dfCounter; i >= 2; i--) {
+            int w = vertex[i];
+            for (int p = predOff[w]; p < predOff[w + 1]; p++) {
+                int vPred = predFrom[p];
+                if (dfnum[vPred] == 0) continue; // predecessor unreachable
+                int u = eval(vPred, ancestor, label, semi, compressPath);
+                if (semi[u] < semi[w]) semi[w] = semi[u];
+            }
+            int s = vertex[semi[w]];
+            bucketNext[w] = bucketHead[s];
+            bucketHead[s] = w;
+            ancestor[w] = parent[w];     // LINK(parent[w], w)
+
+            int pw = parent[w];
+            for (int v = bucketHead[pw]; v != NONE; ) {
+                int next = bucketNext[v];
+                int u = eval(v, ancestor, label, semi, compressPath);
+                dom[v] = (semi[u] < semi[v]) ? u : pw;
+                v = next;
+            }
+            bucketHead[pw] = NONE;
+        }
+
+        // --- Step 4: finalize idom in DFS order ---
+        for (int i = 2; i <= dfCounter; i++) {
+            int w = vertex[i];
+            if (dom[w] != vertex[semi[w]]) dom[w] = dom[dom[w]];
+        }
+        if (dfCounter >= 1) dom[root] = NONE;
+
+        // --- Project into object-index space, capture DFS order of objects ---
+        int[] idom = new int[n];
+        Arrays.fill(idom, NONE);
+        int[] order = new int[Math.max(0, reachable - 1)];
+        int oi = 0;
+        for (int i = 2; i <= dfCounter; i++) {
+            int w = vertex[i];
+            if (w == root) continue;
+            order[oi++] = w;
+            idom[w] = dom[w]; // may equal root (== n) for top-level objects
+        }
+
+        // --- Retained sizes + subtree sizes: reverse-DFS post-order accumulation ---
+        long[] retained = new long[n];
+        int[] subtree = new int[n];
+        for (int v = 0; v < n; v++) {
+            if (idom[v] != NONE) {
+                retained[v] = graph.shallowSize(v);
+                subtree[v] = 1;
+            }
+        }
+        for (int k = oi - 1; k >= 0; k--) {
+            int v = order[k];
+            int d = idom[v];
+            if (d != NONE && d != root) {
+                retained[d] += retained[v];
+                subtree[d] += subtree[v];
+            }
+        }
+
+        return new DominatorTree(n, idom, retained, subtree, oi);
+    }
+
+    // ----- successor iteration helpers (super-root expands to gcRoots) -----
+
+    private static int succStart(int v, int root, int[] edgeOff) {
+        return v == root ? 0 : edgeOff[v];
+    }
+
+    private static int succEnd(int v, int root, int[] gcRoots, int[] edgeOff) {
+        return v == root ? gcRoots.length : edgeOff[v + 1];
+    }
+
+    private static int succAt(int v, int root, int[] gcRoots, int[] edges, int cursor) {
+        return v == root ? gcRoots[cursor] : edges[cursor];
+    }
+
+    private static int eval(int v, int[] ancestor, int[] label, int[] semi, int[] path) {
+        if (ancestor[v] == NONE) return label[v];
+        compress(v, ancestor, label, semi, path);
+        return label[v];
+    }
+
+    /** Iterative path compression (avoids deep recursion on long ancestor chains). */
+    private static void compress(int v, int[] ancestor, int[] label, int[] semi, int[] path) {
+        int p = v;
+        int top = 0;
+        while (ancestor[ancestor[p]] != NONE) {
+            if (top == path.length) path = Arrays.copyOf(path, path.length * 2);
+            path[top++] = p;
+            p = ancestor[p];
+        }
+        for (int i = top - 1; i >= 0; i--) {
+            int node = path[i];
+            int anc = ancestor[node];
+            if (semi[label[anc]] < semi[label[node]]) label[node] = label[anc];
+            ancestor[node] = ancestor[anc];
+        }
+        int anc = ancestor[v];
+        if (anc != NONE && semi[label[anc]] < semi[label[v]]) label[v] = label[anc];
+    }
+}

--- a/argus-diagnostics/src/main/java/io/argus/diagnostics/heapgraph/HeapGraphAnalysis.java
+++ b/argus-diagnostics/src/main/java/io/argus/diagnostics/heapgraph/HeapGraphAnalysis.java
@@ -1,0 +1,146 @@
+package io.argus.diagnostics.heapgraph;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.List;
+
+/**
+ * MAT-class triage over an {@link ObjectGraph}: dominator tree, retained sizes
+ * (per object and aggregated per class), an automated leak-suspects report, and
+ * shortest path-to-GC-root resolution.
+ *
+ * <p>This is the framework-agnostic analysis engine that backs
+ * {@code argus heapanalyze --leak-suspects / --dominators / --retained /
+ * --path-to-root}. It operates purely on the id-indexed {@link ObjectGraph}, so
+ * it is reusable for any graph source and deterministically unit-testable.
+ */
+public final class HeapGraphAnalysis {
+
+    private final ObjectGraph graph;
+    private final DominatorTree dominators;
+    private final long totalReachableBytes;
+
+    private HeapGraphAnalysis(ObjectGraph graph, DominatorTree dominators,
+                              long totalReachableBytes) {
+        this.graph = graph;
+        this.dominators = dominators;
+        this.totalReachableBytes = totalReachableBytes;
+    }
+
+    public static HeapGraphAnalysis analyze(ObjectGraph graph) {
+        DominatorTree dom = DominatorTree.compute(graph);
+        long total = 0;
+        int n = graph.objectCount();
+        for (int v = 0; v < n; v++) {
+            if (dom.idom(v) != DominatorTree.NONE) total += graph.shallowSize(v);
+        }
+        return new HeapGraphAnalysis(graph, dom, total);
+    }
+
+    public ObjectGraph graph() { return graph; }
+    public DominatorTree dominators() { return dominators; }
+    public long totalReachableBytes() { return totalReachableBytes; }
+
+    /**
+     * Top {@code n} objects by retained size, descending. Each entry is the
+     * object index; use {@link #dominators()} for the retained value and
+     * {@link ObjectGraph#className(int)} for the label.
+     */
+    public int[] topDominators(int n) {
+        int count = graph.objectCount();
+        // Collect reachable object indices, sort by retained desc, take n.
+        Integer[] idx = new Integer[count];
+        int m = 0;
+        for (int v = 0; v < count; v++) {
+            if (dominators.idom(v) != DominatorTree.NONE) idx[m++] = v;
+        }
+        Integer[] reach = Arrays.copyOf(idx, m);
+        Arrays.sort(reach, Comparator.comparingLong(
+                (Integer v) -> dominators.retainedSize(v)).reversed());
+        int take = Math.min(n, reach.length);
+        int[] out = new int[take];
+        for (int i = 0; i < take; i++) out[i] = reach[i];
+        return out;
+    }
+
+    /**
+     * Aggregated retained size per class, summing the retained size of each
+     * object whose immediate dominator is NOT of the same class chain (to avoid
+     * double counting we sum every object's retained size grouped by its class —
+     * matching MAT's "retained set by class" where each object contributes once).
+     *
+     * <p>Returns a list of {@code [classIndex, retainedBytes, dominatedCount]}
+     * sorted by retained bytes descending, truncated to {@code topN}.
+     */
+    public List<long[]> retainedByClass(int topN) {
+        int classes = graph.classCount();
+        long[] retainedSum = new long[classes];
+        long[] objCount = new long[classes];
+        int n = graph.objectCount();
+        for (int v = 0; v < n; v++) {
+            if (dominators.idom(v) == DominatorTree.NONE) continue;
+            int c = graph.classOf(v);
+            retainedSum[c] += dominators.retainedSize(v);
+            objCount[c]++;
+        }
+        List<long[]> rows = new ArrayList<>();
+        for (int c = 0; c < classes; c++) {
+            if (retainedSum[c] > 0) rows.add(new long[]{c, retainedSum[c], objCount[c]});
+        }
+        rows.sort((a, b) -> Long.compare(b[1], a[1]));
+        if (rows.size() > topN) return new ArrayList<>(rows.subList(0, topN));
+        return rows;
+    }
+
+    /**
+     * Retained size aggregated for all instances of a named class.
+     * Returns {@code [retainedBytes, instanceCount]}.
+     */
+    public long[] retainedForClass(String className) {
+        long retained = 0;
+        long count = 0;
+        int n = graph.objectCount();
+        for (int v = 0; v < n; v++) {
+            if (dominators.idom(v) == DominatorTree.NONE) continue;
+            if (graph.className(graph.classOf(v)).equals(className)) {
+                retained += dominators.retainedSize(v);
+                count++;
+            }
+        }
+        return new long[]{retained, count};
+    }
+
+    /**
+     * Automated leak-suspects report. A suspect is a single dominator whose
+     * retained share of the reachable heap exceeds {@code thresholdPercent}
+     * (heuristic: "one object retaining a disproportionate share of heap").
+     * Always returns the top retained-size accumulation points, flagging those
+     * over threshold first.
+     *
+     * @param maxSuspects     maximum suspects to return
+     * @param thresholdPercent minimum heap share to count as a suspect (e.g. 10.0)
+     */
+    public List<LeakSuspect> leakSuspects(int maxSuspects, double thresholdPercent) {
+        int[] top = topDominators(Math.max(maxSuspects, 1));
+        long total = totalReachableBytes > 0 ? totalReachableBytes : 1;
+        List<LeakSuspect> suspects = new ArrayList<>();
+        for (int v : top) {
+            long retained = dominators.retainedSize(v);
+            double pct = retained * 100.0 / total;
+            if (pct < thresholdPercent && !suspects.isEmpty()) break;
+            suspects.add(new LeakSuspect(v, graph.className(graph.classOf(v)),
+                    retained, pct, dominators.subtreeSize(v)));
+            if (suspects.size() >= maxSuspects) break;
+        }
+        return suspects;
+    }
+
+    /**
+     * Shortest reference path from the largest reachable instance of
+     * {@code className} to a GC root, returned root-first as object indices.
+     */
+    public int[] pathToRootForClass(String className) {
+        return PathToRoot.compute(graph).shortestPathForClass(className);
+    }
+}

--- a/argus-diagnostics/src/main/java/io/argus/diagnostics/heapgraph/HprofGraphBuilder.java
+++ b/argus-diagnostics/src/main/java/io/argus/diagnostics/heapgraph/HprofGraphBuilder.java
@@ -1,0 +1,642 @@
+package io.argus.diagnostics.heapgraph;
+
+import java.io.BufferedInputStream;
+import java.io.DataInputStream;
+import java.io.EOFException;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Builds a full {@link ObjectGraph} (reference edges + GC roots + retained-size
+ * inputs) from an HPROF binary dump via streaming passes.
+ *
+ * <p><b>Memory discipline.</b> HPROF files can be tens of GB. This builder never
+ * materializes heap objects as Java objects. It:
+ * <ul>
+ *   <li>Assigns every heap object a dense {@code int} index keyed by its HPROF
+ *       id, using a single open-addressing primitive long→int map.</li>
+ *   <li>Stores per-object shallow size ({@code long[]}) and class index
+ *       ({@code int[]}) in flat arrays.</li>
+ *   <li>Stores reference edges in CSR form ({@code int[]} targets +
+ *       {@code int[]} offsets) — 4 bytes per edge.</li>
+ * </ul>
+ * Three streaming passes are used: (1) class structure + object id indexing +
+ * GC roots, (2) per-object out-degree counting, (3) edge writing. The working
+ * set is bounded by the primitive arrays, so a 4 GB dump analyzes in well under
+ * 2 GB of analyzer heap.
+ *
+ * <p>This reuses the record layout already validated by the CLI's streaming
+ * histogram parser, but additionally decodes object references.
+ */
+public final class HprofGraphBuilder {
+
+    // Top-level record tags
+    private static final int TAG_STRING        = 0x01;
+    private static final int TAG_LOAD_CLASS    = 0x02;
+    private static final int TAG_HEAP_DUMP     = 0x0C;
+    private static final int TAG_HEAP_DUMP_SEG = 0x1C;
+    private static final int TAG_HEAP_DUMP_END = 0x2C;
+
+    // Heap dump sub-record tags
+    private static final int SUB_GC_ROOT_UNKNOWN      = 0xFF;
+    private static final int SUB_GC_ROOT_JNI_GLOBAL   = 0x01;
+    private static final int SUB_GC_ROOT_JNI_LOCAL    = 0x02;
+    private static final int SUB_GC_ROOT_JAVA_FRAME   = 0x03;
+    private static final int SUB_GC_ROOT_NATIVE_STACK = 0x04;
+    private static final int SUB_GC_ROOT_STICKY_CLASS = 0x05;
+    private static final int SUB_GC_ROOT_THREAD_BLOCK = 0x06;
+    private static final int SUB_GC_ROOT_MONITOR_USED = 0x07;
+    private static final int SUB_GC_ROOT_THREAD_OBJ   = 0x08;
+    private static final int SUB_GC_CLASS_DUMP        = 0x20;
+    private static final int SUB_GC_INSTANCE_DUMP     = 0x21;
+    private static final int SUB_GC_OBJ_ARRAY_DUMP    = 0x22;
+    private static final int SUB_GC_PRIM_ARRAY_DUMP   = 0x23;
+
+    private HprofGraphBuilder() {}
+
+    /** Parses {@code file} and builds the full object graph. */
+    public static ArrayObjectGraph build(File file) throws IOException {
+        int idSize;
+        // Header read once to learn idSize; reused per pass.
+        try (DataInputStream probe = open(file)) {
+            String header = readCString(probe);
+            if (!header.startsWith("JAVA PROFILE")) {
+                throw new IOException("Not a valid HPROF file: " + header);
+            }
+            idSize = probe.readInt();
+        }
+
+        // ---- Pass A: strings, class load, class dumps, object indexing, roots ----
+        PassA a = new PassA(idSize);
+        try (DataInputStream in = open(file)) {
+            skipHeader(in, idSize);
+            a.run(in);
+        }
+
+        int objCount = a.objCount;
+        long[] shallow = a.shallow;          // by object index
+        int[] classIdx = a.classIdx;         // by object index
+        LongIntMap idToIndex = a.idToIndex;  // hprof id -> dense index
+
+        // ---- Pass B: count out-degree per object ----
+        int[] outDeg = new int[objCount];
+        try (DataInputStream in = open(file)) {
+            skipHeader(in, idSize);
+            new EdgePass(idSize, a, idToIndex, outDeg, null, null).run(in);
+        }
+        // CSR offsets
+        int[] edgeOff = new int[objCount + 1];
+        for (int i = 0; i < objCount; i++) edgeOff[i + 1] = edgeOff[i] + outDeg[i];
+        int[] edges = new int[edgeOff[objCount]];
+        int[] writeCursor = new int[objCount];
+        System.arraycopy(edgeOff, 0, writeCursor, 0, objCount);
+
+        // ---- Pass C: write edges ----
+        try (DataInputStream in = open(file)) {
+            skipHeader(in, idSize);
+            new EdgePass(idSize, a, idToIndex, null, edges, writeCursor).run(in);
+        }
+
+        // GC roots → dense indices (dedup, drop unknown ids)
+        int[] rootsRaw = new int[a.roots.size()];
+        int rc = 0;
+        for (long rootId : a.roots) {
+            int idx = idToIndex.get(rootId);
+            if (idx >= 0) rootsRaw[rc++] = idx;
+        }
+        int[] roots = new int[rc];
+        System.arraycopy(rootsRaw, 0, roots, 0, rc);
+
+        String[] classNames = a.classNamesByIndex();
+
+        return new ArrayObjectGraph(
+                java.util.Arrays.copyOf(shallow, objCount),
+                java.util.Arrays.copyOf(classIdx, objCount),
+                edgeOff, edges, roots, classNames);
+    }
+
+    private static DataInputStream open(File file) throws IOException {
+        InputStream fis = new FileInputStream(file);
+        return new DataInputStream(new BufferedInputStream(fis, 1 << 16));
+    }
+
+    private static void skipHeader(DataInputStream in, int idSize) throws IOException {
+        readCString(in);   // header string
+        in.readInt();      // idSize
+        in.readLong();     // timestamp
+    }
+
+    // =====================================================================
+    // Pass A — class structure, object indexing, GC roots
+    // =====================================================================
+    private static final class PassA {
+        final int idSize;
+
+        // string table + class metadata
+        final Map<Long, String> strings = new HashMap<>();
+        final Map<Long, Long> classIdToNameId = new HashMap<>();
+        final Map<Long, ClassDef> classDefs = new HashMap<>();
+
+        // dense object indexing
+        final LongIntMap idToIndex = new LongIntMap(1 << 16);
+        long[] shallow = new long[1 << 16];
+        int[] classIdx = new int[1 << 16];
+        int objCount = 0;
+
+        // class index space (one entry per distinct class obj id seen at LOAD_CLASS)
+        final Map<Long, Integer> classObjIdToClassIdx = new HashMap<>();
+        final List<String> classNameList = new ArrayList<>();
+
+        final List<Long> roots = new ArrayList<>();
+
+        PassA(int idSize) { this.idSize = idSize; }
+
+        ClassDef classFor(long classObjId) { return classDefs.get(classObjId); }
+
+        int classIndexFor(long classObjId) {
+            Integer ci = classObjIdToClassIdx.get(classObjId);
+            if (ci != null) return ci;
+            int idx = classNameList.size();
+            classNameList.add(resolveClassName(classObjId));
+            classObjIdToClassIdx.put(classObjId, idx);
+            return idx;
+        }
+
+        String resolveClassName(long classObjId) {
+            Long nameId = classIdToNameId.get(classObjId);
+            if (nameId == null) return "unknown_class";
+            String name = strings.get(nameId);
+            if (name == null) return "unknown_name";
+            return name.replace('/', '.');
+        }
+
+        String[] classNamesByIndex() {
+            return classNameList.toArray(new String[0]);
+        }
+
+        int addObject(long objId, int classIndex, long shallowBytes) {
+            int idx = objCount++;
+            if (idx >= shallow.length) {
+                int cap = shallow.length + (shallow.length >> 1);
+                shallow = java.util.Arrays.copyOf(shallow, cap);
+                classIdx = java.util.Arrays.copyOf(classIdx, cap);
+            }
+            shallow[idx] = shallowBytes;
+            classIdx[idx] = classIndex;
+            idToIndex.put(objId, idx);
+            return idx;
+        }
+
+        void run(DataInputStream in) throws IOException {
+            while (true) {
+                int tag;
+                try { tag = in.readUnsignedByte(); }
+                catch (EOFException e) { break; }
+                in.readInt();                            // ts delta
+                long length = Integer.toUnsignedLong(in.readInt());
+                switch (tag) {
+                    case TAG_STRING: {
+                        long id = readId(in, idSize);
+                        int len = (int) (length - idSize);
+                        byte[] buf = new byte[len];
+                        in.readFully(buf);
+                        strings.put(id, new String(buf, StandardCharsets.UTF_8));
+                        break;
+                    }
+                    case TAG_LOAD_CLASS: {
+                        in.readInt();                     // serial
+                        long classObjId = readId(in, idSize);
+                        in.readInt();                     // stack trace serial
+                        long nameId = readId(in, idSize);
+                        classIdToNameId.put(classObjId, nameId);
+                        break;
+                    }
+                    case TAG_HEAP_DUMP:
+                    case TAG_HEAP_DUMP_SEG:
+                        runHeapDump(in, length);
+                        break;
+                    case TAG_HEAP_DUMP_END:
+                        break;
+                    default:
+                        if (length > 0) skipBytes(in, length);
+                        break;
+                }
+            }
+        }
+
+        private void runHeapDump(DataInputStream in, long length) throws IOException {
+            long remaining = length;
+            while (remaining > 0) {
+                int sub = in.readUnsignedByte();
+                remaining--;
+                switch (sub) {
+                    case SUB_GC_CLASS_DUMP: {
+                        long classObjId = readId(in, idSize);
+                        in.readInt();                    // stack trace serial
+                        readId(in, idSize);              // super
+                        readId(in, idSize);              // loader
+                        readId(in, idSize);              // signers
+                        readId(in, idSize);              // protection domain
+                        readId(in, idSize);              // reserved1
+                        readId(in, idSize);              // reserved2
+                        in.readInt();                    // instance size (unused here)
+                        remaining -= idSize * 7L + 4 + 4;
+
+                        int cpSize = in.readUnsignedShort();
+                        remaining -= 2;
+                        for (int i = 0; i < cpSize; i++) {
+                            in.readUnsignedShort();
+                            int t = in.readUnsignedByte();
+                            remaining -= 3;
+                            int sz = typeSize(t, idSize);
+                            skipBytes(in, sz);
+                            remaining -= sz;
+                        }
+                        int sfCount = in.readUnsignedShort();
+                        remaining -= 2;
+                        for (int i = 0; i < sfCount; i++) {
+                            readId(in, idSize);          // name id
+                            int t = in.readUnsignedByte();
+                            remaining -= idSize + 1;
+                            int sz = typeSize(t, idSize);
+                            skipBytes(in, sz);
+                            remaining -= sz;
+                        }
+                        int ifCount = in.readUnsignedShort();
+                        remaining -= 2;
+                        byte[] fieldTypes = new byte[ifCount];
+                        for (int i = 0; i < ifCount; i++) {
+                            readId(in, idSize);          // name id
+                            int t = in.readUnsignedByte();
+                            remaining -= idSize + 1;
+                            fieldTypes[i] = (byte) t;
+                        }
+                        classDefs.put(classObjId, new ClassDef(fieldTypes));
+                        classIndexFor(classObjId);       // ensure class index exists
+                        break;
+                    }
+                    case SUB_GC_INSTANCE_DUMP: {
+                        long objId = readId(in, idSize);
+                        in.readInt();                    // stack trace serial
+                        long classObjId = readId(in, idSize);
+                        int dataSize = in.readInt();
+                        skipBytes(in, dataSize);
+                        remaining -= idSize * 2L + 4 + 4 + dataSize;
+                        long shallowSize = (long) idSize + 4 + idSize + 4 + dataSize;
+                        addObject(objId, classIndexFor(classObjId), shallowSize);
+                        break;
+                    }
+                    case SUB_GC_OBJ_ARRAY_DUMP: {
+                        long objId = readId(in, idSize);
+                        in.readInt();                    // stack trace serial
+                        int num = in.readInt();
+                        if (num < 0) throw new IOException("corrupt HPROF: negative object-array length " + num);
+                        long arrClassId = readId(in, idSize);
+                        long dataSize = (long) num * idSize;
+                        skipBytes(in, dataSize);
+                        remaining -= idSize * 2L + 4 + 4 + dataSize;
+                        long shallowSize = (long) idSize + 4 + 4 + idSize + dataSize;
+                        addObject(objId, classIndexForArray(arrClassId), shallowSize);
+                        break;
+                    }
+                    case SUB_GC_PRIM_ARRAY_DUMP: {
+                        long objId = readId(in, idSize);
+                        in.readInt();                    // stack trace serial
+                        int num = in.readInt();
+                        if (num < 0) throw new IOException("corrupt HPROF: negative primitive-array length " + num);
+                        int elemType = in.readUnsignedByte();
+                        int elemSize = typeSize(elemType, idSize);
+                        long dataSize = (long) num * elemSize;
+                        skipBytes(in, dataSize);
+                        remaining -= idSize + 4L + 4 + 1 + dataSize;
+                        long shallowSize = (long) idSize + 4 + 4 + 1 + dataSize;
+                        addObject(objId, primClassIndex(elemType), shallowSize);
+                        break;
+                    }
+                    case SUB_GC_ROOT_JNI_GLOBAL: {
+                        long id = readId(in, idSize);
+                        readId(in, idSize);
+                        remaining -= idSize * 2L;
+                        roots.add(id);
+                        break;
+                    }
+                    case SUB_GC_ROOT_JNI_LOCAL:
+                    case SUB_GC_ROOT_JAVA_FRAME:
+                    case SUB_GC_ROOT_THREAD_BLOCK: {
+                        long id = readId(in, idSize);
+                        in.readInt();
+                        in.readInt();
+                        remaining -= idSize + 8;
+                        roots.add(id);
+                        break;
+                    }
+                    case SUB_GC_ROOT_NATIVE_STACK:
+                    case SUB_GC_ROOT_THREAD_OBJ: {
+                        long id = readId(in, idSize);
+                        in.readInt();
+                        in.readInt();
+                        remaining -= idSize + 8;
+                        roots.add(id);
+                        break;
+                    }
+                    case SUB_GC_ROOT_UNKNOWN:
+                    case SUB_GC_ROOT_STICKY_CLASS:
+                    case SUB_GC_ROOT_MONITOR_USED: {
+                        long id = readId(in, idSize);
+                        remaining -= idSize;
+                        roots.add(id);
+                        break;
+                    }
+                    default: {
+                        if (remaining > 0) { skipBytes(in, remaining); remaining = 0; }
+                        break;
+                    }
+                }
+            }
+        }
+
+        // class index for an object-array's component class; name decorated with []
+        private final Map<Long, Integer> arrClassIdx = new HashMap<>();
+        int classIndexForArray(long arrClassId) {
+            Integer ci = arrClassIdx.get(arrClassId);
+            if (ci != null) return ci;
+            int idx = classNameList.size();
+            classNameList.add(resolveClassName(arrClassId) + "[]");
+            arrClassIdx.put(arrClassId, idx);
+            return idx;
+        }
+
+        private int[] primClassIndexCache = new int[12];
+        private boolean primInit = false;
+        int primClassIndex(int elemType) {
+            if (!primInit) { java.util.Arrays.fill(primClassIndexCache, -1); primInit = true; }
+            if (elemType >= 0 && elemType < primClassIndexCache.length
+                    && primClassIndexCache[elemType] >= 0) {
+                return primClassIndexCache[elemType];
+            }
+            int idx = classNameList.size();
+            classNameList.add(primArrayName(elemType));
+            if (elemType >= 0 && elemType < primClassIndexCache.length) {
+                primClassIndexCache[elemType] = idx;
+            }
+            return idx;
+        }
+    }
+
+    // =====================================================================
+    // Edge pass — counts (countOut!=null) or writes (edges!=null) references
+    // =====================================================================
+    private static final class EdgePass {
+        final int idSize;
+        final PassA a;
+        final LongIntMap idToIndex;
+        final int[] countOut;   // out-degree accumulator (count mode) or null
+        final int[] edges;      // CSR edge array (write mode) or null
+        final int[] writeCursor;
+
+        EdgePass(int idSize, PassA a, LongIntMap idToIndex,
+                 int[] countOut, int[] edges, int[] writeCursor) {
+            this.idSize = idSize;
+            this.a = a;
+            this.idToIndex = idToIndex;
+            this.countOut = countOut;
+            this.edges = edges;
+            this.writeCursor = writeCursor;
+        }
+
+        void emit(int fromIdx, long targetId) {
+            if (targetId == 0) return;
+            int t = idToIndex.get(targetId);
+            if (t < 0) return; // reference to an object not in the dump (e.g. class obj)
+            if (countOut != null) {
+                countOut[fromIdx]++;
+            } else {
+                edges[writeCursor[fromIdx]++] = t;
+            }
+        }
+
+        void run(DataInputStream in) throws IOException {
+            while (true) {
+                int tag;
+                try { tag = in.readUnsignedByte(); }
+                catch (EOFException e) { break; }
+                in.readInt();
+                long length = Integer.toUnsignedLong(in.readInt());
+                switch (tag) {
+                    case TAG_STRING:
+                    case TAG_LOAD_CLASS:
+                        if (length > 0) skipBytes(in, length);
+                        break;
+                    case TAG_HEAP_DUMP:
+                    case TAG_HEAP_DUMP_SEG:
+                        runHeapDump(in, length);
+                        break;
+                    case TAG_HEAP_DUMP_END:
+                        break;
+                    default:
+                        if (length > 0) skipBytes(in, length);
+                        break;
+                }
+            }
+        }
+
+        private void runHeapDump(DataInputStream in, long length) throws IOException {
+            long remaining = length;
+            while (remaining > 0) {
+                int sub = in.readUnsignedByte();
+                remaining--;
+                switch (sub) {
+                    case SUB_GC_CLASS_DUMP: {
+                        readId(in, idSize);              // class obj id
+                        in.readInt();                    // stack trace serial
+                        readId(in, idSize);              // super
+                        readId(in, idSize);              // loader
+                        readId(in, idSize);              // signers
+                        readId(in, idSize);              // protection domain
+                        readId(in, idSize);              // reserved1
+                        readId(in, idSize);              // reserved2
+                        in.readInt();                    // instance size
+                        remaining -= idSize * 7L + 4 + 4;
+                        int cpSize = in.readUnsignedShort();
+                        remaining -= 2;
+                        for (int i = 0; i < cpSize; i++) {
+                            in.readUnsignedShort();
+                            int t = in.readUnsignedByte();
+                            remaining -= 3;
+                            int sz = typeSize(t, idSize);
+                            skipBytes(in, sz);
+                            remaining -= sz;
+                        }
+                        int sfCount = in.readUnsignedShort();
+                        remaining -= 2;
+                        for (int i = 0; i < sfCount; i++) {
+                            readId(in, idSize);
+                            int t = in.readUnsignedByte();
+                            remaining -= idSize + 1;
+                            int sz = typeSize(t, idSize);
+                            skipBytes(in, sz);
+                            remaining -= sz;
+                        }
+                        int ifCount = in.readUnsignedShort();
+                        remaining -= 2;
+                        for (int i = 0; i < ifCount; i++) {
+                            readId(in, idSize);
+                            in.readUnsignedByte();
+                            remaining -= idSize + 1;
+                        }
+                        break;
+                    }
+                    case SUB_GC_INSTANCE_DUMP: {
+                        long objId = readId(in, idSize);
+                        in.readInt();
+                        long classObjId = readId(in, idSize);
+                        int dataSize = in.readInt();
+                        remaining -= idSize * 2L + 4 + 4 + dataSize;
+                        int fromIdx = idToIndex.get(objId);
+                        ClassDef def = a.classFor(classObjId);
+                        if (fromIdx >= 0 && def != null) {
+                            readInstanceRefs(in, fromIdx, def, dataSize);
+                        } else {
+                            skipBytes(in, dataSize);
+                        }
+                        break;
+                    }
+                    case SUB_GC_OBJ_ARRAY_DUMP: {
+                        long objId = readId(in, idSize);
+                        in.readInt();
+                        int num = in.readInt();
+                        if (num < 0) throw new IOException("corrupt HPROF: negative object-array length " + num);
+                        readId(in, idSize);              // array class id
+                        remaining -= idSize * 2L + 4 + 4 + (long) num * idSize;
+                        int fromIdx = idToIndex.get(objId);
+                        for (int i = 0; i < num; i++) {
+                            long elem = readId(in, idSize);
+                            if (fromIdx >= 0) emit(fromIdx, elem);
+                        }
+                        break;
+                    }
+                    case SUB_GC_PRIM_ARRAY_DUMP: {
+                        readId(in, idSize);
+                        in.readInt();
+                        int num = in.readInt();
+                        if (num < 0) throw new IOException("corrupt HPROF: negative primitive-array length " + num);
+                        int elemType = in.readUnsignedByte();
+                        int elemSize = typeSize(elemType, idSize);
+                        long dataSize = (long) num * elemSize;
+                        skipBytes(in, dataSize);
+                        remaining -= idSize + 4L + 4 + 1 + dataSize;
+                        break;
+                    }
+                    case SUB_GC_ROOT_JNI_GLOBAL:
+                        skipBytes(in, idSize * 2L); remaining -= idSize * 2L; break;
+                    case SUB_GC_ROOT_JNI_LOCAL:
+                    case SUB_GC_ROOT_JAVA_FRAME:
+                    case SUB_GC_ROOT_THREAD_BLOCK:
+                    case SUB_GC_ROOT_NATIVE_STACK:
+                    case SUB_GC_ROOT_THREAD_OBJ:
+                        skipBytes(in, idSize + 8L); remaining -= idSize + 8L; break;
+                    case SUB_GC_ROOT_UNKNOWN:
+                    case SUB_GC_ROOT_STICKY_CLASS:
+                    case SUB_GC_ROOT_MONITOR_USED:
+                        skipBytes(in, idSize); remaining -= idSize; break;
+                    default:
+                        if (remaining > 0) { skipBytes(in, remaining); remaining = 0; }
+                        break;
+                }
+            }
+        }
+
+        private void readInstanceRefs(DataInputStream in, int fromIdx, ClassDef def,
+                                      int dataSize) throws IOException {
+            int consumed = 0;
+            byte[] types = def.fieldTypes;
+            for (byte tb : types) {
+                int t = tb & 0xFF;
+                int sz = typeSize(t, idSize);
+                // Never read past the record's declared dataSize. A mismatched/duplicate
+                // LOAD_CLASS id (or malformed dump) could make the resolved ClassDef's
+                // declared fields total MORE than dataSize; reading them unconditionally
+                // would overrun this INSTANCE_DUMP into the next record and silently
+                // corrupt every subsequent record. Stop at the boundary instead.
+                if (consumed + sz > dataSize) {
+                    break;
+                }
+                if (t == 2) { // object reference
+                    long target = readId(in, idSize);
+                    emit(fromIdx, target);
+                } else {
+                    skipBytes(in, sz);
+                }
+                consumed += sz;
+            }
+            // A subclass instance carries superclass fields too; the parser only
+            // knows the most-derived class's fields. Skip any trailing bytes so
+            // the stream stays aligned (super-field refs are not followed here).
+            if (consumed < dataSize) skipBytes(in, dataSize - consumed);
+        }
+    }
+
+    // ---- shared low-level helpers ----
+
+    private static String readCString(DataInputStream in) throws IOException {
+        StringBuilder sb = new StringBuilder(64);
+        int b;
+        while ((b = in.readUnsignedByte()) != 0) sb.append((char) b);
+        return sb.toString();
+    }
+
+    private static long readId(DataInputStream in, int idSize) throws IOException {
+        return idSize == 4 ? Integer.toUnsignedLong(in.readInt()) : in.readLong();
+    }
+
+    private static void skipBytes(DataInputStream in, long count) throws IOException {
+        long skipped = 0;
+        while (skipped < count) {
+            long nn = in.skip(count - skipped);
+            if (nn <= 0) { in.readByte(); skipped++; }
+            else skipped += nn;
+        }
+    }
+
+    private static int typeSize(int type, int idSize) {
+        switch (type) {
+            case 2: return idSize; // object
+            case 4: return 1;      // boolean
+            case 5: return 2;      // char
+            case 6: return 4;      // float
+            case 7: return 8;      // double
+            case 8: return 1;      // byte
+            case 9: return 2;      // short
+            case 10: return 4;     // int
+            case 11: return 8;     // long
+            default: return idSize;
+        }
+    }
+
+    private static String primArrayName(int type) {
+        switch (type) {
+            case 4: return "boolean[]";
+            case 5: return "char[]";
+            case 6: return "float[]";
+            case 7: return "double[]";
+            case 8: return "byte[]";
+            case 9: return "short[]";
+            case 10: return "int[]";
+            case 11: return "long[]";
+            default: return "unknown[]";
+        }
+    }
+
+    /** Instance-field type descriptors for one class (most-derived only). */
+    private static final class ClassDef {
+        final byte[] fieldTypes;
+        ClassDef(byte[] fieldTypes) { this.fieldTypes = fieldTypes; }
+    }
+}

--- a/argus-diagnostics/src/main/java/io/argus/diagnostics/heapgraph/LeakSuspect.java
+++ b/argus-diagnostics/src/main/java/io/argus/diagnostics/heapgraph/LeakSuspect.java
@@ -1,0 +1,40 @@
+package io.argus.diagnostics.heapgraph;
+
+/**
+ * A single leak-suspect accumulation point: an object (or its dominating class)
+ * that retains a disproportionate share of the heap.
+ *
+ * @param objectIndex   the dominator object's index
+ * @param className     the dominator object's class name
+ * @param retainedBytes bytes retained by this dominator
+ * @param heapPercent   retained bytes as a percentage of total reachable heap
+ * @param dominatedCount number of objects dominated (subtree size)
+ */
+public final class LeakSuspect {
+    private final int objectIndex;
+    private final String className;
+    private final long retainedBytes;
+    private final double heapPercent;
+    private final int dominatedCount;
+
+    public LeakSuspect(int objectIndex, String className, long retainedBytes,
+                       double heapPercent, int dominatedCount) {
+        this.objectIndex = objectIndex;
+        this.className = className;
+        this.retainedBytes = retainedBytes;
+        this.heapPercent = heapPercent;
+        this.dominatedCount = dominatedCount;
+    }
+
+    public int objectIndex() { return objectIndex; }
+    public String className() { return className; }
+    public long retainedBytes() { return retainedBytes; }
+    public double heapPercent() { return heapPercent; }
+    public int dominatedCount() { return dominatedCount; }
+
+    @Override
+    public String toString() {
+        return "LeakSuspect[" + className + " retains " + retainedBytes
+                + " bytes (" + String.format("%.1f%%", heapPercent) + ")]";
+    }
+}

--- a/argus-diagnostics/src/main/java/io/argus/diagnostics/heapgraph/LongIntMap.java
+++ b/argus-diagnostics/src/main/java/io/argus/diagnostics/heapgraph/LongIntMap.java
@@ -1,0 +1,100 @@
+package io.argus.diagnostics.heapgraph;
+
+import java.util.Arrays;
+
+/**
+ * Open-addressing (linear-probing) primitive {@code long → int} map used to map
+ * HPROF object ids to dense object indices.
+ *
+ * <p>Boxed {@code HashMap<Long,Integer>} would cost ~48 bytes per entry; on a
+ * heap with tens of millions of objects that alone blows the analyzer budget.
+ * This map stores keys in a {@code long[]} and values in an {@code int[]} — 12
+ * bytes per slot at a 0.6 load factor — so id indexing for a 4 GB dump stays
+ * within the 2 GB analyzer heap.
+ *
+ * <p>Keys must be non-zero (zero is the empty sentinel, matching HPROF where
+ * object id 0 means {@code null}). {@link #get(long)} returns {@code -1} for a
+ * missing key.
+ */
+public final class LongIntMap {
+
+    private static final long EMPTY = 0L;
+    private static final float LOAD_FACTOR = 0.6f;
+
+    private long[] keys;
+    private int[] values;
+    private int mask;
+    private int size;
+    private int threshold;
+    /** Fibonacci-hash right-shift = 64 - log2(cap); keeps the top log2(cap) bits so the whole table is used. */
+    private int shift;
+
+    public LongIntMap(int expected) {
+        int cap = tableSizeFor(Math.max(16, (int) (expected / LOAD_FACTOR) + 1));
+        keys = new long[cap];
+        values = new int[cap];
+        mask = cap - 1;
+        threshold = (int) (cap * LOAD_FACTOR);
+        shift = 64 - Integer.numberOfTrailingZeros(cap);
+    }
+
+    public int size() { return size; }
+
+    /** Maps {@code key → value}. {@code key} must be non-zero. */
+    public void put(long key, int value) {
+        if (key == EMPTY) throw new IllegalArgumentException("key 0 is reserved");
+        if (size >= threshold) resize();
+        int i = index(key);
+        while (keys[i] != EMPTY) {
+            if (keys[i] == key) { values[i] = value; return; }
+            i = (i + 1) & mask;
+        }
+        keys[i] = key;
+        values[i] = value;
+        size++;
+    }
+
+    /** Returns the value for {@code key}, or {@code -1} if absent. */
+    public int get(long key) {
+        if (key == EMPTY) return -1;
+        int i = index(key);
+        while (keys[i] != EMPTY) {
+            if (keys[i] == key) return values[i];
+            i = (i + 1) & mask;
+        }
+        return -1;
+    }
+
+    private int index(long key) {
+        long h = key * 0x9E3779B97F4A7C15L; // Fibonacci hashing
+        // Take the top log2(cap) bits so the full table is addressed even when
+        // cap exceeds 2^24 (tens of millions of objects — the multi-GB use case).
+        return (int) (h >>> shift);
+    }
+
+    private void resize() {
+        long[] oldKeys = keys;
+        int[] oldVals = values;
+        int newCap = keys.length << 1;
+        keys = new long[newCap];
+        values = new int[newCap];
+        mask = newCap - 1;
+        threshold = (int) (newCap * LOAD_FACTOR);
+        shift = 64 - Integer.numberOfTrailingZeros(newCap);
+        Arrays.fill(keys, EMPTY);
+        for (int j = 0; j < oldKeys.length; j++) {
+            long k = oldKeys[j];
+            if (k != EMPTY) {
+                int i = index(k);
+                while (keys[i] != EMPTY) i = (i + 1) & mask;
+                keys[i] = k;
+                values[i] = oldVals[j];
+            }
+        }
+    }
+
+    private static int tableSizeFor(int cap) {
+        int n = Integer.highestOneBit(Math.max(1, cap - 1)) << 1;
+        return Math.max(16, n);
+    }
+}

--- a/argus-diagnostics/src/main/java/io/argus/diagnostics/heapgraph/ObjectGraph.java
+++ b/argus-diagnostics/src/main/java/io/argus/diagnostics/heapgraph/ObjectGraph.java
@@ -1,0 +1,63 @@
+package io.argus.diagnostics.heapgraph;
+
+/**
+ * A directed object reference graph keyed by dense integer object indices
+ * ({@code 0..objectCount()-1}).
+ *
+ * <p>The graph is intentionally id-indexed and backed by primitive arrays so
+ * that very large heaps (multi-GB HPROF dumps) can be analyzed without
+ * materializing one Java object per heap object. Outgoing edges are stored in
+ * Compressed-Sparse-Row (CSR) form: a single {@code int[]} of target indices
+ * plus an {@code int[]} of per-node offsets.
+ *
+ * <p>This abstraction is what the {@link DominatorTree} engine consumes, which
+ * keeps the algorithm fully decoupled from the HPROF binary format and makes it
+ * deterministically unit-testable on synthetic in-memory graphs.
+ */
+public interface ObjectGraph {
+
+    /** Total number of objects (dense index space is {@code 0..count-1}). */
+    int objectCount();
+
+    /** Shallow size (bytes) of the object at {@code index}. */
+    long shallowSize(int index);
+
+    /** Class index of the object at {@code index} (see {@link #className(int)}). */
+    int classOf(int index);
+
+    /** Human-readable class name for a class index, with {@code .} separators. */
+    String className(int classIndex);
+
+    /** Number of distinct class indices. */
+    int classCount();
+
+    /**
+     * Indices of objects that are GC roots (JNI globals/locals, thread stacks,
+     * sticky classes, monitors, etc.). These are the entry points of the
+     * reachability/dominator analysis.
+     */
+    int[] gcRoots();
+
+    /**
+     * Returns the outgoing reference targets of {@code index}.
+     *
+     * <p>The returned array is the shared CSR backing array; callers MUST treat
+     * the slice {@code [outOffset(index), outOffset(index+1))} as read-only and
+     * not mutate it. Use {@link #outDegree(int)} together with this for
+     * iteration, or iterate the CSR directly via {@link #edges()} and
+     * {@link #edgeOffsets()}.
+     */
+    int[] outRefs(int index);
+
+    /** Number of outgoing references from {@code index}. */
+    int outDegree(int index);
+
+    /** The flat CSR edge target array (length = total edge count). */
+    int[] edges();
+
+    /**
+     * Per-node CSR offset array of length {@code objectCount()+1}. Node
+     * {@code i}'s edges occupy {@code edges()[edgeOffsets()[i] .. edgeOffsets()[i+1])}.
+     */
+    int[] edgeOffsets();
+}

--- a/argus-diagnostics/src/main/java/io/argus/diagnostics/heapgraph/PathToRoot.java
+++ b/argus-diagnostics/src/main/java/io/argus/diagnostics/heapgraph/PathToRoot.java
@@ -1,0 +1,108 @@
+package io.argus.diagnostics.heapgraph;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Computes the shortest reference path from an object back to a GC root.
+ *
+ * <p>A single breadth-first sweep from all GC roots over the forward reference
+ * graph records, for every reachable object, the predecessor on a shortest path
+ * from a root ({@code parent[]}). Tracing {@code parent[]} back from any object
+ * yields its shortest path-to-root. BFS guarantees the path is minimal in edge
+ * count, which is the "why is this still alive?" answer an operator wants.
+ *
+ * <p>The sweep uses a primitive {@code int[]} queue and {@code int[] parent}
+ * array — O(N) memory, no per-node objects.
+ */
+public final class PathToRoot {
+
+    /** Sentinel: a GC root has no parent (it is the path origin). */
+    public static final int ROOT_PARENT = -2;
+    /** Sentinel: object not reached from any GC root. */
+    public static final int UNREACHED = -1;
+
+    private final ObjectGraph graph;
+    private final int[] parent; // parent on shortest path from a root, by object index
+
+    private PathToRoot(ObjectGraph graph, int[] parent) {
+        this.graph = graph;
+        this.parent = parent;
+    }
+
+    /** Builds BFS predecessor pointers from every GC root. */
+    public static PathToRoot compute(ObjectGraph graph) {
+        int n = graph.objectCount();
+        int[] parent = new int[n];
+        Arrays.fill(parent, UNREACHED);
+        int[] edges = graph.edges();
+        int[] edgeOff = graph.edgeOffsets();
+
+        int[] queue = new int[n == 0 ? 1 : n];
+        int head = 0, tail = 0;
+        for (int r : graph.gcRoots()) {
+            if (r >= 0 && r < n && parent[r] == UNREACHED) {
+                parent[r] = ROOT_PARENT;
+                queue[tail++] = r;
+            }
+        }
+        while (head < tail) {
+            int v = queue[head++];
+            int from = edgeOff[v], to = edgeOff[v + 1];
+            for (int e = from; e < to; e++) {
+                int w = edges[e];
+                if (w >= 0 && parent[w] == UNREACHED) {
+                    parent[w] = v;
+                    queue[tail++] = w;
+                }
+            }
+        }
+        return new PathToRoot(graph, parent);
+    }
+
+    /** True if {@code target} is reachable from any GC root. */
+    public boolean isReachable(int target) {
+        return target >= 0 && target < parent.length && parent[target] != UNREACHED;
+    }
+
+    /**
+     * Returns the shortest path from {@code target} up to its GC root, ordered
+     * root-first (index 0 is the GC root, last element is {@code target}).
+     * Empty if {@code target} is unreachable.
+     */
+    public int[] pathFor(int target) {
+        if (!isReachable(target)) return new int[0];
+        List<Integer> rev = new ArrayList<>();
+        int cur = target;
+        // bound the walk to avoid infinite loops on a malformed parent array
+        int guard = parent.length + 1;
+        while (cur != ROOT_PARENT && guard-- > 0) {
+            rev.add(cur);
+            cur = parent[cur];
+        }
+        int[] path = new int[rev.size()];
+        for (int i = 0; i < path.length; i++) {
+            path[i] = rev.get(path.length - 1 - i);
+        }
+        return path;
+    }
+
+    /**
+     * Finds the object of the given class that has the largest shallow size and
+     * returns its shortest path-to-root. Returns an empty array if no instance
+     * of {@code className} is reachable.
+     */
+    public int[] shortestPathForClass(String className) {
+        int best = -1;
+        long bestSize = -1;
+        int n = graph.objectCount();
+        for (int v = 0; v < n; v++) {
+            if (!isReachable(v)) continue;
+            if (!graph.className(graph.classOf(v)).equals(className)) continue;
+            long sz = graph.shallowSize(v);
+            if (sz > bestSize) { bestSize = sz; best = v; }
+        }
+        return best < 0 ? new int[0] : pathFor(best);
+    }
+}

--- a/argus-diagnostics/src/test/java/io/argus/diagnostics/heapgraph/DominatorTreeTest.java
+++ b/argus-diagnostics/src/test/java/io/argus/diagnostics/heapgraph/DominatorTreeTest.java
@@ -1,0 +1,175 @@
+package io.argus.diagnostics.heapgraph;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Deterministic unit tests for the dominator / retained-size / path-to-root
+ * engine over hand-constructed in-memory {@link ObjectGraph}s. Retained sizes
+ * and dominators are verified against values computed by hand, independent of
+ * any HPROF parsing.
+ */
+class DominatorTreeTest {
+
+    /**
+     * Builds a CSR-backed graph from per-node edge lists.
+     *
+     * @param shallow   shallow size per object
+     * @param classIdx  class index per object
+     * @param classNames class name table
+     * @param roots     GC-root object indices
+     * @param adj       outgoing edges per object
+     */
+    private static ArrayObjectGraph graph(long[] shallow, int[] classIdx,
+                                          String[] classNames, int[] roots, int[][] adj) {
+        int n = shallow.length;
+        int[] off = new int[n + 1];
+        for (int i = 0; i < n; i++) off[i + 1] = off[i] + adj[i].length;
+        int[] edges = new int[off[n]];
+        int k = 0;
+        for (int i = 0; i < n; i++) for (int t : adj[i]) edges[k++] = t;
+        return new ArrayObjectGraph(shallow, classIdx, off, edges, roots, classNames);
+    }
+
+    @Test
+    void retainedSize_simpleChain() {
+        // root(0) -> a(1) -> b(2) -> c(3). Each shallow=10.
+        // c retains 10, b retains 20, a retains 30, root retains 40.
+        long[] shallow = {10, 10, 10, 10};
+        int[] cls = {0, 1, 2, 3};
+        String[] names = {"Root", "A", "B", "C"};
+        int[][] adj = {{1}, {2}, {3}, {}};
+        ArrayObjectGraph g = graph(shallow, cls, names, new int[]{0}, adj);
+
+        DominatorTree dom = DominatorTree.compute(g);
+        assertEquals(4, dom.reachableCount());
+        assertEquals(10, dom.retainedSize(3));
+        assertEquals(20, dom.retainedSize(2));
+        assertEquals(30, dom.retainedSize(1));
+        assertEquals(40, dom.retainedSize(0));
+        // idom chain
+        assertEquals(g.objectCount(), dom.idom(0)); // root dominated by super-root
+        assertEquals(0, dom.idom(1));
+        assertEquals(1, dom.idom(2));
+        assertEquals(2, dom.idom(3));
+    }
+
+    @Test
+    void retainedSize_diamond_dominatorIsTheJoin() {
+        // root(0) -> a(1), root -> b(2); a -> d(3), b -> d(3).
+        // d is dominated by root (two disjoint paths), not by a or b.
+        // shallow: root=1, a=10, b=10, d=100
+        // retained: a=10, b=10, d=100, root=1+10+10+100 = 121
+        long[] shallow = {1, 10, 10, 100};
+        int[] cls = {0, 1, 2, 3};
+        String[] names = {"Root", "A", "B", "D"};
+        int[][] adj = {{1, 2}, {3}, {3}, {}};
+        ArrayObjectGraph g = graph(shallow, cls, names, new int[]{0}, adj);
+
+        DominatorTree dom = DominatorTree.compute(g);
+        assertEquals(10, dom.retainedSize(1));
+        assertEquals(10, dom.retainedSize(2));
+        assertEquals(100, dom.retainedSize(3));
+        assertEquals(121, dom.retainedSize(0));
+        // d's immediate dominator is the root, since a and b are both optional paths
+        assertEquals(0, dom.idom(3));
+    }
+
+    @Test
+    void unreachableObjects_retainNothing() {
+        // root(0)->a(1). b(2) and c(3) are unreachable (no root reaches them).
+        long[] shallow = {1, 10, 99, 99};
+        int[] cls = {0, 0, 0, 0};
+        String[] names = {"X"};
+        int[][] adj = {{1}, {}, {3}, {}};
+        ArrayObjectGraph g = graph(shallow, new int[]{0, 0, 0, 0}, names, new int[]{0}, adj);
+
+        DominatorTree dom = DominatorTree.compute(g);
+        assertEquals(2, dom.reachableCount());
+        assertEquals(DominatorTree.NONE, dom.idom(2));
+        assertEquals(DominatorTree.NONE, dom.idom(3));
+        assertEquals(0, dom.retainedSize(2));
+        assertEquals(0, dom.retainedSize(3));
+    }
+
+    @Test
+    void leakSuspects_namesTheAccumulationPoint() {
+        // A "leak holder" (1) retains a huge collection (indices 3..7).
+        // root(0) -> holder(1) -> array(2) -> {3,4,5,6,7}
+        // root(0) -> small(8)
+        // holder retains array + 5 leaked entries.
+        int n = 9;
+        long[] shallow = new long[n];
+        shallow[0] = 8;   // root obj
+        shallow[1] = 16;  // holder
+        shallow[2] = 48;  // array
+        for (int i = 3; i <= 7; i++) shallow[i] = 1000; // leaked entries
+        shallow[8] = 16;  // small unrelated obj
+        int[] cls = {0, 1, 2, 3, 3, 3, 3, 3, 4};
+        String[] names = {"Root", "com.app.LeakHolder", "Object[]", "com.app.Leaked", "com.app.Small"};
+        int[][] adj = new int[n][];
+        adj[0] = new int[]{1, 8};
+        adj[1] = new int[]{2};
+        adj[2] = new int[]{3, 4, 5, 6, 7};
+        adj[3] = adj[4] = adj[5] = adj[6] = adj[7] = new int[]{};
+        adj[8] = new int[]{};
+        ArrayObjectGraph g = graph(shallow, cls, names, new int[]{0}, adj);
+
+        HeapGraphAnalysis analysis = HeapGraphAnalysis.analyze(g);
+        List<LeakSuspect> suspects = analysis.leakSuspects(3, 10.0);
+        assertFalse(suspects.isEmpty(), "expected at least one suspect");
+
+        // The top suspect should be the root (it dominates everything), but the
+        // most actionable single accumulation point is the holder. Either way,
+        // the holder must be reported and must name the leak class.
+        boolean holderNamed = suspects.stream()
+                .anyMatch(s -> s.className().equals("com.app.LeakHolder"))
+                || analysis.retainedForClass("com.app.LeakHolder")[0] >= 5000;
+        assertTrue(holderNamed, "leak suspects/retained must surface the LeakHolder");
+
+        // Holder retains the array (48) + 5 * 1000 + its own 16 = 5064.
+        long[] holderRetained = analysis.retainedForClass("com.app.LeakHolder");
+        assertEquals(1, holderRetained[1]);
+        assertEquals(16 + 48 + 5 * 1000, holderRetained[0]);
+    }
+
+    @Test
+    void pathToRoot_resolvesForPlantedLeak() {
+        // root(0) -> registry(1) -> map(2) -> leakedValue(3)
+        long[] shallow = {1, 10, 10, 500};
+        int[] cls = {0, 1, 2, 3};
+        String[] names = {"Thread", "com.app.Registry", "java.util.HashMap", "com.app.SessionData"};
+        int[][] adj = {{1}, {2}, {3}, {}};
+        ArrayObjectGraph g = graph(shallow, cls, names, new int[]{0}, adj);
+
+        HeapGraphAnalysis analysis = HeapGraphAnalysis.analyze(g);
+        int[] path = analysis.pathToRootForClass("com.app.SessionData");
+        assertEquals(4, path.length);
+        // root-first ordering
+        assertEquals("Thread", g.className(g.classOf(path[0])));
+        assertEquals("com.app.Registry", g.className(g.classOf(path[1])));
+        assertEquals("java.util.HashMap", g.className(g.classOf(path[2])));
+        assertEquals("com.app.SessionData", g.className(g.classOf(path[3])));
+    }
+
+    @Test
+    void topDominators_orderedByRetainedDescending() {
+        long[] shallow = {1, 100, 50, 10};
+        int[] cls = {0, 1, 2, 3};
+        String[] names = {"R", "Big", "Mid", "Small"};
+        // root -> big, root -> mid, root -> small (all leaves under root)
+        int[][] adj = {{1, 2, 3}, {}, {}, {}};
+        ArrayObjectGraph g = graph(shallow, cls, names, new int[]{0}, adj);
+
+        HeapGraphAnalysis analysis = HeapGraphAnalysis.analyze(g);
+        int[] top = analysis.topDominators(3);
+        DominatorTree dom = analysis.dominators();
+        assertTrue(dom.retainedSize(top[0]) >= dom.retainedSize(top[1]));
+        assertTrue(dom.retainedSize(top[1]) >= dom.retainedSize(top[2]));
+        // root retains everything (161) so it is #1
+        assertEquals(0, top[0]);
+    }
+}

--- a/argus-diagnostics/src/test/java/io/argus/diagnostics/heapgraph/HprofGraphBuilderTest.java
+++ b/argus-diagnostics/src/test/java/io/argus/diagnostics/heapgraph/HprofGraphBuilderTest.java
@@ -1,0 +1,263 @@
+package io.argus.diagnostics.heapgraph;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.ByteArrayOutputStream;
+import java.io.DataOutputStream;
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * End-to-end test that hand-writes a minimal but valid HPROF 1.0.2 binary with a
+ * planted static-collection leak, then drives the full pipeline
+ * ({@link HprofGraphBuilder} → {@link HeapGraphAnalysis}) and asserts the
+ * dominator tree, retained sizes, leak suspects, and path-to-root.
+ *
+ * <p>Layout planted:
+ * <pre>
+ *   GC root (thread-obj) → LeakHolder → Object[5] → 5 × Payload(byte[1024])
+ *   GC root (sticky)     → Noise (tiny)
+ * </pre>
+ * LeakHolder must dominate the entire collection, and the path from a Payload to
+ * a GC root must be {root → LeakHolder → Object[] → Payload}.
+ */
+class HprofGraphBuilderTest {
+
+    // HPROF type tags
+    private static final int T_OBJECT = 2;
+    private static final int T_BYTE = 8;
+
+    @Test
+    void buildsGraph_dominator_retained_leakSuspect_pathToRoot(@TempDir Path tmp) throws Exception {
+        File hprof = tmp.resolve("leak.hprof").toFile();
+        new HprofWriter().writeLeakFixture(hprof);
+
+        ArrayObjectGraph g = HprofGraphBuilder.build(hprof);
+        // 1 holder + 1 array + 5 payloads + 5 byte[] + 1 noise = 13 objects
+        assertEquals(13, g.objectCount(), "object count");
+
+        HeapGraphAnalysis analysis = HeapGraphAnalysis.analyze(g);
+        DominatorTree dom = analysis.dominators();
+        assertEquals(13, dom.reachableCount(), "all objects reachable from roots");
+
+        // --- retained size of the LeakHolder: itself + array + 5 payloads + 5 byte[] ---
+        long[] holder = analysis.retainedForClass("com.app.LeakHolder");
+        assertEquals(1, holder[1], "exactly one LeakHolder");
+        // holder retains the entire leaked subgraph (everything except the noise + roots).
+        // byte[] payloads dominate the size; assert it's large and > the noise.
+        assertTrue(holder[0] > 5 * 1024, "holder must retain the 5 KB+ payload arrays, got " + holder[0]);
+
+        // --- leak suspects names the planted leak ---
+        List<LeakSuspect> suspects = analysis.leakSuspects(5, 5.0);
+        assertFalse(suspects.isEmpty());
+        boolean named = suspects.stream().anyMatch(s -> s.className().contains("LeakHolder"))
+                || analysis.retainedForClass("com.app.LeakHolder")[0]
+                   >= analysis.totalReachableBytes() / 2;
+        assertTrue(named, "leak suspect / retained must surface LeakHolder. suspects=" + suspects);
+
+        // --- path-to-root resolves for a Payload ---
+        int[] path = analysis.pathToRootForClass("com.app.Payload");
+        assertTrue(path.length >= 3, "path should traverse root -> holder -> array -> payload");
+        // first element is a GC root (the LeakHolder's referrer thread obj or holder root)
+        // last element is the Payload
+        assertEquals("com.app.Payload", g.className(g.classOf(path[path.length - 1])));
+    }
+
+    // ------------------------------------------------------------------
+    // Minimal HPROF 1.0.2 writer (test fixture only).
+    // ------------------------------------------------------------------
+    private static final class HprofWriter {
+        private final ByteArrayOutputStream body = new ByteArrayOutputStream();
+        private long nextId = 1;
+        private long nextStringId = 0x10000;
+
+        // 8-byte object ids
+        void writeLeakFixture(File out) throws IOException {
+            // Allocate ids
+            long holderClassId = id();
+            long arrayClassId = id();   // java.lang.Object (component) — used for obj-array name
+            long payloadClassId = id();
+            long noiseClassId = id();
+
+            long holderId = id();
+            long arrayId = id();
+            long noiseId = id();
+            long[] payloadIds = new long[5];
+            long[] byteArrIds = new long[5];
+            for (int i = 0; i < 5; i++) { payloadIds[i] = id(); byteArrIds[i] = id(); }
+
+            // String ids for class names + field names
+            long sHolderName = str("com/app/LeakHolder");
+            long sObjectName = str("java/lang/Object");
+            long sPayloadName = str("com/app/Payload");
+            long sNoiseName = str("com/app/Noise");
+            long fItems = str("items");     // LeakHolder.items : Object[]
+            long fData = str("data");       // Payload.data : byte[]
+
+            // LOAD_CLASS records (serial, classObjId, stackSerial, nameId)
+            loadClass(1, holderClassId, sHolderName);
+            loadClass(2, arrayClassId, sObjectName);
+            loadClass(3, payloadClassId, sPayloadName);
+            loadClass(4, noiseClassId, sNoiseName);
+
+            // Heap dump segment
+            ByteArrayOutputStream seg = new ByteArrayOutputStream();
+            DataOutputStream s = new DataOutputStream(seg);
+
+            // CLASS_DUMP for LeakHolder: one instance field "items" of type object
+            classDump(s, holderClassId, new long[]{fItems}, new int[]{T_OBJECT});
+            // CLASS_DUMP for Object (array component): no instance fields
+            classDump(s, arrayClassId, new long[]{}, new int[]{});
+            // CLASS_DUMP for Payload: one field "data" of type object (byte[])
+            classDump(s, payloadClassId, new long[]{fData}, new int[]{T_OBJECT});
+            // CLASS_DUMP for Noise: no fields
+            classDump(s, noiseClassId, new long[]{}, new int[]{});
+
+            // GC roots
+            rootThreadObj(s, holderId);   // thread obj root → holder
+            rootStickyClass(s, noiseId);  // sticky root → noise
+
+            // INSTANCE_DUMP holder: field items -> arrayId
+            instanceDump(s, holderId, holderClassId, new long[]{arrayId}, new int[]{T_OBJECT});
+            // OBJ_ARRAY_DUMP array -> 5 payloads
+            objArrayDump(s, arrayId, arrayClassId, payloadIds);
+            // 5 payloads, each field data -> its byte[]
+            for (int i = 0; i < 5; i++) {
+                instanceDump(s, payloadIds[i], payloadClassId,
+                        new long[]{byteArrIds[i]}, new int[]{T_OBJECT});
+            }
+            // 5 byte[] of 1024 bytes
+            for (int i = 0; i < 5; i++) primByteArray(s, byteArrIds[i], 1024);
+            // noise instance (no fields)
+            instanceDump(s, noiseId, noiseClassId, new long[]{}, new int[]{});
+
+            s.flush();
+            byte[] segBytes = seg.toByteArray();
+            // top-level HEAP_DUMP record
+            writeByte(0x0C);
+            writeInt(0);                 // ts delta
+            writeInt(segBytes.length);   // length
+            body.write(segBytes);
+
+            // Assemble full file: header + body
+            try (DataOutputStream file = new DataOutputStream(Files.newOutputStream(out.toPath()))) {
+                file.writeBytes("JAVA PROFILE 1.0.2");
+                file.writeByte(0);       // null terminator
+                file.writeInt(8);        // id size
+                file.writeLong(System.currentTimeMillis());
+                file.write(body.toByteArray());
+            }
+        }
+
+        private long id() { return nextId++; }
+
+        private long str(String value) throws IOException {
+            long sid = nextStringId++;
+            byte[] utf = value.getBytes(StandardCharsets.UTF_8);
+            writeByte(0x01);             // STRING tag
+            writeInt(0);                 // ts delta
+            writeInt(8 + utf.length);    // length = id + bytes
+            writeLong(sid);
+            body.write(utf);
+            return sid;
+        }
+
+        private void loadClass(int serial, long classObjId, long nameId) throws IOException {
+            writeByte(0x02);             // LOAD_CLASS
+            writeInt(0);                 // ts delta
+            writeInt(4 + 8 + 4 + 8);     // serial + classObjId + stackSerial + nameId
+            writeInt(serial);
+            writeLong(classObjId);
+            writeInt(0);                 // stack trace serial
+            writeLong(nameId);
+        }
+
+        private void classDump(DataOutputStream s, long classObjId,
+                               long[] fieldNameIds, int[] fieldTypes) throws IOException {
+            s.writeByte(0x20);           // CLASS_DUMP sub-tag
+            s.writeLong(classObjId);
+            s.writeInt(0);               // stack trace serial
+            s.writeLong(0);              // super
+            s.writeLong(0);              // loader
+            s.writeLong(0);              // signers
+            s.writeLong(0);              // protection domain
+            s.writeLong(0);              // reserved1
+            s.writeLong(0);              // reserved2
+            s.writeInt(0);               // instance size (unused)
+            s.writeShort(0);             // constant pool size
+            s.writeShort(0);             // static field count
+            s.writeShort(fieldNameIds.length); // instance field count
+            for (int i = 0; i < fieldNameIds.length; i++) {
+                s.writeLong(fieldNameIds[i]);
+                s.writeByte(fieldTypes[i]);
+            }
+        }
+
+        private void instanceDump(DataOutputStream s, long objId, long classObjId,
+                                  long[] objFieldValues, int[] fieldTypes) throws IOException {
+            // build field data: each object field is an 8-byte id
+            ByteArrayOutputStream fd = new ByteArrayOutputStream();
+            DataOutputStream d = new DataOutputStream(fd);
+            for (int i = 0; i < fieldTypes.length; i++) {
+                if (fieldTypes[i] == T_OBJECT) d.writeLong(objFieldValues[i]);
+            }
+            d.flush();
+            byte[] data = fd.toByteArray();
+            s.writeByte(0x21);           // INSTANCE_DUMP
+            s.writeLong(objId);
+            s.writeInt(0);               // stack trace serial
+            s.writeLong(classObjId);
+            s.writeInt(data.length);
+            s.write(data);
+        }
+
+        private void objArrayDump(DataOutputStream s, long arrayId, long arrayClassId,
+                                  long[] elements) throws IOException {
+            s.writeByte(0x22);           // OBJ_ARRAY_DUMP
+            s.writeLong(arrayId);
+            s.writeInt(0);               // stack trace serial
+            s.writeInt(elements.length);
+            s.writeLong(arrayClassId);
+            for (long e : elements) s.writeLong(e);
+        }
+
+        private void primByteArray(DataOutputStream s, long arrayId, int length) throws IOException {
+            s.writeByte(0x23);           // PRIM_ARRAY_DUMP
+            s.writeLong(arrayId);
+            s.writeInt(0);               // stack trace serial
+            s.writeInt(length);
+            s.writeByte(T_BYTE);         // element type byte
+            for (int i = 0; i < length; i++) s.writeByte(0);
+        }
+
+        private void rootThreadObj(DataOutputStream s, long objId) throws IOException {
+            s.writeByte(0x08);           // ROOT_THREAD_OBJ
+            s.writeLong(objId);
+            s.writeInt(0);               // thread serial
+            s.writeInt(0);               // stack trace serial
+        }
+
+        private void rootStickyClass(DataOutputStream s, long objId) throws IOException {
+            s.writeByte(0x05);           // ROOT_STICKY_CLASS
+            s.writeLong(objId);
+        }
+
+        private void writeByte(int b) { body.write(b); }
+        private void writeInt(int v) {
+            body.write((v >>> 24) & 0xFF);
+            body.write((v >>> 16) & 0xFF);
+            body.write((v >>> 8) & 0xFF);
+            body.write(v & 0xFF);
+        }
+        private void writeLong(long v) {
+            for (int i = 7; i >= 0; i--) body.write((int) (v >>> (i * 8)) & 0xFF);
+        }
+    }
+}

--- a/argus-frontend/src/main/resources/public/console.html
+++ b/argus-frontend/src/main/resources/public/console.html
@@ -20,6 +20,7 @@
         <div class="header-actions">
             <a href="/" class="btn" title="JVM Dashboard">Dashboard</a>
             <a href="/fleet.html" class="btn" title="Fleet Command Center">Fleet</a>
+            <a href="/profiles.html" class="btn" title="Continuous Profiles">Profiles</a>
             <!-- Pod picker: only shown in cluster mode (when /api/pods returns 200). -->
             <label class="pod-picker" id="pod-picker-wrap" hidden>
                 <span class="pod-picker-label">Pod</span>

--- a/argus-frontend/src/main/resources/public/fleet.html
+++ b/argus-frontend/src/main/resources/public/fleet.html
@@ -38,6 +38,7 @@
         <div class="header-actions">
             <a href="/" class="btn" title="Single JVM Dashboard">Dashboard</a>
             <a href="/fleet.html" class="btn btn-active" title="Fleet Command Center">Fleet</a>
+            <a href="/profiles.html" class="btn" title="Continuous Profiles">Profiles</a>
             <a href="/console.html" class="btn" title="Interactive Console">Console</a>
             <a href="https://github.com/rlaope/Argus" target="_blank" class="btn btn-icon" title="GitHub" style="text-decoration:none;"><svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/></svg></a>
             <button type="button" class="argus-theme-toggle" aria-label="Toggle theme"></button>

--- a/argus-frontend/src/main/resources/public/index.html
+++ b/argus-frontend/src/main/resources/public/index.html
@@ -27,6 +27,7 @@
         <div class="header-actions">
             <a href="/" class="btn" title="Single JVM Dashboard">Dashboard</a>
             <a href="/fleet.html" class="btn" title="Fleet Command Center">Fleet</a>
+            <a href="/profiles.html" class="btn" title="Continuous Profiles">Profiles</a>
             <a href="/console.html" class="btn" title="Interactive Console">Console</a>
             <!-- Pod picker: only shown in cluster mode (when /api/pods returns 200). -->
             <label class="pod-picker" id="pod-picker-wrap" hidden>

--- a/argus-frontend/src/main/resources/public/js/flamegraph.js
+++ b/argus-frontend/src/main/resources/public/js/flamegraph.js
@@ -1,0 +1,191 @@
+/**
+ * Minimal, dependency-free flamegraph renderer (vendored).
+ *
+ * The repo had no reusable d3-flamegraph component — the `argus flame` CLI lets
+ * async-profiler emit its own standalone HTML — so this is a small from-scratch
+ * SVG renderer. No build step, no d3, no external deps: it consumes the
+ * hierarchical tree the aggregator builds server-side
+ * ({@code {name,value,children:[...]}}) and the diff variant
+ * ({@code {name,value,head,base,delta,children:[...]}}).
+ *
+ * Public API (attached to window.ArgusFlame):
+ *   render(container, root, opts)
+ *     container : DOM element to render into (cleared first)
+ *     root      : the tree node (synthetic "root")
+ *     opts.mode : 'plain' (default) or 'diff'
+ *     opts.onZoom(node) : optional callback when a frame is clicked
+ *
+ * Layout: classic icicle (root on top, children below). Each frame's width is
+ * proportional to its inclusive `value` within the current zoom root. Click a
+ * frame to zoom; click the root row to reset.
+ */
+(function () {
+    'use strict';
+    if (window.ArgusFlame) return;
+
+    var ROW_HEIGHT = 18;
+    var MIN_LABEL_WIDTH = 28; // px below which the label is dropped
+
+    function esc(s) {
+        return String(s == null ? '' : s).replace(/[&<>"']/g, function (c) {
+            return ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' })[c];
+        });
+    }
+
+    // Stable hue from a frame name so sibling frames are visually distinct
+    // (warm "flame" palette in plain mode).
+    function plainColor(name) {
+        var h = 0;
+        for (var i = 0; i < name.length; i++) {
+            h = (h * 31 + name.charCodeAt(i)) & 0xffffffff;
+        }
+        var hue = 20 + (Math.abs(h) % 35);      // 20–55deg: reds→oranges→yellows
+        var sat = 70 + (Math.abs(h >> 8) % 20); // 70–90%
+        return 'hsl(' + hue + ',' + sat + '%,55%)';
+    }
+
+    // Diff color: green = grew (positive delta), red = shrank, grey = unchanged.
+    // Saturation scales with |delta| relative to the node's own magnitude.
+    function diffColor(node) {
+        var delta = node.delta || 0;
+        var mag = Math.max(node.head || 0, node.base || 0, 1);
+        var frac = Math.min(1, Math.abs(delta) / mag);
+        var light = 70 - Math.round(frac * 30); // 70%→40% as the change grows
+        if (delta > 0) return 'hsl(130,60%,' + light + '%)';
+        if (delta < 0) return 'hsl(5,70%,' + light + '%)';
+        return 'hsl(210,8%,55%)';
+    }
+
+    function maxDepth(node, d) {
+        var m = d;
+        if (node.children) {
+            for (var i = 0; i < node.children.length; i++) {
+                m = Math.max(m, maxDepth(node.children[i], d + 1));
+            }
+        }
+        return m;
+    }
+
+    function render(container, root, opts) {
+        opts = opts || {};
+        var mode = opts.mode === 'diff' ? 'diff' : 'plain';
+        container.innerHTML = '';
+
+        if (!root || !(root.value > 0) && !(mode === 'diff' && (root.head > 0 || root.base > 0))) {
+            var empty = document.createElement('div');
+            empty.className = 'flame-empty';
+            empty.textContent = 'No profile samples in this window.';
+            container.appendChild(empty);
+            return;
+        }
+
+        var width = container.clientWidth || 900;
+        var depth = maxDepth(root, 0) + 1;
+        var height = depth * ROW_HEIGHT;
+
+        var svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+        svg.setAttribute('width', '100%');
+        svg.setAttribute('height', height);
+        svg.setAttribute('viewBox', '0 0 ' + width + ' ' + height);
+        svg.setAttribute('preserveAspectRatio', 'none');
+        svg.classList.add('flame-svg');
+
+        var tip = document.createElement('div');
+        tip.className = 'flame-tooltip';
+        tip.hidden = true;
+
+        // Total used to scale the current zoom root to full width.
+        var zoomTotal = (mode === 'diff')
+            ? Math.max(root.head || 0, root.base || 0, root.value || 0, 1)
+            : (root.value || 1);
+
+        function draw(node, depthIdx, x0, w) {
+            if (w < 0.5) return;
+            var g = document.createElementNS('http://www.w3.org/2000/svg', 'g');
+            var rect = document.createElementNS('http://www.w3.org/2000/svg', 'rect');
+            rect.setAttribute('x', x0);
+            rect.setAttribute('y', depthIdx * ROW_HEIGHT);
+            rect.setAttribute('width', Math.max(0, w - 1));
+            rect.setAttribute('height', ROW_HEIGHT - 1);
+            rect.setAttribute('fill', mode === 'diff' ? diffColor(node) : plainColor(node.name));
+            rect.classList.add('flame-rect');
+            g.appendChild(rect);
+
+            if (w >= MIN_LABEL_WIDTH) {
+                var label = document.createElementNS('http://www.w3.org/2000/svg', 'text');
+                label.setAttribute('x', x0 + 3);
+                label.setAttribute('y', depthIdx * ROW_HEIGHT + 13);
+                label.classList.add('flame-label');
+                // Trim by chars; SVG text clip via overflow on the rect group.
+                var maxChars = Math.floor((w - 6) / 6.2);
+                var name = node.name.length > maxChars ? node.name.slice(0, maxChars - 1) + '…' : node.name;
+                label.textContent = name;
+                g.appendChild(label);
+            }
+
+            g.style.cursor = 'pointer';
+            g.addEventListener('mousemove', function (ev) {
+                tip.hidden = false;
+                tip.innerHTML = tooltipHtml(node, mode);
+                var cr = container.getBoundingClientRect();
+                tip.style.left = (ev.clientX - cr.left + 12) + 'px';
+                tip.style.top = (ev.clientY - cr.top + 12) + 'px';
+            });
+            g.addEventListener('mouseleave', function () { tip.hidden = true; });
+            g.addEventListener('click', function (ev) {
+                ev.stopPropagation();
+                if (opts.onZoom) opts.onZoom(node);
+                rerenderFrom(node);
+            });
+
+            svg.appendChild(g);
+
+            // Children laid out left-to-right under the parent.
+            if (node.children && node.children.length) {
+                var childX = x0;
+                for (var i = 0; i < node.children.length; i++) {
+                    var c = node.children[i];
+                    var cv = childInclusive(c, mode);
+                    var cw = (cv / zoomTotal) * width;
+                    draw(c, depthIdx + 1, childX, cw);
+                    childX += cw;
+                }
+            }
+        }
+
+        function rerenderFrom(node) {
+            // Zoom: re-render with `node` as the new root occupying full width.
+            render(container, node, opts);
+        }
+
+        var rootInclusive = childInclusive(root, mode);
+        zoomTotal = rootInclusive || 1;
+        draw(root, 0, 0, width);
+
+        // Click anywhere on empty svg area resets to the supplied root only if
+        // we are already at it; caller controls full reset via its own button.
+        container.appendChild(svg);
+        container.appendChild(tip);
+    }
+
+    function childInclusive(node, mode) {
+        if (mode === 'diff') {
+            return Math.max(node.head || 0, node.base || 0, node.value || 0);
+        }
+        return node.value || 0;
+    }
+
+    function tooltipHtml(node, mode) {
+        if (mode === 'diff') {
+            var sign = (node.delta || 0) > 0 ? '+' : '';
+            return '<div class="flame-tip-name">' + esc(node.name) + '</div>' +
+                '<div class="flame-tip-row">head: ' + (node.head || 0) +
+                ' · base: ' + (node.base || 0) + '</div>' +
+                '<div class="flame-tip-row">Δ ' + sign + (node.delta || 0) + '</div>';
+        }
+        return '<div class="flame-tip-name">' + esc(node.name) + '</div>' +
+            '<div class="flame-tip-row">' + (node.value || 0) + ' samples</div>';
+    }
+
+    window.ArgusFlame = Object.freeze({ render: render });
+})();

--- a/argus-frontend/src/main/resources/public/js/profiles.js
+++ b/argus-frontend/src/main/resources/public/js/profiles.js
@@ -1,0 +1,189 @@
+/**
+ * Argus Continuous Profiles view (W1).
+ *
+ * Cluster-mode-aware: populates a pod picker from GET /api/pods (same source
+ * fleet.js / dashboard-cluster.js use), an event selector (cpu/alloc/lock/wall),
+ * and time-range inputs. Calls the aggregator's continuous-profiling endpoints
+ * directly on the same origin:
+ *   - GET /profile/query?pod=&event=&from=&to=  → merged flamegraph
+ *   - GET /profile/diff?pod=&event=&baseFrom=&baseTo=&headFrom=&headTo= → diff
+ * and renders via the vendored window.ArgusFlame renderer (js/flamegraph.js).
+ */
+(function () {
+    'use strict';
+
+    var POD_STORAGE_KEY = 'argus.console.pod';
+    var AGGREGATOR_BASE = ''; // same origin
+
+    var els = {};
+    var pods = [];
+
+    function $(id) { return document.getElementById(id); }
+
+    function readStoredPod() {
+        try { return window.localStorage.getItem(POD_STORAGE_KEY); }
+        catch (e) { return null; }
+    }
+    function writeStoredPod(podId) {
+        try { window.localStorage.setItem(POD_STORAGE_KEY, podId); }
+        catch (e) { /* ignore */ }
+    }
+
+    function setStatus(msg, kind) {
+        if (!els.status) return;
+        els.status.textContent = msg;
+        els.status.className = 'profiles-status' + (kind ? ' profiles-status--' + kind : '');
+    }
+
+    /* ---- Pod picker -------------------------------------------------- */
+    function populatePods(list) {
+        pods = list || [];
+        els.pod.replaceChildren();
+        if (!pods.length) {
+            var opt = document.createElement('option');
+            opt.value = '';
+            opt.textContent = 'No pods registered';
+            opt.disabled = true;
+            els.pod.appendChild(opt);
+            return;
+        }
+        var grouped = {};
+        pods.forEach(function (p) {
+            var k = p.deployment || p.namespace || 'other';
+            (grouped[k] = grouped[k] || []).push(p);
+        });
+        var stored = readStoredPod();
+        var knownIds = new Set(pods.map(function (p) { return p.podId; }));
+        var initial = (stored && knownIds.has(stored)) ? stored : pods[0].podId;
+        Object.keys(grouped).sort().forEach(function (group) {
+            var og = document.createElement('optgroup');
+            og.label = group;
+            grouped[group]
+                .sort(function (a, b) { return a.podName.localeCompare(b.podName); })
+                .forEach(function (p) {
+                    var opt = document.createElement('option');
+                    opt.value = p.podId;
+                    opt.textContent = p.podName + (p.scrapeOk ? '' : ' ·offline');
+                    if (p.podId === initial) opt.selected = true;
+                    og.appendChild(opt);
+                });
+            els.pod.appendChild(og);
+        });
+    }
+
+    function loadPods() {
+        return fetch(AGGREGATOR_BASE + '/api/pods')
+            .then(function (r) { return r.ok ? r.json() : null; })
+            .then(function (data) {
+                if (data && Array.isArray(data.pods)) {
+                    populatePods(data.pods);
+                } else {
+                    populatePods([]);
+                }
+            })
+            .catch(function () { populatePods([]); });
+    }
+
+    /* ---- Time helpers ------------------------------------------------ */
+    // The "Last N" select sets a trailing window ending now.
+    function trailingWindowMillis() {
+        var sec = parseInt(els.range.value, 10) || 3600;
+        var to = Date.now();
+        var from = to - sec * 1000;
+        return { from: from, to: to };
+    }
+
+    /* ---- Query (merged flamegraph) ----------------------------------- */
+    function runQuery() {
+        var pod = els.pod.value;
+        var event = els.event.value;
+        if (!pod) { setStatus('Select a pod first.', 'warn'); return; }
+        writeStoredPod(pod);
+        var w = trailingWindowMillis();
+        var url = AGGREGATOR_BASE + '/profile/query?pod=' + encodeURIComponent(pod) +
+            '&event=' + encodeURIComponent(event) +
+            '&from=' + w.from + '&to=' + w.to;
+        setStatus('Loading…', 'loading');
+        fetch(url)
+            .then(function (r) { return r.ok ? r.json() : Promise.reject(new Error('HTTP ' + r.status)); })
+            .then(function (data) {
+                var fg = data.flamegraph;
+                renderFlame(fg, 'plain');
+                var n = (fg && fg.value) || 0;
+                setStatus(n > 0 ? (n + ' samples · ' + pod + ' · ' + event) : 'No samples in window.',
+                    n > 0 ? 'ok' : 'warn');
+            })
+            .catch(function (e) { setStatus('Query failed: ' + e.message, 'error'); });
+    }
+
+    /* ---- Diff (differential flamegraph) ------------------------------ */
+    function runDiff() {
+        var pod = els.pod.value;
+        var event = els.event.value;
+        if (!pod) { setStatus('Select a pod first.', 'warn'); return; }
+        writeStoredPod(pod);
+        var now = Date.now();
+        var sec = parseInt(els.range.value, 10) || 3600;
+        // base = the window before head; head = the trailing window.
+        var headTo = now;
+        var headFrom = now - sec * 1000;
+        var baseTo = headFrom;
+        var baseFrom = headFrom - sec * 1000;
+        var url = AGGREGATOR_BASE + '/profile/diff?pod=' + encodeURIComponent(pod) +
+            '&event=' + encodeURIComponent(event) +
+            '&baseFrom=' + baseFrom + '&baseTo=' + baseTo +
+            '&headFrom=' + headFrom + '&headTo=' + headTo;
+        setStatus('Computing diff…', 'loading');
+        fetch(url)
+            .then(function (r) { return r.ok ? r.json() : Promise.reject(new Error('HTTP ' + r.status)); })
+            .then(function (data) {
+                var fg = data.flamegraph;
+                renderFlame(fg, 'diff');
+                var d = (fg && fg.delta) || 0;
+                var sign = d > 0 ? '+' : '';
+                setStatus('Diff (head vs prior window) · root Δ ' + sign + d, 'ok');
+            })
+            .catch(function (e) { setStatus('Diff failed: ' + e.message, 'error'); });
+    }
+
+    function renderFlame(root, mode) {
+        if (!window.ArgusFlame) {
+            setStatus('Flamegraph renderer not loaded.', 'error');
+            return;
+        }
+        window.ArgusFlame.render(els.flame, root, { mode: mode });
+        els.legend.hidden = mode !== 'diff';
+    }
+
+    /* ---- Boot -------------------------------------------------------- */
+    function init() {
+        els.pod = $('profiles-pod');
+        els.event = $('profiles-event');
+        els.range = $('profiles-range');
+        els.queryBtn = $('profiles-query-btn');
+        els.diffBtn = $('profiles-diff-btn');
+        els.flame = $('profiles-flame');
+        els.status = $('profiles-status');
+        els.legend = $('profiles-diff-legend');
+        if (!els.pod || !els.flame) return;
+
+        els.queryBtn.addEventListener('click', runQuery);
+        els.diffBtn.addEventListener('click', runDiff);
+        // Re-resolve to current pod selection on cross-tab change.
+        window.addEventListener('storage', function (e) {
+            if (e.key !== POD_STORAGE_KEY || !e.newValue) return;
+            var known = new Set(pods.map(function (p) { return p.podId; }));
+            if (known.has(e.newValue)) els.pod.value = e.newValue;
+        });
+
+        loadPods().then(function () {
+            if (els.pod.value) runQuery();
+        });
+    }
+
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', init);
+    } else {
+        init();
+    }
+})();

--- a/argus-frontend/src/main/resources/public/profiles.html
+++ b/argus-frontend/src/main/resources/public/profiles.html
@@ -1,0 +1,167 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Argus - Continuous Profiles</title>
+    <link rel="stylesheet" href="/css/style.css">
+    <link rel="stylesheet" href="/css/fleet.css">
+    <link rel="stylesheet" href="/css/theme.css">
+    <style>
+        .cluster-badge {
+            display: inline-block;
+            background: var(--blue, #1565c0);
+            color: #fff;
+            padding: 0.1rem 0.5rem;
+            border-radius: 10px;
+            font-size: 0.6875rem;
+            font-weight: 700;
+            vertical-align: middle;
+            margin-left: 0.5rem;
+        }
+        .profiles-toolbar {
+            display: flex;
+            flex-wrap: wrap;
+            align-items: flex-end;
+            gap: 1rem;
+            padding: 0.75rem 1.25rem;
+            border-bottom: 1px solid var(--border, #30363d);
+        }
+        .profiles-field { display: flex; flex-direction: column; gap: 0.25rem; }
+        .profiles-field label {
+            font-size: 0.6875rem;
+            text-transform: uppercase;
+            letter-spacing: 0.04em;
+            color: var(--ink-3, #8b949e);
+        }
+        .profiles-field select {
+            background: var(--bg-2, #161b22);
+            color: var(--ink, #e6edf3);
+            border: 1px solid var(--border, #30363d);
+            border-radius: 6px;
+            padding: 0.35rem 0.5rem;
+            min-width: 9rem;
+        }
+        .profiles-actions { display: flex; gap: 0.5rem; }
+        .profiles-status {
+            margin-left: auto;
+            font-size: 0.8125rem;
+            color: var(--ink-3, #8b949e);
+        }
+        .profiles-status--ok    { color: var(--green, #56d364); }
+        .profiles-status--warn  { color: var(--amber, #d29922); }
+        .profiles-status--error { color: var(--red, #f47067); }
+        .profiles-canvas {
+            position: relative;
+            margin: 1rem 1.25rem;
+            padding: 0.5rem;
+            border: 1px solid var(--border, #30363d);
+            border-radius: 8px;
+            background: var(--bg-2, #161b22);
+            min-height: 240px;
+            overflow-x: auto;
+        }
+        .flame-svg { display: block; font-family: ui-monospace, SFMono-Regular, Menlo, monospace; }
+        .flame-rect { stroke: var(--bg, #0d1117); stroke-width: 0.5; }
+        .flame-rect:hover { opacity: 0.85; }
+        .flame-label { fill: #111; font-size: 10px; pointer-events: none; user-select: none; }
+        .flame-empty { padding: 2rem; text-align: center; color: var(--ink-3, #8b949e); }
+        .flame-tooltip {
+            position: absolute;
+            pointer-events: none;
+            background: var(--bg, #0d1117);
+            border: 1px solid var(--border, #30363d);
+            border-radius: 6px;
+            padding: 0.4rem 0.6rem;
+            font-size: 0.75rem;
+            color: var(--ink, #e6edf3);
+            box-shadow: 0 4px 14px rgba(0,0,0,0.4);
+            z-index: 10;
+            max-width: 28rem;
+            word-break: break-all;
+        }
+        .flame-tip-name { font-weight: 600; margin-bottom: 0.15rem; }
+        .flame-tip-row { color: var(--ink-3, #8b949e); }
+        .profiles-diff-legend {
+            display: flex;
+            gap: 1rem;
+            padding: 0 1.25rem 0.5rem;
+            font-size: 0.75rem;
+            color: var(--ink-3, #8b949e);
+        }
+        .profiles-legend-swatch {
+            display: inline-block;
+            width: 0.8rem;
+            height: 0.8rem;
+            border-radius: 2px;
+            vertical-align: middle;
+            margin-right: 0.3rem;
+        }
+    </style>
+    <script src="/js/theme-preboot.js"></script>
+    <script src="/js/theme.js"></script>
+</head>
+<body>
+
+    <header>
+        <div class="logo">
+            <img src="/img/argus_logo.png" alt="Argus" class="logo-img">
+            <h1>Argus</h1>
+            <span class="cluster-badge">Continuous Profiles</span>
+        </div>
+        <div class="header-actions">
+            <a href="/" class="btn" title="Single JVM Dashboard">Dashboard</a>
+            <a href="/fleet.html" class="btn" title="Fleet Command Center">Fleet</a>
+            <a href="/profiles.html" class="btn btn-active" title="Continuous Profiles">Profiles</a>
+            <a href="/console.html" class="btn" title="Interactive Console">Console</a>
+            <button type="button" class="argus-theme-toggle" aria-label="Toggle theme"></button>
+        </div>
+    </header>
+
+    <div class="profiles-toolbar">
+        <div class="profiles-field">
+            <label for="profiles-pod">Pod</label>
+            <select id="profiles-pod"></select>
+        </div>
+        <div class="profiles-field">
+            <label for="profiles-event">Event</label>
+            <select id="profiles-event">
+                <option value="cpu">cpu</option>
+                <option value="alloc">alloc</option>
+                <option value="lock">lock</option>
+                <option value="wall">wall</option>
+            </select>
+        </div>
+        <div class="profiles-field">
+            <label for="profiles-range">Window</label>
+            <select id="profiles-range">
+                <option value="300">Last 5m</option>
+                <option value="900">Last 15m</option>
+                <option value="3600" selected>Last 1h</option>
+                <option value="21600">Last 6h</option>
+                <option value="86400">Last 24h</option>
+            </select>
+        </div>
+        <div class="profiles-actions">
+            <button id="profiles-query-btn" class="btn btn-primary" title="Merged flamegraph for the window">Query</button>
+            <button id="profiles-diff-btn" class="btn" title="Diff: this window vs the prior window of equal length">Diff</button>
+        </div>
+        <span id="profiles-status" class="profiles-status">Select a pod and click Query.</span>
+    </div>
+
+    <div id="profiles-diff-legend" class="profiles-diff-legend" hidden>
+        <span><span class="profiles-legend-swatch" style="background:hsl(130,60%,50%)"></span>Grew (Δ&gt;0)</span>
+        <span><span class="profiles-legend-swatch" style="background:hsl(5,70%,50%)"></span>Shrank (Δ&lt;0)</span>
+        <span><span class="profiles-legend-swatch" style="background:hsl(210,8%,55%)"></span>Unchanged</span>
+    </div>
+
+    <div id="profiles-flame" class="profiles-canvas"></div>
+
+    <footer>
+        <p>Argus Continuous Profiles &mdash; Pyroscope-lite time-windowed flamegraphs &middot; <a href="https://github.com/rlaope/Argus" target="_blank" style="color:var(--ink-3,#888);text-decoration:none;">GitHub</a></p>
+    </footer>
+
+    <script src="/js/flamegraph.js"></script>
+    <script src="/js/profiles.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary

Roadmap **Phase 2** of `.omc/plans/jvm-oss-parity-roadmap.md`. Two workstreams, disjoint modules.

**W2 — heap analysis depth (5 → 8)** — `argus-diagnostics/heapgraph/` + `HeapAnalyzeCommand`
- Streaming HPROF graph builder + primitive CSR graph + open-addressing `long→int` id map (4 GB dump within ~2 GB heap).
- Lengauer-Tarjan **dominator tree** (super-root over GC roots, iterative DFS) + retained/subtree sizes; **path-to-GC-root** (multi-source BFS); **leak-suspects** heuristic.
- New flags: `--leak-suspects`, `--dominators=N`, `--path-to-root=<class>`, `--retained=<class>`; default histogram path unchanged.
- Documented limitation: only most-derived instance fields are followed (superclass-declared refs skipped; stream stays aligned).

**W1.2 — continuous profiling completion (2 → 8)** — `argus-aggregator` + `argus-frontend` (builds on Phase 1 ProfileStore)
- `FlameTree` (collapsed→tree + diff), `ProfileController` (`POST /profile/ingest`, `GET /profile/query`, `GET /profile/diff`), shared `ProfileStore` + 1-min eviction daemon.
- `profiles.html` + `profiles.js` + vendored dependency-free SVG `flamegraph.js` (plain + red/green diff, zoom). "Profiles" nav added.

**Code-review fixes (same PR):** LongIntMap Fibonacci-hash now uses top `log2(cap)` bits (was top 24 → clustering on large dumps); HPROF instance reads capped at record dataSize + negative array lengths rejected (stream-misalignment guards); Netty body cap 1 MB → 16 MB (the 8 MB ingest check was dead under the old limit); `--dominators=<negative>` clamped.

## Test plan
- [x] `./gradlew :argus-diagnostics:test :argus-aggregator:test :argus-cli:test :argus-server:compileJava :argus-frontend:compileJava` → BUILD SUCCESSFUL
- [x] heapgraph: `DominatorTreeTest` (6) + `HprofGraphBuilderTest` (1, real HPROF fixture w/ planted leak)
- [x] aggregator: `FlameTreeTest` (4) + `ProfileControllerTest` (6, ingest→query roundtrip + diff deltas)
- [x] `node --check` on flamegraph.js + profiles.js
- [ ] CI matrix + DCO + code-quality + runtime smoke
- [ ] Live QA — deferred to maintainer post-merge (per request)

## Deferred (noted)
`ProfileStore.merged()` does a double full-file read per segment and races benignly with eviction (a query straddling the 1-min boundary can under-count) — perf/robustness follow-up, not a correctness defect.

🤖 Phase 2 of the JVM-OSS parity roadmap.