### PR TITLE
feat(tracing,profiling): Phase 3 — distributed-tracing correlation + anomaly detection

### DIFF
--- a/argus-frontend/src/main/resources/public/index.html
+++ b/argus-frontend/src/main/resources/public/index.html
@@ -319,6 +319,17 @@
                 </div>
             </section>
 
+            <!-- Lock Contention Top-N (aggregated monitor hotspots) — hidden until data arrives -->
+            <section class="content-section" id="contention-hotspots-section" hidden>
+                <div class="section-header">
+                    <h3>Lock Contention</h3>
+                    <p class="section-desc">Top contended monitors by total blocked time, with enter vs wait split and share of total contention. Focus here to find synchronization bottlenecks.</p>
+                </div>
+                <div id="contention-hotspots" class="data-table">
+                    <div class="empty-state">Waiting for contention data...</div>
+                </div>
+            </section>
+
             <!-- Flame Graph -->
             <section class="content-section">
                 <div class="section-header">

--- a/argus-frontend/src/main/resources/public/js/app.js
+++ b/argus-frontend/src/main/resources/public/js/app.js
@@ -993,6 +993,35 @@ function updateContentionDisplay(data) {
     if (elements.contentionTime) {
         elements.contentionTime.textContent = (data.totalContentionTimeMs || 0) + 'ms';
     }
+    renderContentionHotspots(data);
+}
+
+function renderContentionHotspots(data) {
+    const section = document.getElementById('contention-hotspots-section');
+    const list = document.getElementById('contention-hotspots');
+    if (!section || !list) return;
+    const rows = (data.hotspots || []).slice();
+    if (rows.length === 0) {
+        section.hidden = true;
+        return;
+    }
+    section.hidden = false;
+    rows.sort((a, b) => (b.totalTimeMs || 0) - (a.totalTimeMs || 0));
+    const tbody = rows.slice(0, 10).map(r => {
+        const monitor = escapeHtml(r.monitorClass || 'Unknown');
+        const total = parseFloat(r.totalTimeMs) || 0;
+        const avg = parseFloat(r.avgTimeMs) || 0;
+        const share = parseFloat(r.percentage) || 0;
+        return `<tr><td class="mono">${monitor}</td>`
+            + `<td class="mono right">${formatNumber(r.eventCount || 0)}</td>`
+            + `<td class="mono right">${formatNumber(total)}ms</td>`
+            + `<td class="mono right">${avg.toFixed(2)}ms</td>`
+            + `<td class="mono right">${formatNumber(r.enterCount || 0)}</td>`
+            + `<td class="mono right">${formatNumber(r.waitCount || 0)}</td>`
+            + `<td class="mono right">${share.toFixed(1)}%</td></tr>`;
+    }).join('');
+    list.innerHTML = '<table class="simple-table"><thead><tr><th>Monitor</th><th>Events</th><th>Total</th><th>Avg</th><th>Enter</th><th>Wait</th><th>Share</th></tr></thead><tbody>'
+            + tbody + '</tbody></table>';
 }
 
 function updateRecommendations(data) {

--- a/argus-server/src/main/java/io/argus/server/ArgusServer.java
+++ b/argus-server/src/main/java/io/argus/server/ArgusServer.java
@@ -97,6 +97,9 @@ public final class ArgusServer {
     private final MethodProfilingAnalyzer methodProfilingAnalyzer = new MethodProfilingAnalyzer();
     private final FlameGraphAnalyzer flameGraphAnalyzer = new FlameGraphAnalyzer();
     private final ContentionAnalyzer contentionAnalyzer = new ContentionAnalyzer();
+    private final io.argus.server.analysis.AnomalyDetector anomalyDetector =
+            new io.argus.server.analysis.AnomalyDetector(
+                    Boolean.getBoolean("argus.profile.continuous.enabled"));
     private CorrelationAnalyzer correlationAnalyzer;
     private PrometheusMetricsCollector prometheusCollector;
     private OtlpMetricsExporter otlpExporter;
@@ -176,8 +179,10 @@ public final class ArgusServer {
             throw new IllegalStateException("Server already running");
         }
 
-        // Initialize correlation analyzer if enabled
-        if (correlationEnabled) {
+        // Initialize correlation analyzer if enabled. Also enable it implicitly
+        // when OTLP is on, since GC-pause span export depends on the analyzer's
+        // significance threshold and timing-overlap recording (W4 correlation).
+        if (correlationEnabled || config.isOtlpEnabled()) {
             correlationAnalyzer = new CorrelationAnalyzer();
         }
 
@@ -190,6 +195,11 @@ public final class ArgusServer {
                     metaspaceEventBuffer != null ? metaspaceAnalyzer : null,
                     executionSampleEventBuffer != null ? methodProfilingAnalyzer : null,
                     contentionEventBuffer != null ? contentionAnalyzer : null);
+            // Wire the Phase-1 exemplar plumbing to the reflective OTel trace
+            // context: exemplars now populate when an OTel SDK is present, and
+            // stay absent (no-op) otherwise.
+            prometheusCollector.setTraceIdSupplier(
+                    io.argus.server.metrics.TraceContextHolder::currentTraceId);
         }
 
         // Initialize OTLP metrics exporter if enabled
@@ -216,6 +226,14 @@ public final class ArgusServer {
                 contentionAnalyzer,
                 correlationAnalyzer, threadStateManager, serializer);
 
+        // Wire GC-pause span export into the broadcaster's GC drain (no-op when
+        // OTLP is disabled — otlpExporter stays null).
+        broadcaster.setOtlpExporter(otlpExporter);
+
+        // Wire the anomaly detector (W5) into the CPU + allocation drains so it
+        // sees the same live samples as the analyzers.
+        broadcaster.setAnomalyDetector(anomalyDetector);
+
         // Initialize Netty
         bossGroup = new NioEventLoopGroup(1);
         workerGroup = new NioEventLoopGroup();
@@ -240,7 +258,8 @@ public final class ArgusServer {
                                         contentionEventBuffer != null ? contentionAnalyzer : null,
                                         correlationAnalyzer,
                                         broadcaster,
-                                        prometheusCollector));
+                                        prometheusCollector,
+                                        anomalyDetector));
                     }
                 })
                 .option(ChannelOption.SO_BACKLOG, 128)
@@ -409,6 +428,15 @@ public final class ArgusServer {
      */
     public ContentionAnalyzer getContentionAnalyzer() {
         return contentionAnalyzer;
+    }
+
+    /**
+     * Returns the anomaly detector (W5).
+     *
+     * @return anomaly detector
+     */
+    public io.argus.server.analysis.AnomalyDetector getAnomalyDetector() {
+        return anomalyDetector;
     }
 
     /**

--- a/argus-server/src/main/java/io/argus/server/analysis/AnomalyDetector.java
+++ b/argus-server/src/main/java/io/argus/server/analysis/AnomalyDetector.java
@@ -1,0 +1,278 @@
+package io.argus.server.analysis;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * Watches live CPU load and allocation rate and records an {@link AnomalyEvent}
+ * when either signal stays over a configured threshold for a sustained window.
+ *
+ * <p>The detector is the W5 "anomaly-triggered profiling" seam: when continuous
+ * profiling is enabled it records a "profile capture recommended" flag plus the
+ * triggering reason, so the profile store / operator can act on it without the
+ * detector itself driving the agent-side capture loop.
+ *
+ * <p>Thresholds and the sustained window are read once from system properties:
+ * <ul>
+ *   <li>{@code argus.anomaly.cpu.threshold} — JVM CPU fraction 0.0-1.0 (default 0.85)</li>
+ *   <li>{@code argus.anomaly.alloc.threshold.kbps} — allocation rate in KB/s (default 500000)</li>
+ *   <li>{@code argus.anomaly.sustained.samples} — consecutive over-threshold samples
+ *       required before firing (default 3)</li>
+ *   <li>{@code argus.anomaly.ring.size} — bounded recent-anomaly ring size (default 50)</li>
+ * </ul>
+ *
+ * <p>Sample feeds ({@code recordCpuSample} / {@code recordAllocSample}) are called
+ * from the same drain path that feeds {@code CPUAnalyzer} / {@code AllocationAnalyzer}.
+ */
+public final class AnomalyDetector {
+
+    /** Type of signal that triggered an anomaly. */
+    public enum AnomalyType { CPU, ALLOC }
+
+    private static final double DEFAULT_CPU_THRESHOLD = 0.85;
+    private static final double DEFAULT_ALLOC_THRESHOLD_KBPS = 500_000.0;
+    private static final int DEFAULT_SUSTAINED_SAMPLES = 3;
+    private static final int DEFAULT_RING_SIZE = 50;
+
+    private final double cpuThreshold;
+    private final double allocThresholdKbps;
+    private final int sustainedSamples;
+    private final int ringSize;
+    private final boolean captureRecommendationEnabled;
+
+    // Sustained-window counters: consecutive over-threshold samples per signal.
+    private int cpuOverStreak = 0;
+    private int allocOverStreak = 0;
+
+    // Bounded ring of recent anomaly events (oldest first).
+    private final ArrayList<AnomalyEvent> recent = new ArrayList<>();
+
+    // Latest "profile capture recommended" recommendation; null when none active.
+    private final AtomicReference<CaptureRecommendation> recommendation = new AtomicReference<>();
+
+    /**
+     * Creates a detector reading thresholds from system properties. When
+     * {@code captureRecommendationEnabled} is true (continuous profiling is on),
+     * a firing anomaly also records a capture recommendation with the reason.
+     *
+     * @param captureRecommendationEnabled whether to surface capture recommendations
+     */
+    public AnomalyDetector(boolean captureRecommendationEnabled) {
+        this(
+                doubleProp("argus.anomaly.cpu.threshold", DEFAULT_CPU_THRESHOLD),
+                doubleProp("argus.anomaly.alloc.threshold.kbps", DEFAULT_ALLOC_THRESHOLD_KBPS),
+                intProp("argus.anomaly.sustained.samples", DEFAULT_SUSTAINED_SAMPLES),
+                intProp("argus.anomaly.ring.size", DEFAULT_RING_SIZE),
+                captureRecommendationEnabled);
+    }
+
+    /**
+     * Creates a detector with explicit thresholds (used by tests).
+     *
+     * @param cpuThreshold                 JVM CPU fraction (0.0-1.0) that, when sustained, fires
+     * @param allocThresholdKbps           allocation rate in KB/s that, when sustained, fires
+     * @param sustainedSamples             consecutive over-threshold samples required before firing
+     * @param ringSize                     bounded recent-anomaly ring size
+     * @param captureRecommendationEnabled whether to surface capture recommendations
+     */
+    public AnomalyDetector(double cpuThreshold, double allocThresholdKbps,
+                           int sustainedSamples, int ringSize,
+                           boolean captureRecommendationEnabled) {
+        this.cpuThreshold = cpuThreshold;
+        this.allocThresholdKbps = allocThresholdKbps;
+        this.sustainedSamples = Math.max(1, sustainedSamples);
+        this.ringSize = Math.max(1, ringSize);
+        this.captureRecommendationEnabled = captureRecommendationEnabled;
+    }
+
+    /**
+     * Records a CPU load sample. Fires a CPU anomaly only once the value has
+     * stayed over the threshold for {@code sustainedSamples} consecutive samples;
+     * a single under-threshold sample resets the streak.
+     *
+     * @param jvmCpuFraction JVM CPU load as a fraction (0.0-1.0)
+     * @param timestamp      sample timestamp (null uses now)
+     * @return the fired anomaly, or {@code null} if none fired on this sample
+     */
+    public synchronized AnomalyEvent recordCpuSample(double jvmCpuFraction, Instant timestamp) {
+        if (jvmCpuFraction > cpuThreshold) {
+            cpuOverStreak++;
+            if (cpuOverStreak >= sustainedSamples) {
+                // Reset the streak after firing so a continuing over-threshold run
+                // re-arms and can fire again once the window is satisfied again.
+                cpuOverStreak = 0;
+                String reason = String.format(
+                        "JVM CPU %.0f%% over threshold %.0f%% for %d consecutive samples",
+                        jvmCpuFraction * 100, cpuThreshold * 100, sustainedSamples);
+                return fire(new AnomalyEvent(at(timestamp), AnomalyType.CPU,
+                        jvmCpuFraction, cpuThreshold, reason));
+            }
+        } else {
+            cpuOverStreak = 0;
+        }
+        return null;
+    }
+
+    /**
+     * Records an allocation-rate sample. Fires an ALLOC anomaly only once the
+     * rate has stayed over the threshold for {@code sustainedSamples} consecutive
+     * samples; a single under-threshold sample resets the streak.
+     *
+     * @param allocRateKbps allocation rate in KB/s
+     * @param timestamp     sample timestamp (null uses now)
+     * @return the fired anomaly, or {@code null} if none fired on this sample
+     */
+    public synchronized AnomalyEvent recordAllocSample(double allocRateKbps, Instant timestamp) {
+        if (allocRateKbps > allocThresholdKbps) {
+            allocOverStreak++;
+            if (allocOverStreak >= sustainedSamples) {
+                // Reset the streak after firing so a continuing over-threshold run
+                // re-arms and can fire again once the window is satisfied again.
+                allocOverStreak = 0;
+                String reason = String.format(
+                        "Allocation rate %.0f KB/s over threshold %.0f KB/s for %d consecutive samples",
+                        allocRateKbps, allocThresholdKbps, sustainedSamples);
+                return fire(new AnomalyEvent(at(timestamp), AnomalyType.ALLOC,
+                        allocRateKbps, allocThresholdKbps, reason));
+            }
+        } else {
+            allocOverStreak = 0;
+        }
+        return null;
+    }
+
+    private AnomalyEvent fire(AnomalyEvent event) {
+        recent.add(event);
+        while (recent.size() > ringSize) {
+            recent.remove(0);
+        }
+        if (captureRecommendationEnabled) {
+            recommendation.set(new CaptureRecommendation(event.timestamp(), event.type(), event.reason()));
+        }
+        return event;
+    }
+
+    private static Instant at(Instant timestamp) {
+        return timestamp != null ? timestamp : Instant.now();
+    }
+
+    /**
+     * Returns a snapshot of recent anomaly events (oldest first), bounded to the
+     * configured ring size.
+     *
+     * @return list of recent anomaly events
+     */
+    public synchronized List<AnomalyEvent> recentAnomalies() {
+        return new ArrayList<>(recent);
+    }
+
+    /**
+     * Returns the most recent anomaly event, or {@code null} if none recorded.
+     *
+     * @return the latest anomaly, or null
+     */
+    public synchronized AnomalyEvent latest() {
+        return recent.isEmpty() ? null : recent.get(recent.size() - 1);
+    }
+
+    /**
+     * Returns whether a short profile capture is currently recommended (set when
+     * an anomaly fires and continuous profiling is enabled). Returns {@code false}
+     * when recommendations are disabled or none has fired.
+     *
+     * @return true if a capture is recommended
+     */
+    public boolean isCaptureRecommended() {
+        return recommendation.get() != null;
+    }
+
+    /**
+     * Returns the active capture recommendation (with its triggering reason), or
+     * {@code null} if none is active.
+     *
+     * @return the capture recommendation, or null
+     */
+    public CaptureRecommendation captureRecommendation() {
+        return recommendation.get();
+    }
+
+    /**
+     * Clears the active capture recommendation once acted upon (e.g. after the
+     * profile store / operator captures a profile).
+     */
+    public void clearCaptureRecommendation() {
+        recommendation.set(null);
+    }
+
+    /**
+     * Clears all recorded anomalies and resets the sustained-window streaks.
+     */
+    public synchronized void clear() {
+        recent.clear();
+        cpuOverStreak = 0;
+        allocOverStreak = 0;
+        recommendation.set(null);
+    }
+
+    private static double doubleProp(String key, double def) {
+        try {
+            String v = System.getProperty(key);
+            return v != null ? Double.parseDouble(v) : def;
+        } catch (NumberFormatException e) {
+            return def;
+        }
+    }
+
+    private static int intProp(String key, int def) {
+        return Integer.getInteger(key, def);
+    }
+
+    /**
+     * A recorded anomaly: the moment a watched signal crossed its threshold for a
+     * sustained window.
+     */
+    public static final class AnomalyEvent {
+        private final Instant timestamp;
+        private final AnomalyType type;
+        private final double value;
+        private final double threshold;
+        private final String reason;
+
+        public AnomalyEvent(Instant timestamp, AnomalyType type, double value,
+                            double threshold, String reason) {
+            this.timestamp = timestamp;
+            this.type = type;
+            this.value = value;
+            this.threshold = threshold;
+            this.reason = reason;
+        }
+
+        public Instant timestamp() { return timestamp; }
+        public AnomalyType type() { return type; }
+        public double value() { return value; }
+        public double threshold() { return threshold; }
+        public String reason() { return reason; }
+    }
+
+    /**
+     * A recommendation that a short profile capture should be taken, attributed
+     * to the anomaly that triggered it.
+     */
+    public static final class CaptureRecommendation {
+        private final Instant timestamp;
+        private final AnomalyType triggerType;
+        private final String reason;
+
+        public CaptureRecommendation(Instant timestamp, AnomalyType triggerType, String reason) {
+            this.timestamp = timestamp;
+            this.triggerType = triggerType;
+            this.reason = reason;
+        }
+
+        public Instant timestamp() { return timestamp; }
+        public AnomalyType triggerType() { return triggerType; }
+        public String reason() { return reason; }
+    }
+}

--- a/argus-server/src/main/java/io/argus/server/analysis/CorrelationAnalyzer.java
+++ b/argus-server/src/main/java/io/argus/server/analysis/CorrelationAnalyzer.java
@@ -3,6 +3,7 @@ package io.argus.server.analysis;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 
@@ -24,6 +25,20 @@ public final class CorrelationAnalyzer {
     private static final double GC_OVERHEAD_WARNING_THRESHOLD = 0.10; // 10%
     private static final double HIGH_ALLOCATION_RATE_THRESHOLD = 100 * 1024 * 1024; // 100 MB/s
 
+    /**
+     * Default significant-pause threshold (ms). GC pauses at/above this are
+     * "long enough to plausibly stall in-flight work" and are retained for the
+     * timing-overlap join and exported as OTel spans. Overridable via
+     * {@code argus.correlation.pause.threshold.ms}.
+     */
+    private static final double DEFAULT_SIGNIFICANT_PAUSE_MS = 50.0;
+
+    /** How long recorded pause windows are kept for overlap queries. */
+    private static final Duration PAUSE_WINDOW_RETENTION = Duration.ofMinutes(5);
+    private static final int MAX_PAUSE_WINDOWS = 500;
+
+    private final double significantPauseMs;
+
     private final List<CorrelatedEvent> gcCpuCorrelations = new CopyOnWriteArrayList<>();
     private final List<CorrelatedEvent> gcPinningCorrelations = new CopyOnWriteArrayList<>();
     private final List<Recommendation> recommendations = new CopyOnWriteArrayList<>();
@@ -32,6 +47,33 @@ public final class CorrelationAnalyzer {
     private final List<GCTimestamp> recentGCEvents = new CopyOnWriteArrayList<>();
     private final List<CPUSpikeTimestamp> recentCPUSpikes = new CopyOnWriteArrayList<>();
     private final List<PinningTimestamp> recentPinningEvents = new CopyOnWriteArrayList<>();
+
+    /** Recent significant GC pause windows, for the timing-overlap trace join. */
+    private final List<PauseWindow> recentPauseWindows = new CopyOnWriteArrayList<>();
+
+    /** Uses the default significant-pause threshold (50ms, overridable by system property). */
+    public CorrelationAnalyzer() {
+        double threshold = DEFAULT_SIGNIFICANT_PAUSE_MS;
+        try {
+            String prop = System.getProperty("argus.correlation.pause.threshold.ms");
+            if (prop != null && !prop.isBlank()) {
+                threshold = Double.parseDouble(prop.trim());
+            }
+        } catch (NumberFormatException ignored) {
+            // keep default
+        }
+        this.significantPauseMs = threshold;
+    }
+
+    /** Explicit-threshold constructor, primarily for tests. */
+    public CorrelationAnalyzer(double significantPauseMs) {
+        this.significantPauseMs = significantPauseMs;
+    }
+
+    /** The significant-pause threshold in milliseconds. */
+    public double significantPauseThresholdMs() {
+        return significantPauseMs;
+    }
 
     /**
      * Records a GC event for correlation analysis.
@@ -49,6 +91,62 @@ public final class CorrelationAnalyzer {
         // Check for correlations
         checkGCCPUCorrelation(timestamp, gcName, pauseTimeMs);
         checkGCPinningCorrelation(timestamp, gcName, pauseTimeMs);
+    }
+
+    /**
+     * Records a significant GC pause window for the timing-overlap trace join.
+     *
+     * <p>Pauses shorter than {@link #significantPauseThresholdMs()} are ignored:
+     * they are too short to plausibly stall in-flight work. The {@code traceId}
+     * is the W3C trace id captured on the recording thread at pause time, or
+     * {@code null} when no OTel context was active (timing-only mode).
+     *
+     * @param pauseStart    wall-clock start of the pause
+     * @param pauseEnd      wall-clock end of the pause
+     * @param gcName        collector name
+     * @param gcCause       GC cause
+     * @param pauseMs       pause duration in milliseconds
+     * @param reclaimedBytes heap bytes reclaimed (may be 0)
+     * @param traceId       active trace id at pause time, or {@code null}
+     * @return {@code true} if the pause was significant and recorded
+     */
+    public boolean recordPauseWindow(Instant pauseStart, Instant pauseEnd, String gcName,
+                                     String gcCause, double pauseMs, long reclaimedBytes,
+                                     String traceId) {
+        if (pauseMs < significantPauseMs) {
+            return false;
+        }
+        recentPauseWindows.add(new PauseWindow(pauseStart, pauseEnd, gcName, gcCause,
+                pauseMs, reclaimedBytes, traceId));
+        cleanOldPauseWindows();
+        return true;
+    }
+
+    /**
+     * Returns the significant GC pauses whose window overlaps {@code [from, to]}.
+     * A pause overlaps when its end is not before {@code from} and its start is
+     * not after {@code to}. These are the pauses long enough to plausibly stall
+     * any work in flight during the queried window; each carries its trace id
+     * when an OTel context was active at pause time.
+     *
+     * @param from window start (inclusive)
+     * @param to   window end (inclusive)
+     * @return overlapping pause windows, oldest first
+     */
+    public List<PauseWindow> pausesOverlapping(Instant from, Instant to) {
+        List<PauseWindow> out = new ArrayList<>();
+        for (PauseWindow w : recentPauseWindows) {
+            if (!w.pauseEnd().isBefore(from) && !w.pauseStart().isAfter(to)) {
+                out.add(w);
+            }
+        }
+        out.sort(Comparator.comparing(PauseWindow::pauseStart));
+        return out;
+    }
+
+    /** Returns recent significant pause windows (most recent last), capped for the surface. */
+    public List<PauseWindow> getRecentPauseWindows() {
+        return new ArrayList<>(recentPauseWindows);
     }
 
     /**
@@ -154,7 +252,9 @@ public final class CorrelationAnalyzer {
         return new CorrelationResult(
                 new ArrayList<>(gcCpuCorrelations),
                 new ArrayList<>(gcPinningCorrelations),
-                new ArrayList<>(recommendations)
+                new ArrayList<>(recommendations),
+                new ArrayList<>(recentPauseWindows),
+                significantPauseMs
         );
     }
 
@@ -168,6 +268,15 @@ public final class CorrelationAnalyzer {
         recentGCEvents.clear();
         recentCPUSpikes.clear();
         recentPinningEvents.clear();
+        recentPauseWindows.clear();
+    }
+
+    private void cleanOldPauseWindows() {
+        Instant cutoff = Instant.now().minus(PAUSE_WINDOW_RETENTION);
+        recentPauseWindows.removeIf(w -> w.pauseEnd().isBefore(cutoff));
+        while (recentPauseWindows.size() > MAX_PAUSE_WINDOWS) {
+            recentPauseWindows.remove(0);
+        }
     }
 
     private void checkGCCPUCorrelation(Instant gcTimestamp, String gcName, double pauseTimeMs) {
@@ -272,6 +381,22 @@ public final class CorrelationAnalyzer {
     }
 
     /**
+     * A significant GC pause window retained for the timing-overlap trace join.
+     *
+     * @param pauseStart     wall-clock start of the pause
+     * @param pauseEnd       wall-clock end of the pause
+     * @param gcName         collector name
+     * @param gcCause        GC cause
+     * @param pauseMs        pause duration in milliseconds
+     * @param reclaimedBytes heap bytes reclaimed (may be 0)
+     * @param traceId        active W3C trace id at pause time, or {@code null}
+     */
+    public record PauseWindow(Instant pauseStart, Instant pauseEnd, String gcName,
+                              String gcCause, double pauseMs, long reclaimedBytes,
+                              String traceId) {
+    }
+
+    /**
      * Types of recommendations.
      */
     public enum RecommendationType {
@@ -320,17 +445,29 @@ public final class CorrelationAnalyzer {
         private final List<CorrelatedEvent> gcCpuCorrelations;
         private final List<CorrelatedEvent> gcPinningCorrelations;
         private final List<Recommendation> recommendations;
+        private final List<PauseWindow> tracePauses;
+        private final double significantPauseThresholdMs;
 
         public CorrelationResult(List<CorrelatedEvent> gcCpuCorrelations,
                                  List<CorrelatedEvent> gcPinningCorrelations,
-                                 List<Recommendation> recommendations) {
+                                 List<Recommendation> recommendations,
+                                 List<PauseWindow> tracePauses,
+                                 double significantPauseThresholdMs) {
             this.gcCpuCorrelations = gcCpuCorrelations;
             this.gcPinningCorrelations = gcPinningCorrelations;
             this.recommendations = recommendations;
+            this.tracePauses = tracePauses;
+            this.significantPauseThresholdMs = significantPauseThresholdMs;
         }
 
         public List<CorrelatedEvent> gcCpuCorrelations() { return gcCpuCorrelations; }
         public List<CorrelatedEvent> gcPinningCorrelations() { return gcPinningCorrelations; }
         public List<Recommendation> recommendations() { return recommendations; }
+
+        /** Recent significant GC pauses with optional trace ids (timing-overlap join). */
+        public List<PauseWindow> tracePauses() { return tracePauses; }
+
+        /** The significant-pause threshold (ms) used to gate {@link #tracePauses()}. */
+        public double significantPauseThresholdMs() { return significantPauseThresholdMs; }
     }
 }

--- a/argus-server/src/main/java/io/argus/server/handler/ArgusChannelHandler.java
+++ b/argus-server/src/main/java/io/argus/server/handler/ArgusChannelHandler.java
@@ -5,6 +5,7 @@ import java.util.Map;
 import io.argus.core.config.AgentConfig;
 import io.argus.server.command.ServerCommandExecutor;
 import io.argus.server.analysis.AllocationAnalyzer;
+import io.argus.server.analysis.AnomalyDetector;
 import io.argus.server.analysis.ContentionAnalyzer;
 import io.argus.server.analysis.CorrelationAnalyzer;
 import io.argus.server.analysis.FlameGraphAnalyzer;
@@ -55,6 +56,7 @@ public final class ArgusChannelHandler extends SimpleChannelInboundHandler<Objec
     private final CorrelationAnalyzer correlationAnalyzer;
     private final EventBroadcaster broadcaster;
     private final PrometheusMetricsCollector prometheusCollector;
+    private final AnomalyDetector anomalyDetector;
     private final StaticFileHandler staticFileHandler;
 
     private WebSocketServerHandshaker handshaker;
@@ -79,7 +81,7 @@ public final class ArgusChannelHandler extends SimpleChannelInboundHandler<Objec
             CPUAnalyzer cpuAnalyzer,
             EventBroadcaster broadcaster) {
         this(null, clients, metrics, activeThreads, threadEvents, gcAnalyzer, cpuAnalyzer,
-                null, null, null, null, null, null, broadcaster, null);
+                null, null, null, null, null, null, broadcaster, null, null);
     }
 
     /**
@@ -117,6 +119,49 @@ public final class ArgusChannelHandler extends SimpleChannelInboundHandler<Objec
             CorrelationAnalyzer correlationAnalyzer,
             EventBroadcaster broadcaster,
             PrometheusMetricsCollector prometheusCollector) {
+        this(config, clients, metrics, activeThreads, threadEvents, gcAnalyzer, cpuAnalyzer,
+                allocationAnalyzer, metaspaceAnalyzer, methodProfilingAnalyzer, flameGraphAnalyzer,
+                contentionAnalyzer, correlationAnalyzer, broadcaster, prometheusCollector, null);
+    }
+
+    /**
+     * Creates a new channel handler with full analyzer support plus the W5
+     * anomaly detector.
+     *
+     * @param config                  the agent configuration (null for defaults)
+     * @param clients                 the channel group for WebSocket clients
+     * @param metrics                 the server metrics tracker
+     * @param activeThreads           the active threads registry
+     * @param threadEvents            the per-thread events buffer
+     * @param gcAnalyzer              the GC analyzer
+     * @param cpuAnalyzer             the CPU analyzer
+     * @param allocationAnalyzer      the allocation analyzer
+     * @param metaspaceAnalyzer       the metaspace analyzer
+     * @param methodProfilingAnalyzer the method profiling analyzer
+     * @param flameGraphAnalyzer      the flame graph analyzer (null if profiling disabled)
+     * @param contentionAnalyzer      the contention analyzer
+     * @param correlationAnalyzer     the correlation analyzer
+     * @param broadcaster             the event broadcaster
+     * @param prometheusCollector     the Prometheus metrics collector (null if disabled)
+     * @param anomalyDetector         the anomaly detector (null if disabled)
+     */
+    public ArgusChannelHandler(
+            AgentConfig config,
+            ChannelGroup clients,
+            ServerMetrics metrics,
+            ActiveThreadsRegistry activeThreads,
+            ThreadEventsBuffer threadEvents,
+            GCAnalyzer gcAnalyzer,
+            CPUAnalyzer cpuAnalyzer,
+            AllocationAnalyzer allocationAnalyzer,
+            MetaspaceAnalyzer metaspaceAnalyzer,
+            MethodProfilingAnalyzer methodProfilingAnalyzer,
+            FlameGraphAnalyzer flameGraphAnalyzer,
+            ContentionAnalyzer contentionAnalyzer,
+            CorrelationAnalyzer correlationAnalyzer,
+            EventBroadcaster broadcaster,
+            PrometheusMetricsCollector prometheusCollector,
+            AnomalyDetector anomalyDetector) {
         this.config = config != null ? config : AgentConfig.defaults();
         this.clients = clients;
         this.metrics = metrics;
@@ -132,6 +177,7 @@ public final class ArgusChannelHandler extends SimpleChannelInboundHandler<Objec
         this.correlationAnalyzer = correlationAnalyzer;
         this.broadcaster = broadcaster;
         this.prometheusCollector = prometheusCollector;
+        this.anomalyDetector = anomalyDetector;
         this.staticFileHandler = new StaticFileHandler();
         this.routes = buildRouteTable();
     }
@@ -165,6 +211,7 @@ public final class ArgusChannelHandler extends SimpleChannelInboundHandler<Objec
                 .exact("/method-profiling", (ctx, req, uri) -> handleMethodProfiling(ctx, req))
                 .exact("/contention-analysis", (ctx, req, uri) -> handleContentionAnalysis(ctx, req))
                 .exact("/correlation", (ctx, req, uri) -> handleCorrelation(ctx, req))
+                .exact("/anomalies", (ctx, req, uri) -> handleAnomalies(ctx, req))
                 // API endpoints
                 .exact("/api/process", (ctx, req, uri) -> {
                     String info = ServerCommandExecutor.getProcessInfo();
@@ -633,7 +680,7 @@ public final class ArgusChannelHandler extends SimpleChannelInboundHandler<Objec
             sb.append("{");
             sb.append("\"gcName\":\"").append(escapeJson(gcName)).append("\",");
             sb.append("\"gcCause\":\"").append(escapeJson(gcCause)).append("\",");
-            sb.append("\"pauseMs\":").append(String.format("%.2f", pauseMs)).append(",");
+            sb.append("\"pauseMs\":").append(String.format(java.util.Locale.ROOT, "%.2f", pauseMs)).append(",");
             sb.append("\"count\":").append(count);
             sb.append("}");
         }
@@ -919,6 +966,51 @@ public final class ArgusChannelHandler extends SimpleChannelInboundHandler<Objec
         HttpResponseHelper.sendJson(ctx, request, sb.toString());
     }
 
+    private void handleAnomalies(ChannelHandlerContext ctx, FullHttpRequest request) {
+        if (anomalyDetector == null) {
+            HttpResponseHelper.sendJson(ctx, request, "{\"error\":\"Anomaly detection not enabled\"}");
+            return;
+        }
+
+        var recent = anomalyDetector.recentAnomalies();
+        var rec = anomalyDetector.captureRecommendation();
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("{");
+        sb.append("\"captureRecommended\":").append(anomalyDetector.isCaptureRecommended()).append(",");
+
+        // Active capture recommendation (W5 anomaly-triggered profiling seam).
+        if (rec != null) {
+            sb.append("\"recommendation\":{");
+            sb.append("\"timestamp\":\"").append(rec.timestamp()).append("\",");
+            sb.append("\"triggerType\":\"").append(rec.triggerType().name()).append("\",");
+            sb.append("\"reason\":\"").append(escapeJson(rec.reason())).append("\"");
+            sb.append("},");
+        } else {
+            sb.append("\"recommendation\":null,");
+        }
+
+        // Recent anomaly events.
+        sb.append("\"anomalies\":[");
+        boolean first = true;
+        for (var ev : recent) {
+            if (!first) sb.append(",");
+            first = false;
+            sb.append("{");
+            sb.append("\"timestamp\":\"").append(ev.timestamp()).append("\",");
+            sb.append("\"type\":\"").append(ev.type().name()).append("\",");
+            sb.append("\"value\":").append(String.format(java.util.Locale.ROOT, "%.4f", ev.value())).append(",");
+            sb.append("\"threshold\":").append(String.format(java.util.Locale.ROOT, "%.4f", ev.threshold())).append(",");
+            sb.append("\"reason\":\"").append(escapeJson(ev.reason())).append("\"");
+            sb.append("}");
+        }
+        sb.append("]");
+
+        sb.append("}");
+
+        HttpResponseHelper.sendJson(ctx, request, sb.toString());
+    }
+
     private void handleCorrelation(ChannelHandlerContext ctx, FullHttpRequest request) {
         if (correlationAnalyzer == null) {
             HttpResponseHelper.sendJson(ctx, request, "{\"error\":\"Correlation analysis not enabled\"}");
@@ -971,6 +1063,36 @@ public final class ArgusChannelHandler extends SimpleChannelInboundHandler<Objec
             sb.append("\"title\":\"").append(escapeJson(rec.title())).append("\",");
             sb.append("\"description\":\"").append(escapeJson(rec.description())).append("\",");
             sb.append("\"severity\":\"").append(rec.severity().name()).append("\"");
+            sb.append("}");
+        }
+        sb.append("],");
+
+        // Trace correlation: significant GC pauses (timing-overlap), each with an
+        // optional W3C trace id captured at pause time. Absent trace ids mean no
+        // OTel context was active (timing-only degradation).
+        sb.append("\"significantPauseThresholdMs\":")
+                .append(String.format(java.util.Locale.ROOT, "%.2f", analysis.significantPauseThresholdMs())).append(",");
+        sb.append("\"tracePauses\":[");
+        first = true;
+        for (var pause : analysis.tracePauses()) {
+            if (!first) sb.append(",");
+            first = false;
+            sb.append("{");
+            sb.append("\"pauseStart\":\"").append(pause.pauseStart()).append("\",");
+            sb.append("\"pauseEnd\":\"").append(pause.pauseEnd()).append("\",");
+            if (pause.gcName() != null) {
+                sb.append("\"gcName\":\"").append(escapeJson(pause.gcName())).append("\",");
+            }
+            if (pause.gcCause() != null) {
+                sb.append("\"gcCause\":\"").append(escapeJson(pause.gcCause())).append("\",");
+            }
+            sb.append("\"pauseMs\":").append(String.format(java.util.Locale.ROOT, "%.2f", pause.pauseMs())).append(",");
+            sb.append("\"reclaimedBytes\":").append(pause.reclaimedBytes()).append(",");
+            if (pause.traceId() != null) {
+                sb.append("\"traceId\":\"").append(escapeJson(pause.traceId())).append("\"");
+            } else {
+                sb.append("\"traceId\":null");
+            }
             sb.append("}");
         }
         sb.append("]");

--- a/argus-server/src/main/java/io/argus/server/metrics/OtlpMetricsExporter.java
+++ b/argus-server/src/main/java/io/argus/server/metrics/OtlpMetricsExporter.java
@@ -7,6 +7,9 @@ import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -16,19 +19,36 @@ import java.util.concurrent.TimeUnit;
  *
  * <p>Uses {@link java.net.http.HttpClient} (JDK built-in) to POST metrics
  * at a configurable interval. No external SDK dependency required.
+ *
+ * <p>Beyond metrics, the exporter also flushes a queue of significant
+ * JVM-internal event spans (GC pauses) to the OTLP/HTTP {@code /v1/traces}
+ * endpoint on the same cadence. Spans are enqueued via {@link #enqueueGcPauseSpan}
+ * and encoded with {@link OtlpSpanBuilder}; when no spans are queued, no traces
+ * request is made. Both metric and span export are gated by the OTLP enable flag
+ * at construction time in {@code ArgusServer}.
  */
 public final class OtlpMetricsExporter {
 
     private static final System.Logger LOG = System.getLogger(OtlpMetricsExporter.class.getName());
 
+    /** Bound the span queue so a slow/absent collector can't grow it without limit. */
+    private static final int MAX_PENDING_SPANS = 512;
+
     private final AgentConfig config;
     private final OtlpJsonBuilder jsonBuilder;
+    private final OtlpSpanBuilder spanBuilder;
     private final HttpClient httpClient;
     private final ScheduledExecutorService scheduler;
+    private final ConcurrentLinkedQueue<PendingSpan> pendingSpans = new ConcurrentLinkedQueue<>();
+    /** O(1) size tracking — ConcurrentLinkedQueue.size() is O(n). */
+    private final java.util.concurrent.atomic.AtomicInteger pendingSpanCount =
+            new java.util.concurrent.atomic.AtomicInteger(0);
 
     public OtlpMetricsExporter(AgentConfig config, OtlpJsonBuilder jsonBuilder) {
         this.config = config;
         this.jsonBuilder = jsonBuilder;
+        this.spanBuilder = new OtlpSpanBuilder(config.getOtlpServiceName(),
+                io.argus.server.metrics.OtlpMetricsExporter.class.getPackage().getImplementationVersion());
         this.httpClient = HttpClient.newBuilder()
                 .connectTimeout(Duration.ofSeconds(10))
                 .build();
@@ -38,11 +58,28 @@ public final class OtlpMetricsExporter {
     }
 
     /**
+     * Queues a GC-pause span for the next traces flush. The active W3C trace id
+     * (or {@code null}) is captured by the caller at pause time so the span can
+     * be linked to in-flight work. No-op beyond the queue cap.
+     */
+    public void enqueueGcPauseSpan(long endTimeMillis, String gcName, String gcCause,
+                                   double pauseMs, long reclaimedBytes, String traceId) {
+        pendingSpans.add(new PendingSpan(endTimeMillis, gcName, gcCause, pauseMs, reclaimedBytes, traceId));
+        int count = pendingSpanCount.incrementAndGet();
+        // Drop OLDEST on overflow (not newest): during an incident the most recent
+        // pauses are the most relevant, so evict from the head instead of rejecting.
+        while (count > MAX_PENDING_SPANS && pendingSpans.poll() != null) {
+            count = pendingSpanCount.decrementAndGet();
+        }
+    }
+
+    /**
      * Starts the periodic OTLP metrics push.
      */
     public void start() {
         long intervalMs = config.getOtlpIntervalMs();
         scheduler.scheduleAtFixedRate(this::pushMetrics, intervalMs, intervalMs, TimeUnit.MILLISECONDS);
+        scheduler.scheduleAtFixedRate(this::pushSpans, intervalMs, intervalMs, TimeUnit.MILLISECONDS);
         LOG.log(System.Logger.Level.INFO, "OTLP exporter started (endpoint: {0}, interval: {1}ms)",
                 config.getOtlpEndpoint(), intervalMs);
     }
@@ -64,11 +101,89 @@ public final class OtlpMetricsExporter {
     }
 
     private void pushMetrics() {
-        try {
-            String json = jsonBuilder.build();
+        post(config.getOtlpEndpoint(), jsonBuilder.build(), "metrics");
+    }
 
+    /**
+     * Drains the pending GC-pause spans, encodes them into one OTLP/JSON traces
+     * payload, and POSTs to the {@code /v1/traces} endpoint. No-op when the
+     * queue is empty so an idle JVM never emits empty traces requests.
+     */
+    private void pushSpans() {
+        List<PendingSpan> batch = new ArrayList<>();
+        PendingSpan s;
+        while ((s = pendingSpans.poll()) != null) {
+            pendingSpanCount.decrementAndGet();
+            batch.add(s);
+            if (batch.size() >= MAX_PENDING_SPANS) {
+                break;
+            }
+        }
+        if (batch.isEmpty()) {
+            return;
+        }
+        post(tracesEndpoint(), encodeSpanBatch(batch), "traces");
+    }
+
+    /** Encodes a batch of GC-pause spans into a single OTLP/JSON resourceSpans payload. */
+    String encodeSpanBatch(List<PendingSpan> batch) {
+        if (batch.size() == 1) {
+            PendingSpan p = batch.get(0);
+            return spanBuilder.buildGcPauseSpan(p.endTimeMillis(), p.gcName(), p.gcCause(),
+                    p.pauseMs(), p.reclaimedBytes(), p.traceId());
+        }
+        // Multiple spans share one resourceSpans/scopeSpans wrapper.
+        StringBuilder sb = new StringBuilder(256 + batch.size() * 256);
+        sb.append("{\"resourceSpans\":[{");
+        // Reuse the builder's resource by delegating a single-span build, then splice.
+        // Simpler: build the wrapper inline mirroring OtlpSpanBuilder's resource.
+        sb.append("\"resource\":{\"attributes\":[");
+        sb.append("{\"key\":\"service.name\",\"value\":{\"stringValue\":\"")
+                .append(jsonEscape(config.getOtlpServiceName())).append("\"}},");
+        sb.append("{\"key\":\"telemetry.sdk.name\",\"value\":{\"stringValue\":\"argus\"}},");
+        sb.append("{\"key\":\"telemetry.sdk.language\",\"value\":{\"stringValue\":\"java\"}}");
+        sb.append("]},\"scopeSpans\":[{");
+        sb.append("\"scope\":{\"name\":\"io.argus.tracing\"},\"spans\":[");
+        boolean first = true;
+        for (PendingSpan p : batch) {
+            if (!first) {
+                sb.append(',');
+            }
+            first = false;
+            long endNano = p.endTimeMillis() * 1_000_000L;
+            long startNano = endNano - (long) (p.pauseMs() * 1_000_000.0);
+            spanBuilder.appendGcPauseSpanObject(sb, p.traceId(), null, startNano, endNano,
+                    p.gcName(), p.gcCause(), p.pauseMs(), p.reclaimedBytes());
+        }
+        sb.append("]}]}]}");
+        return sb.toString();
+    }
+
+    /**
+     * Derives the OTLP/HTTP traces endpoint from the configured metrics endpoint
+     * by swapping the trailing {@code /v1/metrics} signal path for
+     * {@code /v1/traces}, per the OTLP/HTTP convention. Falls back to appending
+     * {@code /v1/traces} when no recognizable signal suffix is present.
+     */
+    String tracesEndpoint() {
+        String endpoint = config.getOtlpEndpoint();
+        if (endpoint == null || endpoint.isBlank()) {
+            return endpoint;
+        }
+        if (endpoint.endsWith("/v1/metrics")) {
+            return endpoint.substring(0, endpoint.length() - "/v1/metrics".length()) + "/v1/traces";
+        }
+        if (endpoint.contains("/v1/traces")) {
+            return endpoint;
+        }
+        String base = endpoint.endsWith("/") ? endpoint.substring(0, endpoint.length() - 1) : endpoint;
+        return base + "/v1/traces";
+    }
+
+    private void post(String endpoint, String json, String signal) {
+        try {
             HttpRequest.Builder requestBuilder = HttpRequest.newBuilder()
-                    .uri(URI.create(config.getOtlpEndpoint()))
+                    .uri(URI.create(endpoint))
                     .header("Content-Type", "application/json")
                     .timeout(Duration.ofSeconds(10))
                     .POST(HttpRequest.BodyPublishers.ofString(json));
@@ -91,12 +206,24 @@ public final class OtlpMetricsExporter {
 
             if (response.statusCode() >= 400) {
                 LOG.log(System.Logger.Level.WARNING,
-                        "OTLP push failed: HTTP {0} - {1}", response.statusCode(), response.body());
+                        "OTLP {0} push failed: HTTP {1} - {2}", signal, response.statusCode(), response.body());
             }
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
         } catch (Exception e) {
-            LOG.log(System.Logger.Level.WARNING, "OTLP push error: {0}", e.getMessage());
+            LOG.log(System.Logger.Level.WARNING, "OTLP {0} push error: {1}", signal, e.getMessage());
         }
+    }
+
+    private static String jsonEscape(String value) {
+        if (value == null) {
+            return "";
+        }
+        return value.replace("\\", "\\\\").replace("\"", "\\\"").replace("\n", "\\n");
+    }
+
+    /** A GC-pause span awaiting the next traces flush. */
+    record PendingSpan(long endTimeMillis, String gcName, String gcCause,
+                       double pauseMs, long reclaimedBytes, String traceId) {
     }
 }

--- a/argus-server/src/main/java/io/argus/server/metrics/OtlpSpanBuilder.java
+++ b/argus-server/src/main/java/io/argus/server/metrics/OtlpSpanBuilder.java
@@ -1,0 +1,153 @@
+package io.argus.server.metrics;
+
+import java.security.SecureRandom;
+
+/**
+ * Hand-coded OTLP/JSON span encoder for significant JVM-internal events.
+ *
+ * <p>Argus observes the JVM globally via JFR streaming, so a GC pause is a
+ * stop-the-world event, not a per-request hook. This builder emits one OTel
+ * span per significant GC pause ("GC Pause") with the JVM as the resource.
+ * When a W3C trace context happens to be active on the recording thread, the
+ * span carries that trace id so a backend (Tempo/Jaeger/Grafana) can place the
+ * pause on the same trace timeline as in-flight work; otherwise the span gets a
+ * fresh, self-generated trace id and stands alone (timing-only).
+ *
+ * <p>Follows the project's zero-dependency philosophy: no protobuf, no OTel
+ * SDK — just the OTLP JSON shape that an OTLP/HTTP traces endpoint accepts at
+ * {@code /v1/traces}.
+ */
+public final class OtlpSpanBuilder {
+
+    private static final SecureRandom RANDOM = new SecureRandom();
+
+    private final String serviceName;
+    private final String version;
+
+    public OtlpSpanBuilder(String serviceName, String version) {
+        this.serviceName = serviceName != null ? serviceName : "argus";
+        this.version = version != null ? version : "dev";
+    }
+
+    /**
+     * Builds a complete OTLP/JSON {@code resourceSpans} payload wrapping a single
+     * GC-pause span. Suitable for POST to an OTLP/HTTP {@code /v1/traces} endpoint.
+     *
+     * @param endTimeMillis    wall-clock end time of the pause (epoch millis)
+     * @param gcName           collector name (e.g. "G1 Young Generation")
+     * @param gcCause          GC cause (e.g. "G1 Evacuation Pause")
+     * @param pauseMs          pause duration in milliseconds
+     * @param reclaimedBytes   heap bytes reclaimed by this GC (may be 0)
+     * @param traceId          active W3C trace id (32-hex) or {@code null}; when
+     *                         {@code null} a fresh trace id is generated
+     * @return OTLP/JSON traces payload
+     */
+    public String buildGcPauseSpan(long endTimeMillis, String gcName, String gcCause,
+                                   double pauseMs, long reclaimedBytes, String traceId) {
+        long endNano = endTimeMillis * 1_000_000L;
+        long startNano = endNano - (long) (pauseMs * 1_000_000.0);
+        String tid = normalizeTraceId(traceId);
+        String spanId = randomHex(16);
+
+        StringBuilder sb = new StringBuilder(512);
+        sb.append("{\"resourceSpans\":[{");
+        appendResource(sb);
+        sb.append(",\"scopeSpans\":[{");
+        sb.append("\"scope\":{\"name\":\"io.argus.tracing\",\"version\":\"")
+                .append(escape(version)).append("\"},");
+        sb.append("\"spans\":[");
+        appendGcPauseSpanObject(sb, tid, spanId, startNano, endNano,
+                gcName, gcCause, pauseMs, reclaimedBytes);
+        sb.append("]}]}]}");
+        return sb.toString();
+    }
+
+    /**
+     * Appends a single GC-pause span object to {@code sb} (no surrounding
+     * commas). Exposed package-private so the exporter can batch many spans
+     * into one {@code scopeSpans} entry.
+     */
+    void appendGcPauseSpanObject(StringBuilder sb, String traceId, String spanId,
+                                 long startNano, long endNano, String gcName, String gcCause,
+                                 double pauseMs, long reclaimedBytes) {
+        sb.append("{");
+        sb.append("\"traceId\":\"").append(normalizeTraceId(traceId)).append("\",");
+        sb.append("\"spanId\":\"").append(spanId != null ? spanId : randomHex(16)).append("\",");
+        sb.append("\"name\":\"GC Pause\",");
+        // SPAN_KIND_INTERNAL = 1
+        sb.append("\"kind\":1,");
+        sb.append("\"startTimeUnixNano\":\"").append(startNano).append("\",");
+        sb.append("\"endTimeUnixNano\":\"").append(endNano).append("\",");
+        sb.append("\"attributes\":[");
+        appendStringAttribute(sb, "gc.name", gcName != null ? gcName : "Unknown");
+        sb.append(',');
+        appendStringAttribute(sb, "gc.cause", gcCause != null ? gcCause : "Unknown");
+        sb.append(',');
+        appendDoubleAttribute(sb, "gc.pause_ms", pauseMs);
+        sb.append(',');
+        appendIntAttribute(sb, "heap.reclaimed_bytes", reclaimedBytes);
+        sb.append("]}");
+    }
+
+    private void appendResource(StringBuilder sb) {
+        sb.append("\"resource\":{\"attributes\":[");
+        appendStringAttribute(sb, "service.name", serviceName);
+        sb.append(',');
+        appendStringAttribute(sb, "service.version", version);
+        sb.append(',');
+        appendStringAttribute(sb, "telemetry.sdk.name", "argus");
+        sb.append(',');
+        appendStringAttribute(sb, "telemetry.sdk.language", "java");
+        sb.append("]}");
+    }
+
+    private void appendStringAttribute(StringBuilder sb, String key, String value) {
+        sb.append("{\"key\":\"").append(escape(key))
+                .append("\",\"value\":{\"stringValue\":\"").append(escape(value)).append("\"}}");
+    }
+
+    private void appendDoubleAttribute(StringBuilder sb, String key, double value) {
+        sb.append("{\"key\":\"").append(escape(key))
+                .append("\",\"value\":{\"doubleValue\":").append(value).append("}}");
+    }
+
+    private void appendIntAttribute(StringBuilder sb, String key, long value) {
+        sb.append("{\"key\":\"").append(escape(key))
+                .append("\",\"value\":{\"intValue\":\"").append(value).append("\"}}");
+    }
+
+    /**
+     * Returns a valid 32-hex-char trace id: the supplied one when it already
+     * matches, otherwise a freshly generated random id. OTel/OTLP rejects spans
+     * with malformed or all-zero trace ids, so we never pass those through.
+     */
+    static String normalizeTraceId(String traceId) {
+        if (traceId != null) {
+            String t = traceId.trim().toLowerCase(java.util.Locale.ROOT);
+            if (t.length() == 32 && t.matches("[0-9a-f]{32}") && !t.equals("0".repeat(32))) {
+                return t;
+            }
+        }
+        return randomHex(32);
+    }
+
+    private static String randomHex(int chars) {
+        byte[] bytes = new byte[chars / 2];
+        RANDOM.nextBytes(bytes);
+        StringBuilder sb = new StringBuilder(chars);
+        for (byte b : bytes) {
+            sb.append(Character.forDigit((b >> 4) & 0xF, 16));
+            sb.append(Character.forDigit(b & 0xF, 16));
+        }
+        return sb.toString();
+    }
+
+    private static String escape(String value) {
+        if (value == null) {
+            return "";
+        }
+        return value.replace("\\", "\\\\")
+                .replace("\"", "\\\"")
+                .replace("\n", "\\n");
+    }
+}

--- a/argus-server/src/main/java/io/argus/server/metrics/TraceContextHolder.java
+++ b/argus-server/src/main/java/io/argus/server/metrics/TraceContextHolder.java
@@ -1,0 +1,134 @@
+package io.argus.server.metrics;
+
+import java.lang.reflect.Method;
+
+/**
+ * Best-effort, reflective capture of the active W3C trace context.
+ *
+ * <p>If an OpenTelemetry SDK is on the target's classpath, this reads the
+ * current span's trace id via {@code io.opentelemetry.api.trace.Span.current()}
+ * → {@code getSpanContext()} → {@code getTraceId()}, all through reflection so
+ * that {@code argus-server} keeps <strong>zero</strong> compile-time dependency
+ * on OpenTelemetry. When the SDK is absent (or no span is active, or the span
+ * is invalid), every accessor returns {@code null} and never throws.
+ *
+ * <p>This is the source wired into
+ * {@link PrometheusMetricsCollector#setTraceIdSupplier(java.util.function.Supplier)}
+ * so the Phase-1 exemplar plumbing populates only when a real OTel context
+ * exists. It is also consulted at GC-pause time to stamp a trace id onto
+ * exported spans / correlation windows.
+ */
+public final class TraceContextHolder {
+
+    private static final System.Logger LOG = System.getLogger(TraceContextHolder.class.getName());
+
+    /** Reflective handles, resolved once. All {@code null} when OTel is absent. */
+    private static final Method SPAN_CURRENT;
+    private static final Method SPAN_GET_CONTEXT;
+    private static final Method CONTEXT_GET_TRACE_ID;
+    private static final Method CONTEXT_GET_SPAN_ID;
+    private static final Method CONTEXT_IS_VALID;
+
+    /** Whether the OTel trace API resolved on this classpath. */
+    private static final boolean AVAILABLE;
+
+    static {
+        Method spanCurrent = null;
+        Method spanGetContext = null;
+        Method ctxGetTraceId = null;
+        Method ctxGetSpanId = null;
+        Method ctxIsValid = null;
+        boolean available = false;
+        try {
+            Class<?> spanClass = Class.forName("io.opentelemetry.api.trace.Span");
+            Class<?> spanContextClass = Class.forName("io.opentelemetry.api.trace.SpanContext");
+            spanCurrent = spanClass.getMethod("current");
+            spanGetContext = spanClass.getMethod("getSpanContext");
+            ctxGetTraceId = spanContextClass.getMethod("getTraceId");
+            ctxGetSpanId = spanContextClass.getMethod("getSpanId");
+            ctxIsValid = spanContextClass.getMethod("isValid");
+            available = true;
+        } catch (Throwable t) {
+            // OTel SDK not present — degrade silently to timing-only mode.
+            LOG.log(System.Logger.Level.DEBUG,
+                    "OpenTelemetry trace API not on classpath; trace correlation degrades to timing-only");
+        }
+        SPAN_CURRENT = spanCurrent;
+        SPAN_GET_CONTEXT = spanGetContext;
+        CONTEXT_GET_TRACE_ID = ctxGetTraceId;
+        CONTEXT_GET_SPAN_ID = ctxGetSpanId;
+        CONTEXT_IS_VALID = ctxIsValid;
+        AVAILABLE = available;
+    }
+
+    private TraceContextHolder() {
+    }
+
+    /**
+     * Returns {@code true} when an OpenTelemetry trace API was found on the
+     * classpath. Even when {@code true}, individual lookups may still return
+     * {@code null} if no span is currently active.
+     */
+    public static boolean isOtelAvailable() {
+        return AVAILABLE;
+    }
+
+    /**
+     * Returns the active W3C trace id (32-char lowercase hex) for the current
+     * thread, or {@code null} when OTel is absent, no span is active, or the
+     * span context is invalid. Never throws.
+     */
+    public static String currentTraceId() {
+        Object ctx = currentSpanContext();
+        if (ctx == null) {
+            return null;
+        }
+        try {
+            Object id = CONTEXT_GET_TRACE_ID.invoke(ctx);
+            return id instanceof String s && !s.isBlank() ? s : null;
+        } catch (Throwable t) {
+            return null;
+        }
+    }
+
+    /**
+     * Returns the active W3C span id (16-char lowercase hex) for the current
+     * thread, or {@code null} when unavailable. Never throws.
+     */
+    public static String currentSpanId() {
+        Object ctx = currentSpanContext();
+        if (ctx == null) {
+            return null;
+        }
+        try {
+            Object id = CONTEXT_GET_SPAN_ID.invoke(ctx);
+            return id instanceof String s && !s.isBlank() ? s : null;
+        } catch (Throwable t) {
+            return null;
+        }
+    }
+
+    /** Resolves and validates the current SpanContext, or {@code null}. */
+    private static Object currentSpanContext() {
+        if (!AVAILABLE) {
+            return null;
+        }
+        try {
+            Object span = SPAN_CURRENT.invoke(null);
+            if (span == null) {
+                return null;
+            }
+            Object ctx = SPAN_GET_CONTEXT.invoke(span);
+            if (ctx == null) {
+                return null;
+            }
+            Object valid = CONTEXT_IS_VALID.invoke(ctx);
+            if (valid instanceof Boolean b && !b) {
+                return null;
+            }
+            return ctx;
+        } catch (Throwable t) {
+            return null;
+        }
+    }
+}

--- a/argus-server/src/main/java/io/argus/server/websocket/EventBroadcaster.java
+++ b/argus-server/src/main/java/io/argus/server/websocket/EventBroadcaster.java
@@ -71,6 +71,17 @@ public final class EventBroadcaster {
     private final FlameGraphAnalyzer flameGraphAnalyzer;
     private final ContentionAnalyzer contentionAnalyzer;
     private final CorrelationAnalyzer correlationAnalyzer;
+    /**
+     * Optional OTLP exporter for GC-pause span export. Set after construction
+     * by {@code ArgusServer} when OTLP is enabled; {@code null} otherwise.
+     */
+    private volatile io.argus.server.metrics.OtlpMetricsExporter otlpExporter;
+    /**
+     * Optional anomaly detector (W5). Set after construction by {@code ArgusServer};
+     * {@code null} disables anomaly-triggered profiling. Fed from the CPU and
+     * allocation drains so it sees the same live samples as the analyzers.
+     */
+    private volatile io.argus.server.analysis.AnomalyDetector anomalyDetector;
     private final ThreadStateManager threadStateManager;
     private final EventJsonSerializer serializer;
     private final ScheduledExecutorService scheduler;
@@ -159,6 +170,30 @@ public final class EventBroadcaster {
         this.stateScheduler = Executors.newSingleThreadScheduledExecutor(
                 r -> { Thread t = new Thread(r, "argus-state-broadcaster"); t.setDaemon(true); return t; }
         );
+    }
+
+    /**
+     * Wires the OTLP exporter used to push GC-pause spans. Optional: when
+     * {@code null} (OTLP disabled), no spans are exported and the GC drain only
+     * records timing-overlap pause windows for the {@code /correlation} surface.
+     */
+    public void setOtlpExporter(io.argus.server.metrics.OtlpMetricsExporter exporter) {
+        this.otlpExporter = exporter;
+    }
+
+    /**
+     * Wires the anomaly detector (W5) fed from the CPU and allocation drains.
+     * Optional: when {@code null} no anomaly detection runs.
+     */
+    public void setAnomalyDetector(io.argus.server.analysis.AnomalyDetector detector) {
+        this.anomalyDetector = detector;
+    }
+
+    /**
+     * Returns the wired anomaly detector, or {@code null} when none is set.
+     */
+    public io.argus.server.analysis.AnomalyDetector getAnomalyDetector() {
+        return anomalyDetector;
     }
 
     /**
@@ -256,6 +291,16 @@ public final class EventBroadcaster {
                 gcAnalyzer.recordGCEvent(event);
                 metrics.incrementGcEvent();
 
+                // Trace correlation: significant GC pauses are timing-overlap
+                // candidates and OTel span exports. The pause is a global
+                // stop-the-world event, so we best-effort capture whatever W3C
+                // trace context is active on this drain thread (null when no OTel
+                // SDK is present — graceful degradation to timing-only).
+                if (event.eventType() == io.argus.core.event.EventType.GC_PAUSE
+                        && event.duration() > 0) {
+                    handleGcPauseCorrelation(event);
+                }
+
                 // Broadcast GC event to clients
                 if (!clients.isEmpty()) {
                     String json = serializeGCEvent(event);
@@ -272,6 +317,12 @@ public final class EventBroadcaster {
                 cpuAnalyzer.recordCPUEvent(event);
                 metrics.incrementCpuEvent();
 
+                // W5: feed the same CPU sample to the anomaly detector (JVM CPU
+                // fraction 0.0-1.0). Fires only on a sustained over-threshold run.
+                if (anomalyDetector != null) {
+                    anomalyDetector.recordCpuSample(event.jvmTotal(), event.timestamp());
+                }
+
                 // Broadcast CPU event to clients
                 if (!clients.isEmpty()) {
                     String json = serializeCPUEvent(event);
@@ -286,6 +337,14 @@ public final class EventBroadcaster {
         if (allocationEventBuffer != null && allocationAnalyzer != null) {
             allocationEventBuffer.drain(event -> {
                 allocationAnalyzer.recordAllocationEvent(event);
+
+                // W5: feed the current allocation rate (KB/s) to the anomaly
+                // detector. The analyzer maintains a 1s rolling rate window, so we
+                // read it back after recording the event.
+                if (anomalyDetector != null) {
+                    double rateKbps = allocationAnalyzer.getCurrentAllocationRate() / 1024.0;
+                    anomalyDetector.recordAllocSample(rateKbps, event.timestamp());
+                }
             });
         }
 
@@ -311,6 +370,36 @@ public final class EventBroadcaster {
             contentionEventBuffer.drain(event -> {
                 contentionAnalyzer.recordContentionEvent(event);
             });
+        }
+    }
+
+    /**
+     * Records a significant GC pause for timing-overlap correlation and exports
+     * it as an OTel span (when OTLP is enabled). The trace id is captured
+     * best-effort from the active OTel context; the {@link CorrelationAnalyzer}
+     * applies the significance threshold (only sufficiently long pauses are kept
+     * / exported).
+     */
+    private void handleGcPauseCorrelation(GCEvent event) {
+        double pauseMs = event.durationMs();
+        // JFR GC events carry the pause START time (RecordedEvent.getStartTime via
+        // GCEventExtractor). The pause window is therefore [start, start+duration],
+        // NOT [end-duration, end] — computing it the other way shifted every window,
+        // span, and trace-overlap join one full pause-duration into the past.
+        java.time.Instant start = event.timestamp() != null ? event.timestamp() : java.time.Instant.now();
+        java.time.Instant end = start.plusNanos(event.duration());
+        String traceId = io.argus.server.metrics.TraceContextHolder.currentTraceId();
+
+        // Single source of truth for "significant": when a CorrelationAnalyzer is
+        // present it both applies the threshold and records the timing-overlap
+        // window; its return value reports whether the pause cleared the bar.
+        boolean significant = correlationAnalyzer != null
+                && correlationAnalyzer.recordPauseWindow(start, end, event.gcName(),
+                        event.gcCause(), pauseMs, event.memoryReclaimed(), traceId);
+
+        if (significant && otlpExporter != null) {
+            otlpExporter.enqueueGcPauseSpan(end.toEpochMilli(), event.gcName(),
+                    event.gcCause(), pauseMs, event.memoryReclaimed(), traceId);
         }
     }
 

--- a/argus-server/src/test/java/io/argus/server/analysis/AnomalyDetectorTest.java
+++ b/argus-server/src/test/java/io/argus/server/analysis/AnomalyDetectorTest.java
@@ -1,0 +1,172 @@
+package io.argus.server.analysis;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class AnomalyDetectorTest {
+
+    private static final Instant T0 = Instant.parse("2026-01-01T00:00:00Z");
+
+    /** sustainedSamples=3, ring=5, capture recommendations on. */
+    private static AnomalyDetector detector() {
+        return new AnomalyDetector(0.85, 500_000.0, 3, 5, true);
+    }
+
+    // ── CPU ──────────────────────────────────────────────────────────────────
+
+    @Test
+    void cpu_underThreshold_neverFires() {
+        AnomalyDetector d = detector();
+        for (int i = 0; i < 10; i++) {
+            assertNull(d.recordCpuSample(0.50, T0.plusSeconds(i)));
+        }
+        assertTrue(d.recentAnomalies().isEmpty());
+        assertFalse(d.isCaptureRecommended());
+    }
+
+    @Test
+    void cpu_overThresholdButNotSustained_doesNotFire() {
+        AnomalyDetector d = detector();
+        // Two over-threshold samples, short of the 3-sample sustained window.
+        assertNull(d.recordCpuSample(0.95, T0));
+        assertNull(d.recordCpuSample(0.95, T0.plusSeconds(1)));
+        assertTrue(d.recentAnomalies().isEmpty());
+    }
+
+    @Test
+    void cpu_sustainedOverThreshold_firesOnce() {
+        AnomalyDetector d = detector();
+        assertNull(d.recordCpuSample(0.95, T0));
+        assertNull(d.recordCpuSample(0.92, T0.plusSeconds(1)));
+        AnomalyDetector.AnomalyEvent fired = d.recordCpuSample(0.99, T0.plusSeconds(2));
+
+        assertNotNull(fired);
+        assertEquals(AnomalyDetector.AnomalyType.CPU, fired.type());
+        assertEquals(0.99, fired.value(), 1e-9);
+        assertEquals(0.85, fired.threshold(), 1e-9);
+        assertEquals(1, d.recentAnomalies().size());
+    }
+
+    @Test
+    void cpu_singleUnderSample_resetsStreak() {
+        AnomalyDetector d = detector();
+        d.recordCpuSample(0.95, T0);
+        d.recordCpuSample(0.95, T0.plusSeconds(1));
+        // Dip under threshold resets the sustained streak.
+        assertNull(d.recordCpuSample(0.10, T0.plusSeconds(2)));
+        // Next two over-threshold samples are not yet a full window.
+        assertNull(d.recordCpuSample(0.95, T0.plusSeconds(3)));
+        assertNull(d.recordCpuSample(0.95, T0.plusSeconds(4)));
+        assertTrue(d.recentAnomalies().isEmpty());
+        // Third consecutive over-threshold sample finally fires.
+        assertNotNull(d.recordCpuSample(0.95, T0.plusSeconds(5)));
+    }
+
+    @Test
+    void cpu_reasonStringMentionsThresholdAndWindow() {
+        AnomalyDetector d = detector();
+        d.recordCpuSample(0.95, T0);
+        d.recordCpuSample(0.95, T0.plusSeconds(1));
+        AnomalyDetector.AnomalyEvent fired = d.recordCpuSample(0.95, T0.plusSeconds(2));
+
+        assertNotNull(fired);
+        String reason = fired.reason();
+        assertTrue(reason.contains("CPU"), reason);
+        assertTrue(reason.contains("85%"), reason);
+        assertTrue(reason.contains("3 consecutive"), reason);
+    }
+
+    // ── Allocation ─────────────────────────────────────────────────────────────
+
+    @Test
+    void alloc_sustainedOverThreshold_firesWithCorrectType() {
+        AnomalyDetector d = detector();
+        assertNull(d.recordAllocSample(600_000, T0));
+        assertNull(d.recordAllocSample(700_000, T0.plusSeconds(1)));
+        AnomalyDetector.AnomalyEvent fired = d.recordAllocSample(800_000, T0.plusSeconds(2));
+
+        assertNotNull(fired);
+        assertEquals(AnomalyDetector.AnomalyType.ALLOC, fired.type());
+        assertEquals(800_000, fired.value(), 1e-6);
+        assertTrue(fired.reason().contains("Allocation rate"), fired.reason());
+        assertTrue(fired.reason().contains("KB/s"), fired.reason());
+    }
+
+    @Test
+    void alloc_underThreshold_neverFires() {
+        AnomalyDetector d = detector();
+        for (int i = 0; i < 6; i++) {
+            assertNull(d.recordAllocSample(100_000, T0.plusSeconds(i)));
+        }
+        assertTrue(d.recentAnomalies().isEmpty());
+    }
+
+    // ── Ring bound + recommendation ──────────────────────────────────────────────
+
+    @Test
+    void ringBound_isRespected() {
+        // ring=2 so older anomalies are evicted; fire 4 times.
+        AnomalyDetector d = new AnomalyDetector(0.85, 500_000.0, 1, 2, true);
+        for (int i = 0; i < 4; i++) {
+            assertNotNull(d.recordCpuSample(0.95, T0.plusSeconds(i)));
+        }
+        List<AnomalyDetector.AnomalyEvent> recent = d.recentAnomalies();
+        assertEquals(2, recent.size());
+        // The two retained anomalies are the most recent (oldest first).
+        assertEquals(T0.plusSeconds(2), recent.get(0).timestamp());
+        assertEquals(T0.plusSeconds(3), recent.get(1).timestamp());
+    }
+
+    @Test
+    void captureRecommendation_setOnFire_andClearable() {
+        AnomalyDetector d = new AnomalyDetector(0.85, 500_000.0, 1, 5, true);
+        assertFalse(d.isCaptureRecommended());
+
+        d.recordCpuSample(0.95, T0);
+        assertTrue(d.isCaptureRecommended());
+        AnomalyDetector.CaptureRecommendation rec = d.captureRecommendation();
+        assertNotNull(rec);
+        assertEquals(AnomalyDetector.AnomalyType.CPU, rec.triggerType());
+
+        d.clearCaptureRecommendation();
+        assertFalse(d.isCaptureRecommended());
+        // Anomaly history is independent of the recommendation flag.
+        assertEquals(1, d.recentAnomalies().size());
+    }
+
+    @Test
+    void captureRecommendation_disabled_noFlagButHistoryKept() {
+        AnomalyDetector d = new AnomalyDetector(0.85, 500_000.0, 1, 5, false);
+        assertNotNull(d.recordCpuSample(0.95, T0));
+        assertFalse(d.isCaptureRecommended());
+        assertNull(d.captureRecommendation());
+        assertEquals(1, d.recentAnomalies().size());
+    }
+
+    @Test
+    void latest_returnsMostRecent() {
+        AnomalyDetector d = new AnomalyDetector(0.85, 500_000.0, 1, 5, true);
+        assertNull(d.latest());
+        d.recordCpuSample(0.95, T0);
+        d.recordAllocSample(600_000, T0.plusSeconds(1));
+        AnomalyDetector.AnomalyEvent latest = d.latest();
+        assertNotNull(latest);
+        assertEquals(AnomalyDetector.AnomalyType.ALLOC, latest.type());
+        assertEquals(T0.plusSeconds(1), latest.timestamp());
+    }
+
+    @Test
+    void clear_resetsEverything() {
+        AnomalyDetector d = new AnomalyDetector(0.85, 500_000.0, 1, 5, true);
+        d.recordCpuSample(0.95, T0);
+        assertFalse(d.recentAnomalies().isEmpty());
+        d.clear();
+        assertTrue(d.recentAnomalies().isEmpty());
+        assertFalse(d.isCaptureRecommended());
+        assertNull(d.latest());
+    }
+}

--- a/argus-server/src/test/java/io/argus/server/analysis/CorrelationAnalyzerTracePauseTest.java
+++ b/argus-server/src/test/java/io/argus/server/analysis/CorrelationAnalyzerTracePauseTest.java
@@ -1,0 +1,95 @@
+package io.argus.server.analysis;
+
+import io.argus.server.analysis.CorrelationAnalyzer.PauseWindow;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests the W4 timing-overlap correlation surface on {@link CorrelationAnalyzer}:
+ * the significance threshold, the pause-window recording, the overlap query, and
+ * trace-id retention.
+ */
+class CorrelationAnalyzerTracePauseTest {
+
+    @Test
+    void sub_threshold_pauses_are_ignored() {
+        CorrelationAnalyzer analyzer = new CorrelationAnalyzer(50.0);
+        Instant t = Instant.parse("2026-05-28T10:00:00Z");
+        boolean recorded = analyzer.recordPauseWindow(
+                t, t.plusMillis(10), "G1 Young Generation", "G1 Evacuation Pause",
+                10.0, 0L, null);
+        assertFalse(recorded, "10ms pause is below the 50ms threshold");
+        assertTrue(analyzer.getRecentPauseWindows().isEmpty(), "no window should be retained");
+    }
+
+    @Test
+    void significant_pause_is_recorded_with_trace_id() {
+        CorrelationAnalyzer analyzer = new CorrelationAnalyzer(50.0);
+        Instant start = Instant.parse("2026-05-28T10:00:00Z");
+        boolean recorded = analyzer.recordPauseWindow(
+                start, start.plusMillis(120), "G1 Old Generation", "G1 Humongous Allocation",
+                120.0, 4_096L, "0af7651916cd43dd8448eb211c80319c");
+        assertTrue(recorded, "120ms pause clears the 50ms threshold");
+
+        List<PauseWindow> windows = analyzer.getRecentPauseWindows();
+        assertEquals(1, windows.size());
+        PauseWindow w = windows.get(0);
+        assertEquals("G1 Old Generation", w.gcName());
+        assertEquals("G1 Humongous Allocation", w.gcCause());
+        assertEquals(120.0, w.pauseMs(), 0.001);
+        assertEquals(4_096L, w.reclaimedBytes());
+        assertEquals("0af7651916cd43dd8448eb211c80319c", w.traceId());
+    }
+
+    @Test
+    void overlap_query_returns_pauses_intersecting_the_window() {
+        CorrelationAnalyzer analyzer = new CorrelationAnalyzer(50.0);
+        Instant base = Instant.parse("2026-05-28T10:00:00Z");
+
+        // Pause A: 10:00:00.000 -> 10:00:00.100 (overlaps query start edge)
+        analyzer.recordPauseWindow(base, base.plusMillis(100),
+                "G1", "Evac", 100.0, 0L, "aaaa651916cd43dd8448eb211c80319c");
+        // Pause B: 10:00:02.000 -> 10:00:02.080 (inside the query window)
+        analyzer.recordPauseWindow(base.plusSeconds(2), base.plusSeconds(2).plusMillis(80),
+                "G1", "Evac", 80.0, 0L, null);
+        // Pause C: 10:00:10.000 -> 10:00:10.060 (outside the query window)
+        analyzer.recordPauseWindow(base.plusSeconds(10), base.plusSeconds(10).plusMillis(60),
+                "G1", "Evac", 60.0, 0L, null);
+
+        // Query window: 10:00:00.050 -> 10:00:05.000
+        List<PauseWindow> overlapping = analyzer.pausesOverlapping(
+                base.plusMillis(50), base.plusSeconds(5));
+
+        assertEquals(2, overlapping.size(), "A (edge overlap) and B (inside) must match; C must not");
+        // Sorted oldest-first
+        assertEquals("aaaa651916cd43dd8448eb211c80319c", overlapping.get(0).traceId());
+        assertEquals(100.0, overlapping.get(0).pauseMs(), 0.001);
+        assertNull(overlapping.get(1).traceId());
+        assertEquals(80.0, overlapping.get(1).pauseMs(), 0.001);
+    }
+
+    @Test
+    void analysis_exposes_threshold_and_pauses() {
+        CorrelationAnalyzer analyzer = new CorrelationAnalyzer(75.0);
+        Instant t = Instant.parse("2026-05-28T10:00:00Z");
+        analyzer.recordPauseWindow(t, t.plusMillis(200), "ZGC", "Proactive", 200.0, 0L, null);
+
+        var result = analyzer.getAnalysis();
+        assertEquals(75.0, result.significantPauseThresholdMs(), 0.001);
+        assertEquals(1, result.tracePauses().size());
+    }
+
+    @Test
+    void clear_removes_recorded_pauses() {
+        CorrelationAnalyzer analyzer = new CorrelationAnalyzer(50.0);
+        Instant t = Instant.parse("2026-05-28T10:00:00Z");
+        analyzer.recordPauseWindow(t, t.plusMillis(100), "G1", "Evac", 100.0, 0L, null);
+        assertFalse(analyzer.getRecentPauseWindows().isEmpty());
+        analyzer.clear();
+        assertTrue(analyzer.getRecentPauseWindows().isEmpty());
+    }
+}

--- a/argus-server/src/test/java/io/argus/server/metrics/OtlpSpanBuilderTest.java
+++ b/argus-server/src/test/java/io/argus/server/metrics/OtlpSpanBuilderTest.java
@@ -1,0 +1,80 @@
+package io.argus.server.metrics;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Validates the hand-coded OTLP/JSON GC-pause span encoding: the resourceSpans
+ * structure, span name/kind, required attributes (gc.name, gc.cause,
+ * gc.pause_ms, heap.reclaimed_bytes), and trace-id normalization (supplied vs.
+ * generated).
+ */
+class OtlpSpanBuilderTest {
+
+    private final OtlpSpanBuilder builder = new OtlpSpanBuilder("argus-test", "1.2.3");
+
+    @Test
+    void wellformed_span_carries_all_attributes() {
+        String json = builder.buildGcPauseSpan(
+                1_700_000_000_000L, "G1 Young Generation", "G1 Evacuation Pause",
+                72.5, 12_345_678L, null);
+
+        assertTrue(json.startsWith("{\"resourceSpans\":[{"), "must be an OTLP resourceSpans payload");
+        assertTrue(json.contains("\"scopeSpans\":["), "must contain scopeSpans");
+        assertTrue(json.contains("\"name\":\"GC Pause\""), "span name must be 'GC Pause'");
+        assertTrue(json.contains("\"kind\":1"), "kind must be SPAN_KIND_INTERNAL (1)");
+
+        // Required attributes
+        assertTrue(json.contains("\"key\":\"gc.name\""), "missing gc.name attribute");
+        assertTrue(json.contains("G1 Young Generation"), "gc.name value missing");
+        assertTrue(json.contains("\"key\":\"gc.cause\""), "missing gc.cause attribute");
+        assertTrue(json.contains("G1 Evacuation Pause"), "gc.cause value missing");
+        assertTrue(json.contains("\"key\":\"gc.pause_ms\""), "missing gc.pause_ms attribute");
+        assertTrue(json.contains("\"doubleValue\":72.5"), "gc.pause_ms value missing");
+        assertTrue(json.contains("\"key\":\"heap.reclaimed_bytes\""), "missing heap.reclaimed_bytes attribute");
+        assertTrue(json.contains("\"intValue\":\"12345678\""), "heap.reclaimed_bytes value missing");
+
+        // Resource identifies the JVM/service
+        assertTrue(json.contains("\"key\":\"service.name\""), "resource must carry service.name");
+        assertTrue(json.contains("argus-test"), "service.name value missing");
+
+        // Timestamps present and ordered: start < end
+        assertTrue(json.contains("\"startTimeUnixNano\""), "missing startTimeUnixNano");
+        assertTrue(json.contains("\"endTimeUnixNano\""), "missing endTimeUnixNano");
+    }
+
+    @Test
+    void supplied_trace_id_is_used_when_valid() {
+        String traceId = "0af7651916cd43dd8448eb211c80319c"; // 32-hex
+        String json = builder.buildGcPauseSpan(1_700_000_000_000L,
+                "ZGC", "Allocation Rate", 10.0, 0L, traceId);
+        assertTrue(json.contains("\"traceId\":\"" + traceId + "\""),
+                "valid supplied trace id must be preserved");
+    }
+
+    @Test
+    void invalid_trace_id_is_replaced_with_generated_one() {
+        String json = builder.buildGcPauseSpan(1_700_000_000_000L,
+                "ZGC", "Allocation Rate", 10.0, 0L, "not-a-valid-id");
+        // A fresh 32-hex trace id must be emitted; the invalid input must not appear.
+        assertFalse(json.contains("not-a-valid-id"), "invalid trace id must not pass through");
+        assertTrue(OtlpSpanBuilder.normalizeTraceId("not-a-valid-id").matches("[0-9a-f]{32}"),
+                "normalized id must be 32-hex");
+    }
+
+    @Test
+    void all_zero_trace_id_is_rejected() {
+        String zeros = "0".repeat(32);
+        String normalized = OtlpSpanBuilder.normalizeTraceId(zeros);
+        assertNotEquals(zeros, normalized, "all-zero trace id is invalid and must be replaced");
+        assertTrue(normalized.matches("[0-9a-f]{32}"));
+    }
+
+    @Test
+    void null_gc_fields_default_to_unknown() {
+        String json = builder.buildGcPauseSpan(1_700_000_000_000L, null, null, 5.0, 0L, null);
+        assertTrue(json.contains("\"stringValue\":\"Unknown\""),
+                "null gc.name/gc.cause must default to 'Unknown'");
+    }
+}

--- a/argus-server/src/test/java/io/argus/server/metrics/PrometheusExemplarWiringTest.java
+++ b/argus-server/src/test/java/io/argus/server/metrics/PrometheusExemplarWiringTest.java
@@ -1,0 +1,77 @@
+package io.argus.server.metrics;
+
+import io.argus.core.config.AgentConfig;
+import io.argus.core.event.GCEvent;
+import io.argus.server.analysis.CPUAnalyzer;
+import io.argus.server.analysis.CarrierThreadAnalyzer;
+import io.argus.server.analysis.GCAnalyzer;
+import io.argus.server.analysis.PinningAnalyzer;
+import io.argus.server.state.ActiveThreadsRegistry;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Verifies the W4 wiring of the Phase-1 exemplar plumbing: the GC pause
+ * histogram's {@code +Inf} bucket carries a {@code trace_id} exemplar in
+ * OpenMetrics mode exactly when the supplier yields an id, and never in classic
+ * 0.0.4 output.
+ */
+class PrometheusExemplarWiringTest {
+
+    private PrometheusMetricsCollector collector(GCAnalyzer gc) {
+        return new PrometheusMetricsCollector(
+                AgentConfig.defaults(),
+                new ServerMetrics(),
+                new ActiveThreadsRegistry(),
+                new PinningAnalyzer(),
+                new CarrierThreadAnalyzer(),
+                gc,
+                new CPUAnalyzer(),
+                null, null, null, null);
+    }
+
+    private GCAnalyzer gcWithPauses() {
+        GCAnalyzer gc = new GCAnalyzer();
+        gc.recordGCEvent(GCEvent.pause(Instant.now(),
+                120_000_000L, "G1 Young Generation", "G1 Evacuation Pause"));
+        return gc;
+    }
+
+    @Test
+    void exemplar_populates_when_stub_supplier_returns_id() {
+        PrometheusMetricsCollector c = collector(gcWithPauses());
+        c.setTraceIdSupplier(() -> "0af7651916cd43dd8448eb211c80319c");
+        String om = c.collectMetrics(true);
+        assertTrue(om.contains("# {trace_id=\"0af7651916cd43dd8448eb211c80319c\"}"),
+                "exemplar must populate when the supplier yields a trace id");
+    }
+
+    @Test
+    void no_exemplar_when_supplier_returns_null() {
+        PrometheusMetricsCollector c = collector(gcWithPauses());
+        c.setTraceIdSupplier(() -> null);
+        assertFalse(c.collectMetrics(true).contains("# {trace_id="),
+                "no exemplar when the supplier yields null (OTel absent)");
+    }
+
+    @Test
+    void null_supplier_resets_to_noop() {
+        PrometheusMetricsCollector c = collector(gcWithPauses());
+        c.setTraceIdSupplier(() -> "0af7651916cd43dd8448eb211c80319c");
+        c.setTraceIdSupplier(null); // must reset to the no-op default
+        assertFalse(c.collectMetrics(true).contains("# {trace_id="),
+                "a null supplier must reset to the no-op default");
+    }
+
+    @Test
+    void supplier_throwing_does_not_break_collection() {
+        PrometheusMetricsCollector c = collector(gcWithPauses());
+        c.setTraceIdSupplier(() -> { throw new RuntimeException("boom"); });
+        assertDoesNotThrow(() -> c.collectMetrics(true));
+        assertFalse(c.collectMetrics(true).contains("# {trace_id="),
+                "a throwing supplier must degrade to no exemplar");
+    }
+}

--- a/argus-server/src/test/java/io/argus/server/metrics/TraceContextHolderTest.java
+++ b/argus-server/src/test/java/io/argus/server/metrics/TraceContextHolderTest.java
@@ -1,0 +1,43 @@
+package io.argus.server.metrics;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Verifies graceful degradation of the reflective OTel trace-context capture.
+ *
+ * <p>The test classpath has no OpenTelemetry SDK, so the holder must report the
+ * API as unavailable and return {@code null} from every accessor without ever
+ * throwing.
+ */
+class TraceContextHolderTest {
+
+    @Test
+    void otel_reported_absent_on_clean_classpath() {
+        assertFalse(TraceContextHolder.isOtelAvailable(),
+                "no OTel SDK on the test classpath, so it must report absent");
+    }
+
+    @Test
+    void currentTraceId_returns_null_when_otel_absent() {
+        assertNull(TraceContextHolder.currentTraceId(),
+                "trace id must be null with no OTel SDK present");
+    }
+
+    @Test
+    void currentSpanId_returns_null_when_otel_absent() {
+        assertNull(TraceContextHolder.currentSpanId(),
+                "span id must be null with no OTel SDK present");
+    }
+
+    @Test
+    void repeated_lookups_never_throw() {
+        assertDoesNotThrow(() -> {
+            for (int i = 0; i < 1000; i++) {
+                TraceContextHolder.currentTraceId();
+                TraceContextHolder.currentSpanId();
+            }
+        });
+    }
+}


### PR DESCRIPTION
## Summary

Roadmap **Phase 3** of `.omc/plans/jvm-oss-parity-roadmap.md`. Two workstreams in `argus-server` (+ frontend).

**W4 — distributed-tracing correlation (0 → 8)**
- `TraceContextHolder` — reflective, zero-compile-dep W3C trace-id capture (OTel SDK optional; graceful no-op when absent, no NoClassDefFoundError).
- GC-pause OTel **span export** (`OtlpSpanBuilder` + `OtlpMetricsExporter` → derived `/v1/traces`, batched, gated by OTLP flag).
- `CorrelationAnalyzer` timing-overlap (`pausesOverlapping`) + `/correlation` JSON `tracePauses[]`; Phase-1 Prometheus exemplar hook now wired.
- Architecture: GC pauses are STW-global, so this is timing-overlap + span export, not per-request instrumentation. No new Gradle dep.

**W5 — profiling depth: anomaly detection + contention top-N (6 → 8)**
- `AnomalyDetector` — sustained-window CPU/alloc threshold detector, bounded ring, capture-recommendation seam; fed from EventBroadcaster drains; `GET /anomalies`.
- Frontend "Lock Contention" panel over the existing `/contention-analysis` top-N.
- Deferred (noted): alloc→retained-heap cross-link (needs live heap-dump correlation with the W2 graph).

**Code-review fixes (same PR):**
- **HIGH** — GC pause window was `[end-duration, end]` but the JFR timestamp is the pause **START**; every window/span/overlap-join was shifted one full pause-duration into the past (defeating W4's correlation). Now `[start, start+duration]`.
- **MEDIUM** — span queue now drops **oldest** on overflow (was drop-newest) with O(1) size tracking.
- **LOW** — `Locale.ROOT` on new `/anomalies` + `tracePauses` JSON numbers (+ the Phase-1 collectorBreakdown line).

## Test plan
- [x] `./gradlew :argus-server:test :argus-cli:compileJava :argus-frontend:compileJava` (+ aggregator/diagnostics compile) → BUILD SUCCESSFUL
- [x] New tests: TraceContextHolder (4), OtlpSpanBuilder (5), CorrelationAnalyzer trace-pause (5), PrometheusExemplarWiring (4), AnomalyDetector (12)
- [x] `node --check` app.js
- [ ] CI matrix + DCO + code-quality + runtime smoke
- [ ] Live QA — deferred to maintainer post-merge (per request)

## Accepted-minor (noted, not changed)
`tracesEndpoint()` is correct for standard OTLP endpoints; `CorrelationAnalyzer` COW cleanup is single-writer-safe today; batched-span resource omits `service.version` (cosmetic).

🤖 Phase 3 of the JVM-OSS parity roadmap.