### PR TITLE
fix: restore native-image build and guard attach commands

### DIFF
--- a/argus-cli/src/main/java/io/argus/cli/jmx/JmxAttachment.java
+++ b/argus-cli/src/main/java/io/argus/cli/jmx/JmxAttachment.java
@@ -72,6 +72,15 @@ public final class JmxAttachment {
         com.sun.tools.attach.VirtualMachine vm;
         try {
             vm = com.sun.tools.attach.VirtualMachine.attach(String.valueOf(pid));
+        } catch (LinkageError e) {
+            // The Attach API needs the JDK's libattach native library, which a
+            // GraalVM native-image build does not ship — without this guard the
+            // UnsatisfiedLinkError (an Error, not an Exception) escapes as a raw
+            // stack trace. Convert it so callers take their normal graceful path.
+            throw new JmxAttachmentException(
+                    "Attach API unavailable in this build (no libattach). Run "
+                    + "attach-based commands from the JAR instead: "
+                    + "java -jar argus-cli.jar <command> " + pid, e);
         } catch (Exception e) {
             throw new JmxAttachmentException(
                     "Cannot attach to PID " + pid + ": " + e.getMessage(), e);

--- a/argus-cli/src/main/resources/META-INF/native-image/io.argus/argus-cli/native-image.properties
+++ b/argus-cli/src/main/resources/META-INF/native-image/io.argus/argus-cli/native-image.properties
@@ -2,4 +2,5 @@ Args = --no-fallback \
        --enable-url-protocols=http \
        -H:+ReportExceptionStackTraces \
        --initialize-at-build-time=io.argus.cli \
-       --initialize-at-build-time=io.argus.core
+       --initialize-at-build-time=io.argus.core \
+       --initialize-at-run-time=io.argus.cli.instrument

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -377,13 +377,40 @@ try (var executor = Executors.newVirtualThreadPerTaskExecutor()) {
 
 ## Native Binary (GraalVM)
 
-Pre-built native binaries are available in [Releases](https://github.com/rlaope/Argus/releases):
+Argus ships a GraalVM native-image build of the CLI for instant startup and no
+JVM dependency on the host. When a release succeeds, pre-built binaries are
+attached to the [release](https://github.com/rlaope/Argus/releases):
+
 - `argus-linux-amd64` — Linux x86_64
 - `argus-macos-aarch64` — macOS Apple Silicon
 
-Or build from source with GraalVM installed:
+> The `native-image` workflow runs **after** a release is published. If those two
+> assets are missing from a given tag, the native build failed for that tag — use
+> the `argus-cli-*-all.jar` instead.
+
+Build from source with GraalVM 21+ installed (the bundled
+`META-INF/native-image/` reachability metadata is applied automatically):
 
 ```bash
 ./gradlew :argus-cli:nativeImage
 ./argus-cli/build/native/argus --help
 ```
+
+### Command compatibility in the native binary
+
+The native binary inspects a target JVM by spawning the JDK tools (`jcmd`,
+`jstack`, `jstat`, `jps`) as subprocesses and by parsing files (GC logs, heap
+dumps). Those paths work unchanged.
+
+Commands that **attach into the target JVM** through the Attach API
+(`com.sun.tools.attach.VirtualMachine`) do **not** work in the native binary:
+SubstrateVM does not ship the `libattach` native library, so they fail at runtime
+with `UnsatisfiedLinkError: No attach in java.library.path`. Run those through the
+JAR (`java -jar argus-cli-*-all.jar <command>`) instead.
+
+| Commands | Mechanism | Native | JAR |
+|---|---|:--:|:--:|
+| `gc` `gcutil` `gccause` `gcnew` `gcrun` `heap` `histo` `metaspace` `threaddump` `threads` `deadlock` `classloader` `classstat` `compiler` `compilerqueue` `info` `ps` `env` `sysprops` `vmflag` `buffers` `finalizer` `perfcounter` `dynlibs` `stringtable` `symboltable` `sc` `nmt` | `jcmd` / `jstack` / `jstat` subprocess | ✅ | ✅ |
+| `gclog` `gclogdiff` `gcscore` `gcwhy` `heapanalyze` and other file analyzers | file parsing (no target attach) | ✅ | ✅ |
+| `mbean` `spring` `pool` `g1` `zgc` `threads --top` | JMX over the Attach API | ❌ | ✅ |
+| `instrument` | dynamic Java agent (ByteBuddy) | ❌ | ✅ |

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -377,9 +377,22 @@ try (var executor = Executors.newVirtualThreadPerTaskExecutor()) {
 
 ## Native Binary (GraalVM)
 
-Argus ships a GraalVM native-image build of the CLI for instant startup and no
-JVM dependency on the host. When a release succeeds, pre-built binaries are
-attached to the [release](https://github.com/rlaope/Argus/releases):
+Argus ships a GraalVM native-image build of the CLI. Its sweet spot is
+**offline analysis** — point it at a GC log or a heap dump and it runs as a
+single self-contained executable, with instant startup and no JVM (not even a
+JDK) needed on the host:
+
+```bash
+argus gclog gc.log           # GC log analysis + tuning advice
+argus gcscore gc.log         # A–F GC health score
+argus heapanalyze app.hprof  # heap-dump histogram + insights
+```
+
+This is also where the fast startup pays off most — in scripts or `watch` loops
+the JVM's warm-up cost would otherwise dominate.
+
+When a release succeeds, pre-built binaries are attached to the
+[release](https://github.com/rlaope/Argus/releases):
 
 - `argus-linux-amd64` — Linux x86_64
 - `argus-macos-aarch64` — macOS Apple Silicon
@@ -396,17 +409,20 @@ Build from source with GraalVM 21+ installed (the bundled
 ./argus-cli/build/native/argus --help
 ```
 
-### Command compatibility in the native binary
+### Live-target commands
 
-The native binary inspects a target JVM by spawning the JDK tools (`jcmd`,
-`jstack`, `jstat`, `jps`) as subprocesses and by parsing files (GC logs, heap
-dumps). Those paths work unchanged.
+The native binary can also inspect a *running* JVM, but with caveats — reach for
+the JAR if you need the full command set against a live process:
 
-Commands that **attach into the target JVM** through the Attach API
-(`com.sun.tools.attach.VirtualMachine`) do **not** work in the native binary:
-SubstrateVM does not ship the `libattach` native library, so they fail at runtime
-with `UnsatisfiedLinkError: No attach in java.library.path`. Run those through the
-JAR (`java -jar argus-cli-*-all.jar <command>`) instead.
+- **Works**: commands that shell out to the JDK tools (`jcmd`, `jstack`,
+  `jstat`, `jps`) — `gc`, `heap`, `threads`, `threaddump`, and friends. Note
+  these still require those JDK tools to be installed on the host, so the
+  "no JDK needed" benefit applies to the offline analyzers above, not here.
+- **JAR only**: commands that **attach into** the target JVM via the Attach API
+  (`com.sun.tools.attach.VirtualMachine`). SubstrateVM ships no `libattach`, so
+  they fail with `UnsatisfiedLinkError: No attach in java.library.path` (the
+  native binary now reports this cleanly instead of crashing). Run them through
+  the JAR: `java -jar argus-cli-*-all.jar <command>`.
 
 | Commands | Mechanism | Native | JAR |
 |---|---|:--:|:--:|


### PR DESCRIPTION
## Summary

- Native-image build has been broken since **1.5.0** (`#246`): `--initialize-at-build-time=io.argus.cli` drags `InstrumentSession.RANDOM` into the image heap, aborting the `--no-fallback` build. v1.5.0 shipped with **no** `argus-linux-amd64` / `argus-macos-aarch64` assets as a result. Fixed by carving `io.argus.cli.instrument` out to run-time init (one line in `native-image.properties`).
- Attach-based commands (`mbean`, `spring`, `pool`, `g1`, `zgc`, `threads --top`) crashed in the native binary with a raw `UnsatisfiedLinkError: No attach in java.library.path` (SubstrateVM ships no `libattach`). `JmxAttachment` now catches `LinkageError` and rethrows `JmxAttachmentException`, so the existing per-command graceful handlers fire instead.
- `docs/getting-started.md` documents the native vs JAR command-compatibility matrix and warns that release binaries are absent when the native build fails for a tag.

## Verification (GraalVM 21.0.11, macOS aarch64)

- `./gradlew :argus-cli:fatJar` + `native-image` now **builds** (was aborting at the `Random` image-heap check).
- Native binary: subprocess/file-based commands produce correct output — verified `gc gcutil gccause gcnew gcrun heap histo metaspace threads threaddump deadlock classloader classstat compiler compilerqueue info ps env sysprops vmflag buffers finalizer perfcounter dynlibs stringtable symboltable sc nmt`.
- Native binary: `mbean` / `pool` / `g1` / `zgc` now print a clean "run from the JAR" message — **no stack trace**.
- Regression check: on the JVM (JAR) `mbean <pid>` still attaches and lists MBeans, so the normal attach path is unchanged.

## Test plan

- [ ] CI `native-image` workflow goes green on this branch / next tag
- [ ] Confirm `argus-linux-amd64` / `argus-macos-aarch64` get attached to the next release
- [ ] Manual: run an attach command (e.g. `mbean`) from the native binary and confirm the message, not a crash

Fixes #250