### PR TITLE
feat: OTLP Profiles signal (pprof) encoder behind experimental flag

### DIFF
--- a/argus-aggregator/src/main/java/io/argus/aggregator/profile/OtlpProfilesEncoder.java
+++ b/argus-aggregator/src/main/java/io/argus/aggregator/profile/OtlpProfilesEncoder.java
@@ -133,11 +133,13 @@ public final class OtlpProfilesEncoder {
         for (Sample s : data.samples) {
             StringBuilder stack = new StringBuilder();
             // locationIds are leaf-first; walk in reverse to print root-first.
+            // Join on a frame-index boundary (not on builder length) so empty frame
+            // names — a leading ';', trailing ';', or doubled ';;' — round-trip.
             for (int i = s.locationIds.length - 1; i >= 0; i--) {
                 Location loc = data.locations.get(s.locationIds[i]);
                 Function fn = data.functions.get(loc.functionId);
                 String name = data.stringTable.get(fn.nameStringId);
-                if (stack.length() > 0) {
+                if (i < s.locationIds.length - 1) {
                     stack.append(';');
                 }
                 stack.append(name);
@@ -256,7 +258,15 @@ public final class OtlpProfilesEncoder {
 
     // ── shared helpers ───────────────────────────────────────────────────────
 
-    /** Splits a collapsed stack into frames (root-first), dropping empty segments. */
+    /**
+     * Splits a collapsed stack into frames (root-first), preserving <em>every</em>
+     * {@code ;}-delimited segment — including empty ones produced by a leading
+     * {@code ;}, a trailing {@code ;}, or a doubled {@code ;;}. Empty segments are
+     * treated as real frames (async-profiler can emit blank/unknown frame names),
+     * which is what makes {@code toCollapsed(toProfilesData(x))} a lossless identity
+     * for any key (see the class-level "Losslessness" note) and keeps two distinct
+     * stacks from silently merging. A {@code null}/empty stack maps to no frames.
+     */
     private static List<String> splitFrames(String stack) {
         List<String> out = new ArrayList<>();
         if (stack == null || stack.isEmpty()) {
@@ -265,15 +275,11 @@ public final class OtlpProfilesEncoder {
         int start = 0;
         for (int i = 0; i < stack.length(); i++) {
             if (stack.charAt(i) == ';') {
-                if (i > start) {
-                    out.add(stack.substring(start, i));
-                }
+                out.add(stack.substring(start, i));
                 start = i + 1;
             }
         }
-        if (start < stack.length()) {
-            out.add(stack.substring(start));
-        }
+        out.add(stack.substring(start));
         return out;
     }
 

--- a/argus-aggregator/src/main/java/io/argus/aggregator/profile/OtlpProfilesEncoder.java
+++ b/argus-aggregator/src/main/java/io/argus/aggregator/profile/OtlpProfilesEncoder.java
@@ -1,0 +1,391 @@
+package io.argus.aggregator.profile;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Converts collapsed-stack profiles into the OTLP <strong>Profiles</strong> signal
+ * shape ({@code ProfilesData}) and emits it as OTLP/JSON, hand-coded in the same
+ * dependency-free style as {@code io.argus.server.metrics.OtlpJsonBuilder} /
+ * {@code OtlpSpanBuilder}.
+ *
+ * <p>The OTLP Profiles signal is the fourth OpenTelemetry signal. It reached
+ * <em>Alpha</em> (2026-03) and is <strong>pre-GA</strong>; its wire shape can still
+ * change. To keep the pre-GA spec from destabilising the default build this encoder
+ * is gated behind the experimental flag {@value #FLAG_ENABLED} (default
+ * {@code false}) — {@link #encode} returns {@code null} (a no-op) unless the flag is
+ * explicitly set, and nothing in the default build wires it.
+ *
+ * <h2>ProfilesData model (the pprof-derived shape)</h2>
+ * The OTLP Profiles message reuses the pprof interning model: a single
+ * <em>string table</em>, a <em>function</em> table and a <em>location</em> table that
+ * index into the string table, and a list of <em>samples</em> where each sample is a
+ * value plus an ordered list of location indices (leaf-first, pprof convention). We
+ * model exactly that — {@link ProfilesData}, {@link Function}, {@link Location},
+ * {@link Sample} — without any protobuf/pprof library, matching the project's
+ * zero-heavy-dependency ethos.
+ *
+ * <h2>Losslessness</h2>
+ * Because we never depend on a pprof codec, we prove losslessness the honest,
+ * dependency-free way: {@link #toProfilesData} interns collapsed stacks into the
+ * model and {@link #toCollapsed} reconstructs the original {@code stack -> count}
+ * map; a unit test asserts the round-trip is identity. (End-to-end ingest by a live
+ * OTel Collector profiles pipeline is a separate, documented manual step that needs
+ * external infrastructure.)
+ *
+ * <h2>Trace linkage (#245)</h2>
+ * When a {@link ProfileTraceContext} is present, every sample carries
+ * {@code trace_id} / {@code span_id} attribute references so a backend can correlate
+ * the profile with the trace timeline produced by the GC-pause↔trace work. When the
+ * context is absent the attributes are omitted.
+ */
+public final class OtlpProfilesEncoder {
+
+    /** Experimental, pre-GA gate. Default {@code false}; nothing wires it by default. */
+    public static final String FLAG_ENABLED = "argus.profiles.otlp.enabled";
+
+    /** Semantic-convention attribute keys for trace linkage on a sample. */
+    static final String ATTR_TRACE_ID = "trace_id";
+    static final String ATTR_SPAN_ID = "span_id";
+
+    private OtlpProfilesEncoder() {
+    }
+
+    /** {@code true} only when the experimental flag is explicitly enabled. */
+    public static boolean isEnabled() {
+        return Boolean.getBoolean(FLAG_ENABLED);
+    }
+
+    /**
+     * Encodes one collapsed-stack profile to an OTLP/JSON {@code ProfilesData}
+     * payload, or returns {@code null} (no-op) when the experimental flag
+     * {@value #FLAG_ENABLED} is disabled.
+     *
+     * @param collapsed {@code stack -> sampleCount}; semicolon-delimited frames,
+     *                  leaf last (as async-profiler / {@link ProfileStore#merged} emit)
+     * @param trace     active trace context, or {@link ProfileTraceContext#none()}
+     * @return OTLP/JSON profiles payload, or {@code null} when disabled
+     */
+    public static String encode(Map<String, Long> collapsed, ProfileTraceContext trace) {
+        if (!isEnabled()) {
+            return null;
+        }
+        return encodeUnconditionally(collapsed, trace);
+    }
+
+    /**
+     * Encodes regardless of the flag, for callers that gate emission themselves
+     * (and for deterministic tests that must not toggle a global system property).
+     * The standard entry point ({@link #encode}) stays gated behind
+     * {@value #FLAG_ENABLED}.
+     */
+    public static String encodeUnconditionally(Map<String, Long> collapsed, ProfileTraceContext trace) {
+        return toJson(toProfilesData(collapsed), trace == null ? ProfileTraceContext.none() : trace);
+    }
+
+    // ── collapsed → ProfilesData ─────────────────────────────────────────────
+
+    /**
+     * Interns the collapsed stacks into the pprof-style {@link ProfilesData} model
+     * (string / function / location tables + samples). Stacks are stored leaf-first
+     * per pprof convention; counts {@code <= 0} are skipped. Iteration order is
+     * preserved (the input map's order) so encoding is deterministic.
+     */
+    public static ProfilesData toProfilesData(Map<String, Long> collapsed) {
+        ProfilesData data = new ProfilesData();
+        // Index 0 of the string table is the empty string, per pprof convention.
+        data.internString("");
+        if (collapsed == null) {
+            return data;
+        }
+        for (Map.Entry<String, Long> e : collapsed.entrySet()) {
+            long count = e.getValue() == null ? 0L : e.getValue();
+            if (count <= 0L) {
+                continue;
+            }
+            List<String> frames = splitFrames(e.getKey()); // root-first
+            // pprof stores locations leaf-first; reverse.
+            int[] locationIds = new int[frames.size()];
+            for (int i = 0; i < frames.size(); i++) {
+                String frame = frames.get(frames.size() - 1 - i);
+                locationIds[i] = data.internLocation(frame);
+            }
+            data.samples.add(new Sample(locationIds, count));
+        }
+        return data;
+    }
+
+    // ── ProfilesData → collapsed (the round-trip seam) ───────────────────────
+
+    /**
+     * Reconstructs the original {@code stack -> count} collapsed map from a
+     * {@link ProfilesData}. Inverse of {@link #toProfilesData}: re-orders each
+     * sample's leaf-first locations back to root-first, resolves frame names from
+     * the function/string tables, and sums counts per identical stack.
+     */
+    public static Map<String, Long> toCollapsed(ProfilesData data) {
+        Map<String, Long> out = new LinkedHashMap<>();
+        if (data == null) {
+            return out;
+        }
+        for (Sample s : data.samples) {
+            StringBuilder stack = new StringBuilder();
+            // locationIds are leaf-first; walk in reverse to print root-first.
+            for (int i = s.locationIds.length - 1; i >= 0; i--) {
+                Location loc = data.locations.get(s.locationIds[i]);
+                Function fn = data.functions.get(loc.functionId);
+                String name = data.stringTable.get(fn.nameStringId);
+                if (stack.length() > 0) {
+                    stack.append(';');
+                }
+                stack.append(name);
+            }
+            out.merge(stack.toString(), s.value, Long::sum);
+        }
+        return out;
+    }
+
+    // ── ProfilesData → OTLP/JSON ─────────────────────────────────────────────
+
+    private static String toJson(ProfilesData data, ProfileTraceContext trace) {
+        long nowNano = System.currentTimeMillis() * 1_000_000L;
+        StringBuilder sb = new StringBuilder(1024);
+        sb.append("{\"resourceProfiles\":[{");
+        appendResource(sb);
+        sb.append(",\"scopeProfiles\":[{");
+        sb.append("\"scope\":{\"name\":\"io.argus.profiles\",\"version\":\"")
+                .append(escape(version())).append("\"},");
+        sb.append("\"profiles\":[{");
+        // sampleType: a single CPU/sample-count axis (unit "count").
+        sb.append("\"sampleType\":[{\"type\":\"samples\",\"unit\":\"count\"}],");
+        appendStringTable(sb, data);
+        sb.append(',');
+        appendFunctions(sb, data);
+        sb.append(',');
+        appendLocations(sb, data);
+        sb.append(',');
+        appendSamples(sb, data, trace);
+        sb.append(",\"timeNanos\":\"").append(nowNano).append("\"");
+        sb.append("}]}]}]}");
+        return sb.toString();
+    }
+
+    private static void appendResource(StringBuilder sb) {
+        sb.append("\"resource\":{\"attributes\":[");
+        appendStringAttribute(sb, "service.name", "argus");
+        sb.append(',');
+        appendStringAttribute(sb, "telemetry.sdk.name", "argus");
+        sb.append(',');
+        appendStringAttribute(sb, "telemetry.sdk.language", "java");
+        sb.append("]}");
+    }
+
+    private static void appendStringTable(StringBuilder sb, ProfilesData data) {
+        sb.append("\"stringTable\":[");
+        for (int i = 0; i < data.stringTable.size(); i++) {
+            if (i > 0) sb.append(',');
+            sb.append('"').append(escape(data.stringTable.get(i))).append('"');
+        }
+        sb.append(']');
+    }
+
+    private static void appendFunctions(StringBuilder sb, ProfilesData data) {
+        sb.append("\"function\":[");
+        for (int i = 0; i < data.functions.size(); i++) {
+            if (i > 0) sb.append(',');
+            Function fn = data.functions.get(i);
+            sb.append("{\"id\":\"").append(i)
+              .append("\",\"name\":\"").append(fn.nameStringId).append("\"}");
+        }
+        sb.append(']');
+    }
+
+    private static void appendLocations(StringBuilder sb, ProfilesData data) {
+        sb.append("\"location\":[");
+        for (int i = 0; i < data.locations.size(); i++) {
+            if (i > 0) sb.append(',');
+            Location loc = data.locations.get(i);
+            sb.append("{\"id\":\"").append(i)
+              .append("\",\"line\":[{\"functionIndex\":\"").append(loc.functionId)
+              .append("\"}]}");
+        }
+        sb.append(']');
+    }
+
+    private static void appendSamples(StringBuilder sb, ProfilesData data, ProfileTraceContext trace) {
+        sb.append("\"sample\":[");
+        boolean linked = trace != null && trace.isPresent();
+        for (int i = 0; i < data.samples.size(); i++) {
+            if (i > 0) sb.append(',');
+            Sample s = data.samples.get(i);
+            sb.append("{\"locationIndex\":[");
+            for (int j = 0; j < s.locationIds.length; j++) {
+                if (j > 0) sb.append(',');
+                sb.append('"').append(s.locationIds[j]).append('"');
+            }
+            sb.append("],\"value\":[\"").append(s.value).append("\"]");
+            if (linked) {
+                sb.append(",\"attributes\":[");
+                boolean firstAttr = true;
+                if (trace.traceId() != null) {
+                    appendStringAttribute(sb, ATTR_TRACE_ID, trace.traceId());
+                    firstAttr = false;
+                }
+                if (trace.spanId() != null) {
+                    if (!firstAttr) sb.append(',');
+                    appendStringAttribute(sb, ATTR_SPAN_ID, trace.spanId());
+                }
+                sb.append(']');
+            }
+            sb.append('}');
+        }
+        sb.append(']');
+    }
+
+    private static void appendStringAttribute(StringBuilder sb, String key, String value) {
+        sb.append("{\"key\":\"").append(escape(key))
+          .append("\",\"value\":{\"stringValue\":\"").append(escape(value)).append("\"}}");
+    }
+
+    private static String version() {
+        String v = OtlpProfilesEncoder.class.getPackage().getImplementationVersion();
+        return v != null ? v : "dev";
+    }
+
+    // ── shared helpers ───────────────────────────────────────────────────────
+
+    /** Splits a collapsed stack into frames (root-first), dropping empty segments. */
+    private static List<String> splitFrames(String stack) {
+        List<String> out = new ArrayList<>();
+        if (stack == null || stack.isEmpty()) {
+            return out;
+        }
+        int start = 0;
+        for (int i = 0; i < stack.length(); i++) {
+            if (stack.charAt(i) == ';') {
+                if (i > start) {
+                    out.add(stack.substring(start, i));
+                }
+                start = i + 1;
+            }
+        }
+        if (start < stack.length()) {
+            out.add(stack.substring(start));
+        }
+        return out;
+    }
+
+    private static String escape(String s) {
+        if (s == null) {
+            return "";
+        }
+        StringBuilder sb = new StringBuilder(s.length() + 8);
+        for (int i = 0; i < s.length(); i++) {
+            char c = s.charAt(i);
+            switch (c) {
+                case '\\': sb.append("\\\\"); break;
+                case '"':  sb.append("\\\""); break;
+                case '\n': sb.append("\\n"); break;
+                case '\r': sb.append("\\r"); break;
+                case '\t': sb.append("\\t"); break;
+                case '\b': sb.append("\\b"); break;
+                case '\f': sb.append("\\f"); break;
+                default:
+                    if (c < 0x20) {
+                        sb.append(String.format("\\u%04x", (int) c));
+                    } else {
+                        sb.append(c);
+                    }
+            }
+        }
+        return sb.toString();
+    }
+
+    // ── pprof-derived model types ────────────────────────────────────────────
+
+    /**
+     * The OTLP Profiles {@code ProfilesData} body: interned string / function /
+     * location tables plus the sample list. Mutable while interning; treat as
+     * read-only after {@link #toProfilesData} returns.
+     */
+    public static final class ProfilesData {
+        final List<String> stringTable = new ArrayList<>();
+        final List<Function> functions = new ArrayList<>();
+        final List<Location> locations = new ArrayList<>();
+        final List<Sample> samples = new ArrayList<>();
+
+        /** frame name -> location index (one location per distinct frame name). */
+        private final Map<String, Integer> locationByFrame = new LinkedHashMap<>();
+        /** string -> string-table index. */
+        private final Map<String, Integer> stringIndex = new LinkedHashMap<>();
+
+        int internString(String s) {
+            String key = s == null ? "" : s;
+            Integer idx = stringIndex.get(key);
+            if (idx != null) {
+                return idx;
+            }
+            int newIdx = stringTable.size();
+            stringTable.add(key);
+            stringIndex.put(key, newIdx);
+            return newIdx;
+        }
+
+        int internLocation(String frame) {
+            Integer existing = locationByFrame.get(frame);
+            if (existing != null) {
+                return existing;
+            }
+            int nameId = internString(frame);
+            int functionId = functions.size();
+            functions.add(new Function(nameId));
+            int locationId = locations.size();
+            locations.add(new Location(functionId));
+            locationByFrame.put(frame, locationId);
+            return locationId;
+        }
+
+        public List<String> stringTable() {
+            return stringTable;
+        }
+
+        public List<Sample> samples() {
+            return samples;
+        }
+    }
+
+    /** A pprof function: its name interned into the string table. */
+    public static final class Function {
+        final int nameStringId;
+
+        Function(int nameStringId) {
+            this.nameStringId = nameStringId;
+        }
+    }
+
+    /** A pprof location: a single line pointing at one function. */
+    public static final class Location {
+        final int functionId;
+
+        Location(int functionId) {
+            this.functionId = functionId;
+        }
+    }
+
+    /** A pprof sample: leaf-first location indices and a single count value. */
+    public static final class Sample {
+        final int[] locationIds;
+        final long value;
+
+        Sample(int[] locationIds, long value) {
+            this.locationIds = locationIds;
+            this.value = value;
+        }
+
+        public long value() {
+            return value;
+        }
+    }
+}

--- a/argus-aggregator/src/main/java/io/argus/aggregator/profile/ProfileTraceContext.java
+++ b/argus-aggregator/src/main/java/io/argus/aggregator/profile/ProfileTraceContext.java
@@ -1,0 +1,73 @@
+package io.argus.aggregator.profile;
+
+/**
+ * Immutable carrier for an active W3C trace context (trace id + span id) to be
+ * stamped onto OTLP profile samples.
+ *
+ * <p>This mirrors the trace/span ids that the GC-pause↔trace correlation work
+ * (#245, {@code io.argus.server.metrics.TraceContextHolder}) resolves reflectively
+ * from an OpenTelemetry SDK. {@code argus-aggregator} keeps zero compile-time
+ * dependency on {@code argus-server} and on OpenTelemetry, so the caller passes a
+ * resolved context in rather than this module reaching across the seam. When no
+ * context is active, callers pass {@link #none()} (or {@code null}) and the
+ * encoder omits the link attributes from samples.
+ *
+ * <p>The OTLP Profiles signal models trace linkage as sample attributes keyed by
+ * the semantic-convention attributes {@code trace_id} / {@code span_id}; we attach
+ * those when {@link #isPresent()} is {@code true}.
+ */
+public final class ProfileTraceContext {
+
+    private static final ProfileTraceContext NONE = new ProfileTraceContext(null, null);
+
+    private final String traceId;
+    private final String spanId;
+
+    private ProfileTraceContext(String traceId, String spanId) {
+        this.traceId = normalize(traceId, 32);
+        this.spanId = normalize(spanId, 16);
+    }
+
+    /** The empty context: no trace linkage. */
+    public static ProfileTraceContext none() {
+        return NONE;
+    }
+
+    /**
+     * Builds a context from the supplied W3C ids. Either may be {@code null} or
+     * malformed; malformed/blank ids are dropped (treated as absent). A context
+     * with neither a valid trace id nor a valid span id is equivalent to
+     * {@link #none()}.
+     */
+    public static ProfileTraceContext of(String traceId, String spanId) {
+        ProfileTraceContext ctx = new ProfileTraceContext(traceId, spanId);
+        return ctx.isPresent() ? ctx : NONE;
+    }
+
+    /** The active trace id (32-hex lowercase) or {@code null} when absent. */
+    public String traceId() {
+        return traceId;
+    }
+
+    /** The active span id (16-hex lowercase) or {@code null} when absent. */
+    public String spanId() {
+        return spanId;
+    }
+
+    /** {@code true} when at least one of trace id / span id is present and valid. */
+    public boolean isPresent() {
+        return traceId != null || spanId != null;
+    }
+
+    /** Validates a W3C id: must be {@code hexLen} lowercase hex and not all-zero. */
+    private static String normalize(String id, int hexLen) {
+        if (id == null) {
+            return null;
+        }
+        String t = id.trim().toLowerCase(java.util.Locale.ROOT);
+        if (t.length() == hexLen && t.matches("[0-9a-f]{" + hexLen + "}") && !t.equals("0".repeat(hexLen))) {
+            return t;
+        }
+        return null;
+    }
+}

--- a/argus-aggregator/src/test/java/io/argus/aggregator/OtlpProfilesEncoderTest.java
+++ b/argus-aggregator/src/test/java/io/argus/aggregator/OtlpProfilesEncoderTest.java
@@ -59,6 +59,39 @@ class OtlpProfilesEncoderTest {
     }
 
     @Test
+    void roundTripPreservesLeadingTrailingAndDoubledSemicolons() {
+        // async-profiler can emit blank/unknown frame names, so leading ';',
+        // trailing ';', and doubled ';;' must survive the round-trip unchanged.
+        Map<String, Long> collapsed = new LinkedHashMap<>();
+        collapsed.put(";main", 2L);   // leading empty frame
+        collapsed.put("main;", 3L);   // trailing empty frame
+        collapsed.put("a;;b", 4L);    // doubled (interior empty frame)
+
+        ProfilesData data = OtlpProfilesEncoder.toProfilesData(collapsed);
+        Map<String, Long> back = OtlpProfilesEncoder.toCollapsed(data);
+
+        assertEquals(collapsed, back,
+                "leading/trailing/doubled semicolons must round-trip identically");
+    }
+
+    @Test
+    void distinctStacksDifferingOnlyByEmptyFramesDoNotMerge() {
+        // Previously ";main" and "main" both collapsed to ["main"] and merged.
+        // Empty frames are now real frames, so these stay distinct.
+        Map<String, Long> collapsed = new LinkedHashMap<>();
+        collapsed.put("main", 5L);
+        collapsed.put(";main", 7L);
+
+        ProfilesData data = OtlpProfilesEncoder.toProfilesData(collapsed);
+        Map<String, Long> back = OtlpProfilesEncoder.toCollapsed(data);
+
+        assertEquals(2, data.samples().size(), "the two stacks must not merge into one sample");
+        assertEquals(collapsed, back);
+        assertEquals(5L, back.get("main"));
+        assertEquals(7L, back.get(";main"));
+    }
+
+    @Test
     void roundTripSkipsNonPositiveCounts() {
         Map<String, Long> collapsed = new LinkedHashMap<>();
         collapsed.put("main;a", 5L);

--- a/argus-aggregator/src/test/java/io/argus/aggregator/OtlpProfilesEncoderTest.java
+++ b/argus-aggregator/src/test/java/io/argus/aggregator/OtlpProfilesEncoderTest.java
@@ -1,0 +1,154 @@
+package io.argus.aggregator;
+
+import io.argus.aggregator.profile.OtlpProfilesEncoder;
+import io.argus.aggregator.profile.OtlpProfilesEncoder.ProfilesData;
+import io.argus.aggregator.profile.ProfileTraceContext;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Unit tests for the OTLP Profiles (pprof-shaped) encoder.
+ *
+ * <p>Covers the W5 acceptance criteria: lossless collapsed→ProfilesData→collapsed
+ * round-trip, trace/span linkage presence/absence, the experimental flag gate
+ * ({@code argus.profiles.otlp.enabled}, default off ⇒ no-op), and the hand-coded
+ * OTLP/JSON shape (string/function/location tables + samples).
+ */
+class OtlpProfilesEncoderTest {
+
+    @AfterEach
+    void clearFlag() {
+        System.clearProperty(OtlpProfilesEncoder.FLAG_ENABLED);
+    }
+
+    // ── Criterion 2: lossless round-trip ──────────────────────────────────────
+
+    @Test
+    void roundTripIsLosslessOnSampleValuesAndFrames() {
+        Map<String, Long> collapsed = new LinkedHashMap<>();
+        collapsed.put("main;a;b", 10L);
+        collapsed.put("main;a;c", 5L);
+        collapsed.put("main;d", 3L);
+
+        ProfilesData data = OtlpProfilesEncoder.toProfilesData(collapsed);
+        Map<String, Long> back = OtlpProfilesEncoder.toCollapsed(data);
+
+        assertEquals(collapsed, back, "round-trip must preserve every stack and count");
+    }
+
+    @Test
+    void roundTripInternsSharedFramesOnceAndKeepsLeafFirstOrdering() {
+        Map<String, Long> collapsed = new LinkedHashMap<>();
+        collapsed.put("main;a;b", 7L);
+        collapsed.put("main;a;d", 4L);
+
+        ProfilesData data = OtlpProfilesEncoder.toProfilesData(collapsed);
+
+        // String table: index 0 is "" (pprof convention) + {main,a,b,d} = 5 distinct.
+        assertEquals("", data.stringTable().get(0));
+        assertEquals(5, data.stringTable().size(),
+                "shared frames main/a interned once: ''+main+a+b+d");
+
+        Map<String, Long> back = OtlpProfilesEncoder.toCollapsed(data);
+        assertEquals(collapsed, back);
+    }
+
+    @Test
+    void roundTripSkipsNonPositiveCounts() {
+        Map<String, Long> collapsed = new LinkedHashMap<>();
+        collapsed.put("main;a", 5L);
+        collapsed.put("main;zero", 0L);
+        collapsed.put("main;neg", -3L);
+
+        ProfilesData data = OtlpProfilesEncoder.toProfilesData(collapsed);
+        Map<String, Long> back = OtlpProfilesEncoder.toCollapsed(data);
+
+        assertEquals(Map.of("main;a", 5L), back);
+        assertEquals(1, data.samples().size());
+    }
+
+    // ── Criterion 3: trace/span linkage ───────────────────────────────────────
+
+    @Test
+    void samplesCarryTraceAndSpanIdWhenContextPresent() {
+        Map<String, Long> collapsed = Map.of("main;a", 4L);
+        String traceId = "0123456789abcdef0123456789abcdef";
+        String spanId = "fedcba9876543210";
+
+        String json = OtlpProfilesEncoder.encodeUnconditionally(
+                collapsed, ProfileTraceContext.of(traceId, spanId));
+
+        assertTrue(json.contains("\"key\":\"trace_id\""), json);
+        assertTrue(json.contains("\"stringValue\":\"" + traceId + "\""), json);
+        assertTrue(json.contains("\"key\":\"span_id\""), json);
+        assertTrue(json.contains("\"stringValue\":\"" + spanId + "\""), json);
+    }
+
+    @Test
+    void samplesOmitLinkageWhenContextAbsent() {
+        Map<String, Long> collapsed = Map.of("main;a", 4L);
+
+        String json = OtlpProfilesEncoder.encodeUnconditionally(
+                collapsed, ProfileTraceContext.none());
+
+        assertFalse(json.contains("trace_id"), json);
+        assertFalse(json.contains("span_id"), json);
+        assertFalse(json.contains("\"attributes\":[{\"key\":\"trace_id\""), json);
+    }
+
+    @Test
+    void malformedTraceContextIsTreatedAsAbsent() {
+        Map<String, Long> collapsed = Map.of("main;a", 4L);
+
+        // Too short / all-zero ids are invalid -> none().
+        ProfileTraceContext ctx = ProfileTraceContext.of("not-hex", "0000000000000000");
+        assertFalse(ctx.isPresent());
+
+        String json = OtlpProfilesEncoder.encodeUnconditionally(collapsed, ctx);
+        assertFalse(json.contains("trace_id"), json);
+        assertFalse(json.contains("span_id"), json);
+    }
+
+    // ── Criterion 4: experimental flag gate (default off ⇒ no-op) ─────────────
+
+    @Test
+    void encodeIsNoOpWhenFlagDisabledByDefault() {
+        assertFalse(OtlpProfilesEncoder.isEnabled());
+        String json = OtlpProfilesEncoder.encode(Map.of("main;a", 4L), ProfileTraceContext.none());
+        assertNull(json, "encode must be a no-op (null) when the experimental flag is off");
+    }
+
+    @Test
+    void encodeEmitsWhenFlagEnabled() {
+        System.setProperty(OtlpProfilesEncoder.FLAG_ENABLED, "true");
+        assertTrue(OtlpProfilesEncoder.isEnabled());
+        String json = OtlpProfilesEncoder.encode(Map.of("main;a", 4L), ProfileTraceContext.none());
+        assertNotNull(json);
+        assertTrue(json.startsWith("{\"resourceProfiles\":["), json);
+    }
+
+    // ── Criterion 1: OTLP/JSON ProfilesData shape ─────────────────────────────
+
+    @Test
+    void emitsProfilesDataShapeWithTables() {
+        Map<String, Long> collapsed = new LinkedHashMap<>();
+        collapsed.put("main;a", 2L);
+
+        String json = OtlpProfilesEncoder.encodeUnconditionally(collapsed, ProfileTraceContext.none());
+
+        assertTrue(json.startsWith("{\"resourceProfiles\":[{"), json);
+        assertTrue(json.contains("\"scopeProfiles\":["), json);
+        assertTrue(json.contains("\"scope\":{\"name\":\"io.argus.profiles\""), json);
+        assertTrue(json.contains("\"sampleType\":[{\"type\":\"samples\",\"unit\":\"count\"}]"), json);
+        assertTrue(json.contains("\"stringTable\":["), json);
+        assertTrue(json.contains("\"function\":["), json);
+        assertTrue(json.contains("\"location\":["), json);
+        assertTrue(json.contains("\"sample\":[{\"locationIndex\":["), json);
+        assertTrue(json.contains("\"value\":[\"2\"]"), json);
+    }
+}


### PR DESCRIPTION
## Summary

Adds an **OTLP Profiles signal encoder** that converts Argus collapsed-stack profiles into the OTLP `ProfilesData` shape and emits it as OTLP/JSON, in the **same hand-coded, dependency-free style** as the existing OTLP metrics encoder (`OtlpJsonBuilder`) and span encoder (`OtlpSpanBuilder`).

OTLP Profiles is the **4th OpenTelemetry signal** — it reached **Alpha (2026-03) and is pre-GA**; its wire shape can still change. To keep the pre-GA spec from destabilising the default build, the encoder is **OFF by default** behind the experimental flag `argus.profiles.otlp.enabled`. `encode()` is a no-op (returns `null`) unless the flag is explicitly set, and **nothing wires it by default**.

## Dependency-free approach (and how losslessness is proven)

We deliberately add **no protobuf / pprof library** — consistent with the project's zero-heavy-dependency ethos. The OTLP Profiles message reuses the pprof interning model (one string table, function + location tables that index into it, and samples carrying leaf-first location indices + a value), and we model exactly that by hand (`ProfilesData`, `Function`, `Location`, `Sample`).

Because there is no pprof codec to round-trip through, losslessness is proven the honest, dependency-free way: `toProfilesData(collapsed)` interns the stacks, and the inverse `toCollapsed(ProfilesData)` reconstructs the original `stack -> count` map; a unit test asserts the round-trip is identity (equal sample values **and** stack frames). 

> Note: end-to-end ingest by a **live OTel Collector profiles pipeline** is a separate, **documented MANUAL verification step** that needs external infrastructure; it is intentionally not part of this CI-runnable change.

## Trace linkage (reuses #245)

When a trace context is present, every sample carries `trace_id` / `span_id` link attributes so a backend can correlate the profile with the trace timeline produced by the GC-pause↔trace correlation work (#245). `argus-aggregator` keeps **zero** compile-time dependency on `argus-server`/OpenTelemetry, so the resolved W3C ids are passed in via `ProfileTraceContext` (mirroring `TraceContextHolder`) rather than reaching across the module seam. When no context is active the attributes are omitted.

## Acceptance criteria — how each is verified

1. **Encoder → ProfilesData shape as OTLP/JSON, matching the hand-coded metrics encoder, no new dependency.** — `emitsProfilesDataShapeWithTables` asserts `resourceProfiles`/`scopeProfiles`/`sampleType`/`stringTable`/`function`/`location`/`sample` shape. No new Gradle dependency added.
2. **Lossless round-trip on a fixture.** — `roundTripIsLosslessOnSampleValuesAndFrames` + `roundTripInternsSharedFramesOnceAndKeepsLeafFirstOrdering` + `roundTripSkipsNonPositiveCounts` assert `collapsed == toCollapsed(toProfilesData(collapsed))`.
3. **Trace/span linkage present iff context present.** — `samplesCarryTraceAndSpanIdWhenContextPresent`, `samplesOmitLinkageWhenContextAbsent`, `malformedTraceContextIsTreatedAsAbsent`.
4. **Experimental flag, default false ⇒ no emission.** — `encodeIsNoOpWhenFlagDisabledByDefault` (returns `null`) and `encodeEmitsWhenFlagEnabled`.
5. **Isolated so the pre-GA spec cannot destabilise the default build.** — gated entry point, nothing wired by default; the only new code is three files in `argus-aggregator/.../profile/`.

## Verification

- `./gradlew :argus-aggregator:test --tests "io.argus.aggregator.OtlpProfilesEncoderTest"` → **BUILD SUCCESSFUL**, 9 tests, 0 failures, 0 errors.
- `./gradlew :argus-aggregator:test` (full module) → **BUILD SUCCESSFUL**.
- `./gradlew :argus-aggregator:build` → **BUILD SUCCESSFUL** (jar + check, no strict implicit-dependency error in this module).

## Files

- `argus-aggregator/.../profile/OtlpProfilesEncoder.java` (encoder + pprof-shaped model + flag gate)
- `argus-aggregator/.../profile/ProfileTraceContext.java` (trace/span link carrier)
- `argus-aggregator/.../OtlpProfilesEncoderTest.java` (9 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
