### PR TITLE
docs(site): surface 1.5.0 capabilities on the landing page

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -110,7 +110,27 @@
                     </div>
                     <div class="feature-card">
                         <h4>Zero Overhead Design</h4>
-                        <p>Built on JFR and JMX MXBeans — the same low-overhead infrastructure that the JVM uses internally. No bytecode modification, no sampling bias.</p>
+                        <p>The core diagnostic path is built on JFR and JMX MXBeans — the same low-overhead infrastructure the JVM uses internally. No bytecode modification by default, no sampling bias.</p>
+                    </div>
+                    <div class="feature-card">
+                        <h4>MAT-class Heap Analysis</h4>
+                        <p><code>argus heapanalyze --leak-suspects --dominators=N --path-to-root</code> builds a dominator tree, retained sizes, GC-roots reachability, and an automated leak-suspects report — offline, on multi-GB dumps, within a bounded analyzer heap.</p>
+                    </div>
+                    <div class="feature-card">
+                        <h4>Continuous Profiling</h4>
+                        <p>Disk-backed, time-windowed per-pod CPU/alloc profiles with merged-window flamegraph queries and differential flamegraphs across time ranges — no external TSDB.</p>
+                    </div>
+                    <div class="feature-card">
+                        <h4>Distributed-Tracing Correlation</h4>
+                        <p>GC pauses are correlated with in-flight W3C trace context and exported as OpenTelemetry spans, with trace-ID exemplars on pause-time metrics — see which traces a pause stalled in Tempo, Jaeger, or Grafana.</p>
+                    </div>
+                    <div class="feature-card">
+                        <h4>Opt-in Live Instrumentation</h4>
+                        <p><code>argus instrument {watch|trace|monitor} &lt;pid&gt; &lt;Class#method&gt;</code> captures args, return, exceptions, and timing on a running JVM via dynamic-attach bytecode instrumentation. Default OFF, isolated, auto-detaches with zero residual bytecode.</p>
+                    </div>
+                    <div class="feature-card">
+                        <h4>OpenMetrics &amp; Grafana</h4>
+                        <p>OpenMetrics-compliant <code>/prometheus</code> export with per-collector GC pause histograms and trace-ID exemplars, plus a shipped Grafana dashboard and recording/alert rules.</p>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
## Summary
The site landing page (`site/index.html`) "Why Argus?" grid only described the pre-1.5.0 feature set — none of the new capabilities were mentioned. Adds five feature cards:

- **MAT-class Heap Analysis** — dominator tree, retained sizes, leak suspects, path-to-root
- **Continuous Profiling** — disk-backed per-pod profiles, merged + differential flamegraphs
- **Distributed-Tracing Correlation** — GC pause → OTel spans + trace-ID exemplars
- **Opt-in Live Instrumentation** — `argus instrument {watch|trace|monitor}`, default OFF, zero residual
- **OpenMetrics & Grafana** — OpenMetrics export, per-collector GC histograms, shipped dashboard

Also qualifies the "Zero Overhead Design" card to "no bytecode modification **by default**" so it doesn't contradict the opt-in instrument module.

Version badge (v1.5.0) and command count (70) on this page were already synced in the release PR.

## Test plan
- [x] 9 feature cards render (4 original + 5 new); HTML entities (`&lt;`/`&gt;`/`&amp;`) valid
- [ ] Visual check on GitHub Pages after merge