### PR TITLE
chore(release): update Homebrew formula sha256 for v1.5.0

### DIFF
--- a/Formula/argus.rb
+++ b/Formula/argus.rb
@@ -2,7 +2,7 @@ class Argus < Formula
   desc "JVM Monitoring Orchestration Tools — diagnostic CLI, dashboard, TUI, and rule-based doctor"
   homepage "https://github.com/rlaope/Argus"
   url "https://github.com/rlaope/Argus/releases/download/v1.5.0/argus-cli-1.5.0-all.jar"
-  sha256 "42ae225ebc68670097fe5adcf26872db089895df2b594e58b03d15415e4b0901"
+  sha256 "501cfb9dd612ec335186fe05649259fcecff193552e62be2820b26302cdbeea9"
   license "MIT"
 
   depends_on "openjdk@21"


### PR DESCRIPTION
## Summary
Post-release follow-up for **v1.5.0**: set `Formula/argus.rb` `sha256` to the real published artifact hash.

- **`501cfb9dd612ec335186fe05649259fcecff193552e62be2820b26302cdbeea9`** — `argus-cli-1.5.0-all.jar`
- Verified two ways: matches the release `checksums.txt` **and** an independent `shasum -a 256` of the downloaded jar.
- The prior value was the stale v1.4.0 hash; it could only be replaced after `release.yml` published the 1.5.0 artifact (sha256 can't be computed pre-release).

This was the one item `release-sync` escalated for the v1.5.0 cut.

## Test plan
- [x] `sha256` matches `gh release download v1.5.0 -p checksums.txt`
- [x] `sha256` matches independent `curl … | shasum -a 256`