### PR TITLE
feat: Pyroscope profile push from the continuous profile store

### DIFF
--- a/argus-aggregator/src/main/java/io/argus/aggregator/profile/PyroscopeProfileType.java
+++ b/argus-aggregator/src/main/java/io/argus/aggregator/profile/PyroscopeProfileType.java
@@ -1,0 +1,43 @@
+package io.argus.aggregator.profile;
+
+/**
+ * Maps Argus async-profiler event types to the profile-type names Pyroscope's
+ * ingest API expects in the {@code name} label set (the part after the
+ * {@code service_name}, e.g. {@code my-svc.process_cpu{...}}).
+ *
+ * <p>The mapping follows Pyroscope/Grafana's documented application-name suffix
+ * convention for the folded/collapsed ingest format:
+ * <ul>
+ *   <li>{@code cpu}   → {@code process_cpu}</li>
+ *   <li>{@code alloc} → {@code memory:alloc_space:bytes}</li>
+ *   <li>{@code lock}  → {@code mutex:contentions:count}</li>
+ *   <li>{@code wall}  → {@code wall}</li>
+ * </ul>
+ *
+ * <p>Unknown event types pass through verbatim so a future async-profiler event
+ * can still be pushed (Pyroscope tolerates arbitrary suffixes); the four mapped
+ * types above are the ones this project captures.
+ */
+public final class PyroscopeProfileType {
+
+    private PyroscopeProfileType() {}
+
+    /**
+     * Returns the Pyroscope profile-type suffix for an Argus {@code eventType}.
+     *
+     * @param eventType async-profiler event ("cpu", "alloc", "lock", "wall", …)
+     * @return the Pyroscope profile-type name; the raw event type if unmapped
+     */
+    public static String forEvent(String eventType) {
+        if (eventType == null) {
+            return "";
+        }
+        switch (eventType) {
+            case "cpu":   return "process_cpu";
+            case "alloc": return "memory:alloc_space:bytes";
+            case "lock":  return "mutex:contentions:count";
+            case "wall":  return "wall";
+            default:      return eventType;
+        }
+    }
+}

--- a/argus-aggregator/src/main/java/io/argus/aggregator/profile/PyroscopePushConfig.java
+++ b/argus-aggregator/src/main/java/io/argus/aggregator/profile/PyroscopePushConfig.java
@@ -1,0 +1,62 @@
+package io.argus.aggregator.profile;
+
+/**
+ * Configuration for the optional {@link PyroscopePusher}. The push is OFF unless
+ * an ingest endpoint is configured, so the default behaviour is the existing
+ * local-only {@link ProfileStore} with zero outbound traffic.
+ *
+ * <p>The endpoint is read from the system property
+ * {@code argus.profile.push.pyroscope.endpoint} (e.g.
+ * {@code http://pyroscope:4040}). An optional region label comes from
+ * {@code argus.profile.push.pyroscope.region}. When the endpoint is unset, blank,
+ * or this config is constructed with a null/blank endpoint, {@link #enabled()}
+ * is {@code false} and no push is ever attempted.
+ */
+public final class PyroscopePushConfig {
+
+    /** System property holding the Pyroscope ingest base URL. */
+    public static final String ENDPOINT_PROPERTY = "argus.profile.push.pyroscope.endpoint";
+
+    /** Optional system property holding a {@code region} label value. */
+    public static final String REGION_PROPERTY = "argus.profile.push.pyroscope.region";
+
+    private final String endpoint;
+    private final String region;
+    private final boolean enabled;
+
+    public PyroscopePushConfig(String endpoint, String region) {
+        this.endpoint = trimToNull(endpoint);
+        this.region = trimToNull(region);
+        this.enabled = this.endpoint != null;
+    }
+
+    /** Reads the config from system properties. */
+    public static PyroscopePushConfig fromSystemProperties() {
+        return new PyroscopePushConfig(
+                System.getProperty(ENDPOINT_PROPERTY),
+                System.getProperty(REGION_PROPERTY));
+    }
+
+    /** Ingest base URL (no trailing slash assumed), or null when disabled. */
+    public String endpoint() {
+        return endpoint;
+    }
+
+    /** Optional {@code region} label value, or null when unset. */
+    public String region() {
+        return region;
+    }
+
+    /** True iff an ingest endpoint is configured and push should be attempted. */
+    public boolean enabled() {
+        return enabled;
+    }
+
+    private static String trimToNull(String s) {
+        if (s == null) {
+            return null;
+        }
+        String t = s.strip();
+        return t.isEmpty() ? null : t;
+    }
+}

--- a/argus-aggregator/src/main/java/io/argus/aggregator/profile/PyroscopePusher.java
+++ b/argus-aggregator/src/main/java/io/argus/aggregator/profile/PyroscopePusher.java
@@ -1,0 +1,181 @@
+package io.argus.aggregator.profile;
+
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * Optionally mirrors a captured profile window to a Pyroscope ingest endpoint,
+ * reusing the same {@code (podId, service, eventType, window)} keys as
+ * {@link ProfileStore}.
+ *
+ * <p>This wraps {@link ProfileStore#append}: callers route captures through
+ * {@link #appendAndPush} so the local disk store stays the source of truth and
+ * the push is a best-effort side channel. The push is gated by
+ * {@link PyroscopePushConfig#enabled()} — when no endpoint is configured the
+ * local-store behaviour is unchanged and {@link #send} is never called.
+ *
+ * <h2>Request shape</h2>
+ * Pyroscope's folded ingest API:
+ * <pre>
+ *   POST &lt;endpoint&gt;/ingest?name=&lt;labelset&gt;&amp;from=&lt;ms&gt;&amp;until=&lt;ms&gt;&amp;format=folded
+ *   Content-Type: text/plain
+ *   body: one "stack count" line per collapsed stack
+ * </pre>
+ * where {@code labelset} is {@code service.&lt;type&gt;{pod="…",region="…"}} —
+ * the Pyroscope application-name + label-pair convention. {@code service_name}
+ * comes from the {@link ProfileStore} service key, {@code <type>} from
+ * {@link PyroscopeProfileType}, {@code pod} from the pod key, and {@code region}
+ * from {@link PyroscopePushConfig#region()} when set.
+ *
+ * <h2>Failure handling</h2>
+ * A refused connection, 5xx, timeout, or any thrown error is caught, counted,
+ * and logged at WARNING; it never propagates, so the capture/store loop survives
+ * a broken or absent Pyroscope. The local store write always happens first.
+ */
+public final class PyroscopePusher {
+
+    private static final System.Logger LOG = System.getLogger(PyroscopePusher.class.getName());
+
+    private final ProfileStore store;
+    private final PyroscopePushConfig config;
+    private final PyroscopeTransport transport;
+
+    private final AtomicLong pushAttempts = new AtomicLong(0);
+    private final AtomicLong pushSuccesses = new AtomicLong(0);
+    private final AtomicLong pushFailures = new AtomicLong(0);
+
+    public PyroscopePusher(ProfileStore store, PyroscopePushConfig config, PyroscopeTransport transport) {
+        if (store == null) {
+            throw new IllegalArgumentException("store must not be null");
+        }
+        if (config == null) {
+            throw new IllegalArgumentException("config must not be null");
+        }
+        if (transport == null) {
+            throw new IllegalArgumentException("transport must not be null");
+        }
+        this.store = store;
+        this.config = config;
+        this.transport = transport;
+    }
+
+    /** Convenience factory wiring the default JDK-HttpClient transport. */
+    public static PyroscopePusher create(ProfileStore store, PyroscopePushConfig config) {
+        return new PyroscopePusher(store, config, new PyroscopeTransport.HttpClientTransport());
+    }
+
+    public boolean pushEnabled() {
+        return config.enabled();
+    }
+
+    public long pushAttempts() { return pushAttempts.get(); }
+    public long pushSuccesses() { return pushSuccesses.get(); }
+    public long pushFailures() { return pushFailures.get(); }
+
+    /**
+     * Appends one capture cycle to the local {@link ProfileStore} and, when push
+     * is enabled, mirrors it to Pyroscope. The local append always runs; the push
+     * is best-effort and never throws back to the caller.
+     *
+     * @see ProfileStore#append for the parameter contract
+     */
+    public void appendAndPush(String podId, String service, String eventType,
+                              long timestampMillis, Map<String, Long> collapsedCounts) {
+        // Local store is the source of truth; write it first and unconditionally.
+        store.append(podId, service, eventType, timestampMillis, collapsedCounts);
+
+        if (!config.enabled()) {
+            return; // endpoint unset → no push attempted
+        }
+        if (collapsedCounts == null || collapsedCounts.isEmpty()) {
+            return;
+        }
+        pushOneWindow(podId, service, eventType, timestampMillis, collapsedCounts);
+    }
+
+    private void pushOneWindow(String podId, String service, String eventType,
+                               long timestampMillis, Map<String, Long> collapsedCounts) {
+        pushAttempts.incrementAndGet();
+        try {
+            String url = buildUrl(podId, service, eventType, timestampMillis);
+            String body = foldedBody(collapsedCounts);
+            int status = transport.send(new PyroscopeTransport.PushRequest(url, body));
+            if (status >= 200 && status < 300) {
+                pushSuccesses.incrementAndGet();
+            } else {
+                pushFailures.incrementAndGet();
+                LOG.log(System.Logger.Level.WARNING,
+                        () -> "pyroscope push got HTTP " + status + "; profile retained in local store");
+            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            pushFailures.incrementAndGet();
+            LOG.log(System.Logger.Level.WARNING, "pyroscope push interrupted; profile retained in local store");
+        } catch (Throwable t) {
+            // Never let a transport failure crash the capture/store loop.
+            pushFailures.incrementAndGet();
+            LOG.log(System.Logger.Level.WARNING,
+                    () -> "pyroscope push failed: " + t.getMessage() + "; profile retained in local store");
+        }
+    }
+
+    /**
+     * Builds the full ingest URL for one window. The window {@code [from, until)}
+     * is derived from the store's configured window so {@code from}/{@code until}
+     * align with the stored segment, not the raw sample timestamp.
+     */
+    String buildUrl(String podId, String service, String eventType, long timestampMillis) {
+        long from = store.config().windowStartFor(timestampMillis);
+        long until = from + store.config().windowMillis();
+        String name = labelSet(podId, service, eventType);
+        StringBuilder sb = new StringBuilder(config.endpoint().length() + name.length() + 64);
+        sb.append(stripTrailingSlash(config.endpoint())).append("/ingest")
+          .append("?name=").append(URLEncoder.encode(name, StandardCharsets.UTF_8))
+          .append("&from=").append(from)
+          .append("&until=").append(until)
+          .append("&format=folded");
+        return sb.toString();
+    }
+
+    /**
+     * Builds the Pyroscope application name + label set, e.g.
+     * {@code my-svc.process_cpu{pod="ns/pod-a",region="us-east"}}. A blank service
+     * falls back to {@code argus} so the application name is never empty.
+     */
+    String labelSet(String podId, String service, String eventType) {
+        String svc = (service == null || service.isBlank()) ? "argus" : service;
+        String type = PyroscopeProfileType.forEvent(eventType);
+        StringBuilder sb = new StringBuilder(64);
+        sb.append(svc).append('.').append(type)
+          .append("{service_name=").append(quote(svc))
+          .append(",pod=").append(quote(podId == null ? "" : podId));
+        if (config.region() != null) {
+            sb.append(",region=").append(quote(config.region()));
+        }
+        sb.append('}');
+        return sb.toString();
+    }
+
+    /** Renders the collapsed-stack map as Pyroscope folded body: {@code "stack count"} per line. */
+    static String foldedBody(Map<String, Long> collapsedCounts) {
+        StringBuilder sb = new StringBuilder(256);
+        for (Map.Entry<String, Long> e : collapsedCounts.entrySet()) {
+            long count = e.getValue() == null ? 0L : e.getValue();
+            if (count <= 0L) {
+                continue;
+            }
+            sb.append(e.getKey()).append(' ').append(count).append('\n');
+        }
+        return sb.toString();
+    }
+
+    private static String quote(String v) {
+        return '"' + v.replace("\\", "\\\\").replace("\"", "\\\"") + '"';
+    }
+
+    private static String stripTrailingSlash(String s) {
+        return s.endsWith("/") ? s.substring(0, s.length() - 1) : s;
+    }
+}

--- a/argus-aggregator/src/main/java/io/argus/aggregator/profile/PyroscopeTransport.java
+++ b/argus-aggregator/src/main/java/io/argus/aggregator/profile/PyroscopeTransport.java
@@ -1,0 +1,68 @@
+package io.argus.aggregator.profile;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+
+/**
+ * The injectable seam {@link PyroscopePusher} uses to send a folded-stacks ingest
+ * request. Abstracting the send keeps the pusher testable without a live
+ * Pyroscope server: tests inject a fake transport that records the request, or
+ * one that throws to exercise failure degradation.
+ *
+ * <p>A {@link PushRequest} carries the fully-built ingest URL (including the
+ * {@code name}/{@code from}/{@code until}/{@code format} query) and the folded
+ * body. Implementations return the HTTP status code; a non-2xx status or any
+ * thrown {@link IOException} is treated by the pusher as a push failure.
+ */
+public interface PyroscopeTransport {
+
+    /**
+     * Sends one ingest request.
+     *
+     * @return the HTTP status code returned by the ingest endpoint
+     * @throws IOException          on connect/timeout/IO failure (treated as a push failure)
+     * @throws InterruptedException if the calling thread is interrupted while sending
+     */
+    int send(PushRequest request) throws IOException, InterruptedException;
+
+    /** A fully-built Pyroscope ingest request: target URL plus folded body. */
+    record PushRequest(String url, String foldedBody) {}
+
+    /**
+     * The default JDK {@link HttpClient}-backed transport. POSTs the folded body
+     * as {@code text/plain} to the ingest URL with a bounded connect/request
+     * timeout. No heavy dependency — {@code java.net.http} only.
+     */
+    final class HttpClientTransport implements PyroscopeTransport {
+
+        private static final Duration CONNECT_TIMEOUT = Duration.ofSeconds(3);
+        private static final Duration REQUEST_TIMEOUT = Duration.ofSeconds(10);
+
+        private final HttpClient client;
+
+        public HttpClientTransport() {
+            this(HttpClient.newBuilder().connectTimeout(CONNECT_TIMEOUT).build());
+        }
+
+        HttpClientTransport(HttpClient client) {
+            this.client = client;
+        }
+
+        @Override
+        public int send(PushRequest request) throws IOException, InterruptedException {
+            HttpRequest req = HttpRequest.newBuilder()
+                    .uri(URI.create(request.url()))
+                    .timeout(REQUEST_TIMEOUT)
+                    .header("Content-Type", "text/plain")
+                    .POST(HttpRequest.BodyPublishers.ofString(request.foldedBody(), StandardCharsets.UTF_8))
+                    .build();
+            HttpResponse<Void> resp = client.send(req, HttpResponse.BodyHandlers.discarding());
+            return resp.statusCode();
+        }
+    }
+}

--- a/argus-aggregator/src/test/java/io/argus/aggregator/PyroscopePusherTest.java
+++ b/argus-aggregator/src/test/java/io/argus/aggregator/PyroscopePusherTest.java
@@ -1,0 +1,171 @@
+package io.argus.aggregator;
+
+import io.argus.aggregator.profile.ProfileStore;
+import io.argus.aggregator.profile.ProfileStoreConfig;
+import io.argus.aggregator.profile.PyroscopeProfileType;
+import io.argus.aggregator.profile.PyroscopePushConfig;
+import io.argus.aggregator.profile.PyroscopePusher;
+import io.argus.aggregator.profile.PyroscopeTransport;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class PyroscopePusherTest {
+
+    /** Records every request instead of hitting a server. */
+    private static final class RecordingTransport implements PyroscopeTransport {
+        final List<PushRequest> requests = new ArrayList<>();
+        int status = 200;
+
+        @Override
+        public int send(PushRequest request) {
+            requests.add(request);
+            return status;
+        }
+    }
+
+    /** Always throws, to exercise failure degradation. */
+    private static final class ThrowingTransport implements PyroscopeTransport {
+        int calls = 0;
+
+        @Override
+        public int send(PushRequest request) throws IOException {
+            calls++;
+            throw new IOException("connection refused");
+        }
+    }
+
+    private static final long TS = Instant.parse("2026-05-28T00:00:00Z").toEpochMilli();
+
+    // ── AC2: event → Pyroscope profile-type mapping ────────────────────────────
+
+    @Test
+    void mapsEventTypesToPyroscopeProfileTypes() {
+        assertEquals("process_cpu", PyroscopeProfileType.forEvent("cpu"));
+        assertEquals("memory:alloc_space:bytes", PyroscopeProfileType.forEvent("alloc"));
+        assertEquals("mutex:contentions:count", PyroscopeProfileType.forEvent("lock"));
+        assertEquals("wall", PyroscopeProfileType.forEvent("wall"));
+        // Unknown types pass through verbatim.
+        assertEquals("itimer", PyroscopeProfileType.forEvent("itimer"));
+    }
+
+    // ── AC1/AC2: request URL, label set, and folded body shape ──────────────────
+
+    @Test
+    void buildsIngestUrlLabelSetAndFoldedBody(@TempDir Path dir) {
+        ProfileStore store = new ProfileStore(ProfileStoreConfig.at(dir));
+        PyroscopePushConfig cfg = new PyroscopePushConfig("http://pyroscope:4040/", "us-east");
+        RecordingTransport transport = new RecordingTransport();
+        PyroscopePusher pusher = new PyroscopePusher(store, cfg, transport);
+
+        pusher.appendAndPush("ns/pod-a", "checkout", "cpu", TS,
+                Map.of("main;work", 7L));
+
+        assertEquals(1, transport.requests.size(), "one push for one window");
+        PyroscopeTransport.PushRequest req = transport.requests.get(0);
+
+        long from = TS; // window start (TS is already aligned to 00:00:00)
+        long until = from + 60_000;
+        assertTrue(req.url().startsWith("http://pyroscope:4040/ingest?name="),
+                "URL: " + req.url());
+        assertTrue(req.url().contains("&from=" + from), "from in URL: " + req.url());
+        assertTrue(req.url().contains("&until=" + until), "until in URL: " + req.url());
+        assertTrue(req.url().contains("&format=folded"), "format=folded: " + req.url());
+
+        // Decoded label set: service.<type>{service_name=...,pod=...,region=...}
+        String name = java.net.URLDecoder.decode(
+                req.url().replaceAll(".*[?&]name=([^&]*).*", "$1"),
+                java.nio.charset.StandardCharsets.UTF_8);
+        assertTrue(name.startsWith("checkout.process_cpu{"), "app name + type: " + name);
+        assertTrue(name.contains("service_name=\"checkout\""), "service_name label: " + name);
+        assertTrue(name.contains("pod=\"ns/pod-a\""), "pod label: " + name);
+        assertTrue(name.contains("region=\"us-east\""), "region label: " + name);
+
+        assertEquals("main;work 7\n", req.foldedBody(), "folded body: stack<space>count");
+    }
+
+    @Test
+    void omitsRegionLabelWhenUnset(@TempDir Path dir) {
+        ProfileStore store = new ProfileStore(ProfileStoreConfig.at(dir));
+        PyroscopePushConfig cfg = new PyroscopePushConfig("http://pyroscope:4040", null);
+        RecordingTransport transport = new RecordingTransport();
+        PyroscopePusher pusher = new PyroscopePusher(store, cfg, transport);
+
+        pusher.appendAndPush("ns/pod-a", "svc", "alloc", TS, Map.of("a;b", 3L));
+
+        String name = java.net.URLDecoder.decode(
+                transport.requests.get(0).url().replaceAll(".*[?&]name=([^&]*).*", "$1"),
+                java.nio.charset.StandardCharsets.UTF_8);
+        assertTrue(name.startsWith("svc.memory:alloc_space:bytes{"), name);
+        assertFalse(name.contains("region="), "no region label when unset: " + name);
+    }
+
+    // ── AC3: gating — endpoint unset ⇒ zero push attempts ───────────────────────
+
+    @Test
+    void doesNotPushWhenEndpointUnset(@TempDir Path dir) {
+        ProfileStore store = new ProfileStore(ProfileStoreConfig.at(dir));
+        PyroscopePushConfig cfg = new PyroscopePushConfig(null, null);
+        RecordingTransport transport = new RecordingTransport();
+        PyroscopePusher pusher = new PyroscopePusher(store, cfg, transport);
+
+        assertFalse(pusher.pushEnabled());
+        pusher.appendAndPush("ns/pod-a", "svc", "cpu", TS, Map.of("main;a", 5L));
+
+        assertEquals(0, transport.requests.size(), "no push when endpoint unset");
+        assertEquals(0L, pusher.pushAttempts(), "zero push attempts");
+
+        // But the local store still recorded the sample.
+        Map<String, Long> merged = store.merged("ns/pod-a", "cpu",
+                Instant.ofEpochMilli(TS), Instant.ofEpochMilli(TS + 60_000));
+        assertEquals(5L, merged.get("main;a"), "local store still written");
+    }
+
+    // ── AC4: push failure degrades to local store, never crashes the loop ───────
+
+    @Test
+    void survivesFailingTransportAndKeepsLocalStore(@TempDir Path dir) {
+        ProfileStore store = new ProfileStore(ProfileStoreConfig.at(dir));
+        PyroscopePushConfig cfg = new PyroscopePushConfig("http://pyroscope:4040", null);
+        ThrowingTransport transport = new ThrowingTransport();
+        PyroscopePusher pusher = new PyroscopePusher(store, cfg, transport);
+
+        // Must not throw despite the transport always throwing.
+        assertDoesNotThrow(() ->
+                pusher.appendAndPush("ns/pod-a", "svc", "cpu", TS, Map.of("main;a", 9L)));
+
+        assertEquals(1, transport.calls, "push was attempted");
+        assertEquals(1L, pusher.pushAttempts());
+        assertEquals(1L, pusher.pushFailures(), "failure counted");
+        assertEquals(0L, pusher.pushSuccesses());
+
+        // Local store retained the sample despite the push failure.
+        Map<String, Long> merged = store.merged("ns/pod-a", "cpu",
+                Instant.ofEpochMilli(TS), Instant.ofEpochMilli(TS + 60_000));
+        assertEquals(9L, merged.get("main;a"), "profile degraded to local store");
+    }
+
+    @Test
+    void countsNon2xxAsFailureButDoesNotThrow(@TempDir Path dir) {
+        ProfileStore store = new ProfileStore(ProfileStoreConfig.at(dir));
+        PyroscopePushConfig cfg = new PyroscopePushConfig("http://pyroscope:4040", null);
+        RecordingTransport transport = new RecordingTransport();
+        transport.status = 503;
+        PyroscopePusher pusher = new PyroscopePusher(store, cfg, transport);
+
+        assertDoesNotThrow(() ->
+                pusher.appendAndPush("ns/pod-a", "svc", "cpu", TS, Map.of("main;a", 1L)));
+
+        assertEquals(1L, pusher.pushAttempts());
+        assertEquals(1L, pusher.pushFailures(), "5xx counted as failure");
+        assertEquals(0L, pusher.pushSuccesses());
+    }
+}


### PR DESCRIPTION
## Summary

Adds an **opt-in** path that mirrors captured collapsed-stack profile windows from the disk-backed `ProfileStore` to a [Pyroscope](https://grafana.com/oss/pyroscope/) ingest endpoint. It reuses the existing per-pod/service/event keys `(podId, service, eventType, window)` — no parallel keying scheme.

**Push is OFF unless `argus.profile.push.pyroscope.endpoint` is configured.** When the endpoint is unset, behaviour is identical to today: local-only disk storage, zero outbound traffic, zero push attempts. This is a strict no-regression addition.

## How it works

`PyroscopePusher.appendAndPush(...)` wraps `ProfileStore.append(...)`. The local disk store is written first and unconditionally (it stays the source of truth); the Pyroscope push is a best-effort side channel. When enabled, it POSTs the folded body to:

```
POST <endpoint>/ingest?name=<labelset>&from=<windowStartMs>&until=<windowEndMs>&format=folded
Content-Type: text/plain
body: one "stack count" line per collapsed stack
```

The label set follows Pyroscope's application-name + label convention, built from the store keys:
`service.<type>{service_name="…",pod="…",region="…"}` (the `region` label is omitted when `argus.profile.push.pyroscope.region` is unset). `from`/`until` align to the store's configured window, not the raw sample timestamp.

## Event → Pyroscope profile-type mapping

| Argus event | Pyroscope profile type |
|---|---|
| `cpu` | `process_cpu` |
| `alloc` | `memory:alloc_space:bytes` |
| `lock` | `mutex:contentions:count` |
| `wall` | `wall` |

Unknown event types pass through verbatim.

## Acceptance criteria & how verified

1. **Pyroscope ingest client pushing collapsed stacks, keyed off existing ProfileStore keys** — `PyroscopePusher` + `PyroscopeTransport.HttpClientTransport`. Verified by `buildsIngestUrlLabelSetAndFoldedBody` (asserts URL `/ingest?name=…&from=…&until=…&format=folded`, decoded label set, and `"stack count"` folded body).
2. **Event→type mapping + request URL/label/body shape under unit test with no live server** — `PyroscopeProfileType` + `mapsEventTypesToPyroscopeProfileTypes`, plus the shape test above using an in-memory recording transport (no live server).
3. **Gated behind `argus.profile.push.pyroscope.endpoint`; unset ⇒ zero push attempts** — `PyroscopePushConfig`. Verified by `doesNotPushWhenEndpointUnset` (0 requests, 0 attempts, local store still written).
4. **Push failure degrades to local store with a logged warning, never crashes the loop** — verified by `survivesFailingTransportAndKeepsLocalStore` (injected throwing transport ⇒ no exception, failure counted, sample retained locally) and `countsNon2xxAsFailureButDoesNotThrow` (5xx ⇒ failure, no throw).
5. **JDK HTTP client only, no new heavy dependency** — `java.net.http.HttpClient`; no change to `build.gradle.kts` dependencies.

## Verification

- `./gradlew :argus-aggregator:test` → **BUILD SUCCESSFUL**; new `PyroscopePusherTest` = 6 tests, 0 failures; full aggregator suite = 94 tests green.
- `./gradlew :argus-aggregator:build` → **BUILD SUCCESSFUL**. The pre-existing strict `jar` implicit-dependency validation did **not** block this module, so the optional `tasks.jar { dependsOn(...) }` fix was **not applied**.

**Live verification** against a real Pyroscope instance (`docker run grafana/pyroscope`) is a documented manual step since it requires external infra; unit tests cover mapping, gating, and failure-degradation via an injected transport so CI needs no network.

🤖 Generated with [Claude Code](https://claude.com/claude-code)