### PR TITLE
feat: Argus-unique profiling intelligence (anomaly-triggered capture, alloc→retained cross-link, unified view)

### DIFF
--- a/argus-aggregator/src/main/java/io/argus/aggregator/profile/AllocRetainedCrossLink.java
+++ b/argus-aggregator/src/main/java/io/argus/aggregator/profile/AllocRetainedCrossLink.java
@@ -1,0 +1,127 @@
+package io.argus.aggregator.profile;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Joins allocation-profile hot types with heap dominator / retained-size data to
+ * answer the JVM-deep question "the types we allocate the most — how much heap do
+ * they actually <em>retain</em>?".
+ *
+ * <p>This cross-link has no host-profiler / eBPF equivalent: allocation rate alone
+ * (what a flame graph or perf counter shows) does not tell you whether those
+ * allocations are short-lived churn or long-lived retention. Joining the
+ * async-profiler / JFR {@code alloc} hot types against the dominator-tree retained
+ * sizes (from {@code argus-diagnostics} heapgraph) attributes "allocation site/type
+ * X retains N bytes", which only a JVM-object-graph-aware tool can produce.
+ *
+ * <p>Pure and dependency-free: it operates on plain inputs (a list of
+ * {@link AllocType} hot types and a {@code className -> retainedBytes} map) so it is
+ * unit-testable without a live JVM or heap dump. The glue that extracts those inputs
+ * from {@code AllocationAnalyzer.AllocationAnalysisResult} (server) and
+ * {@code HeapGraphAnalysis.retainedByClass} (diagnostics) is a thin caller-side
+ * adapter and is the integration follow-up.
+ */
+public final class AllocRetainedCrossLink {
+
+    private AllocRetainedCrossLink() {}
+
+    /**
+     * A hot allocation type from an allocation profile: the type's fully-qualified
+     * name and the bytes/objects allocated to it over the profiling window.
+     */
+    public static final class AllocType {
+        private final String className;
+        private final long allocatedBytes;
+        private final long allocationCount;
+
+        public AllocType(String className, long allocatedBytes, long allocationCount) {
+            this.className = className;
+            this.allocatedBytes = allocatedBytes;
+            this.allocationCount = allocationCount;
+        }
+
+        public String className() { return className; }
+        public long allocatedBytes() { return allocatedBytes; }
+        public long allocationCount() { return allocationCount; }
+    }
+
+    /**
+     * One cross-linked entry: an allocation hot type attributed to the heap it
+     * retains, with the ratio of retained-to-allocated bytes (a churn vs. retention
+     * signal — a high ratio means the allocations stick around).
+     */
+    public static final class Entry {
+        private final String className;
+        private final long allocatedBytes;
+        private final long allocationCount;
+        private final long retainedBytes;
+
+        public Entry(String className, long allocatedBytes, long allocationCount, long retainedBytes) {
+            this.className = className;
+            this.allocatedBytes = allocatedBytes;
+            this.allocationCount = allocationCount;
+            this.retainedBytes = retainedBytes;
+        }
+
+        public String className() { return className; }
+        public long allocatedBytes() { return allocatedBytes; }
+        public long allocationCount() { return allocationCount; }
+        public long retainedBytes() { return retainedBytes; }
+
+        /**
+         * Retained-to-allocated ratio. {@code 0.0} when nothing was allocated.
+         * A value near 1.0 means the allocated bytes are largely still retained;
+         * a value near 0.0 means short-lived churn.
+         */
+        public double retainedRatio() {
+            return allocatedBytes <= 0 ? 0.0 : (double) retainedBytes / (double) allocatedBytes;
+        }
+
+        /** Human-readable attribution line, e.g. for a report row. */
+        public String describe() {
+            return String.format("allocation type %s retains %d bytes (allocated %d bytes)",
+                    className, retainedBytes, allocatedBytes);
+        }
+    }
+
+    /**
+     * Cross-links allocation hot types with their retained sizes.
+     *
+     * <p>For each hot allocation type, looks up its retained size in
+     * {@code retainedByType} (0 when the type retains nothing reachable, e.g. pure
+     * churn). The result is sorted by retained bytes descending, then by allocated
+     * bytes descending, so the type that retains the most heap leads — which is the
+     * actionable one for a leak / memory-pressure investigation.
+     *
+     * @param hotTypes       allocation-profile hot types (non-null; null/blank-named entries skipped)
+     * @param retainedByType {@code className -> retainedBytes} from heap dominator analysis (non-null)
+     * @return cross-linked entries, sorted by retained bytes (desc), then allocated bytes (desc)
+     */
+    public static List<Entry> link(List<AllocType> hotTypes, Map<String, Long> retainedByType) {
+        if (hotTypes == null) {
+            throw new IllegalArgumentException("hotTypes must not be null");
+        }
+        if (retainedByType == null) {
+            throw new IllegalArgumentException("retainedByType must not be null");
+        }
+        List<Entry> entries = new ArrayList<>(hotTypes.size());
+        for (AllocType t : hotTypes) {
+            if (t == null || t.className() == null || t.className().isBlank()) {
+                continue;
+            }
+            Long retained = retainedByType.get(t.className());
+            long retainedBytes = retained == null ? 0L : retained;
+            entries.add(new Entry(t.className(), t.allocatedBytes(), t.allocationCount(), retainedBytes));
+        }
+        entries.sort((a, b) -> {
+            int byRetained = Long.compare(b.retainedBytes(), a.retainedBytes());
+            if (byRetained != 0) {
+                return byRetained;
+            }
+            return Long.compare(b.allocatedBytes(), a.allocatedBytes());
+        });
+        return entries;
+    }
+}

--- a/argus-aggregator/src/main/java/io/argus/aggregator/profile/UnifiedProfileView.java
+++ b/argus-aggregator/src/main/java/io/argus/aggregator/profile/UnifiedProfileView.java
@@ -1,0 +1,118 @@
+package io.argus.aggregator.profile;
+
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * Merges profile samples that arrive from two different JVM sources — JFR
+ * (Flight Recorder) execution-sample stacks and async-profiler collapsed stacks —
+ * into one unified {@code stack -> count} view, while still tracking which source
+ * each stack came from.
+ *
+ * <p>Argus ingests both kinds of profile: JFR events (always-available, low-overhead,
+ * built into the JVM) and async-profiler captures (richer native + alloc detail).
+ * They describe the same threads but in two different formats and overhead profiles.
+ * A unified view lets a single flame graph / query span both sources without the
+ * operator having to know which collector produced a given window.
+ *
+ * <p>Both inputs are collapsed-stack maps ({@code "a;b;c" -> count}, leaf last) as
+ * {@link FlameTree} and {@link ProfileStore} already use. The merged map sums counts
+ * for identical stacks across sources; per-source totals and the set of contributing
+ * sources are preserved so a caller can attribute or filter.
+ *
+ * <p>Pure and dependency-free, so it is unit-testable without a live JVM. The
+ * resulting {@link #merged()} map feeds straight into {@link FlameTree#toJson} for a
+ * single unified flame graph.
+ */
+public final class UnifiedProfileView {
+
+    /** Origin of a set of collapsed stacks. */
+    public enum Source { JFR, ASYNC_PROFILER }
+
+    // Summed stack -> total count across all merged sources.
+    private final Map<String, Long> merged = new LinkedHashMap<>();
+    // Per-source total sample count contributed.
+    private final Map<Source, Long> perSourceTotals = new LinkedHashMap<>();
+
+    /**
+     * Adds a source's collapsed stacks into the unified view, summing counts for
+     * stacks already present.
+     *
+     * @param source   which collector produced these stacks (non-null)
+     * @param collapsed {@code stack -> count} map (null treated as empty; non-positive counts skipped)
+     * @return this view, for chaining
+     */
+    public UnifiedProfileView add(Source source, Map<String, Long> collapsed) {
+        if (source == null) {
+            throw new IllegalArgumentException("source must not be null");
+        }
+        perSourceTotals.putIfAbsent(source, 0L);
+        if (collapsed == null) {
+            return this;
+        }
+        for (Map.Entry<String, Long> e : collapsed.entrySet()) {
+            String stack = e.getKey();
+            long count = e.getValue() == null ? 0L : e.getValue();
+            if (stack == null || stack.isBlank() || count <= 0L) {
+                continue;
+            }
+            merged.merge(stack, count, Long::sum);
+            perSourceTotals.merge(source, count, Long::sum);
+        }
+        return this;
+    }
+
+    /**
+     * Convenience factory: merge one JFR map and one async-profiler map.
+     *
+     * @param jfr   JFR-sourced collapsed stacks (may be null)
+     * @param async async-profiler-sourced collapsed stacks (may be null)
+     * @return a unified view containing both sources
+     */
+    public static UnifiedProfileView of(Map<String, Long> jfr, Map<String, Long> async) {
+        return new UnifiedProfileView()
+                .add(Source.JFR, jfr)
+                .add(Source.ASYNC_PROFILER, async);
+    }
+
+    /**
+     * The unified {@code stack -> totalCount} map, summed across all added sources.
+     * Suitable to hand directly to {@link FlameTree#toJson}.
+     *
+     * @return a copy of the merged map
+     */
+    public Map<String, Long> merged() {
+        return new LinkedHashMap<>(merged);
+    }
+
+    /**
+     * Per-source contributed sample totals. A source that was added with no
+     * positive-count stacks still appears with a total of {@code 0}.
+     *
+     * @return a copy of the per-source totals
+     */
+    public Map<Source, Long> perSourceTotals() {
+        return new HashMap<>(perSourceTotals);
+    }
+
+    /**
+     * Whether the given source contributed to this unified view (i.e. was added,
+     * regardless of whether it carried any positive-count stacks).
+     *
+     * @param source the source to check
+     * @return true if the source was added
+     */
+    public boolean hasSource(Source source) {
+        return perSourceTotals.containsKey(source);
+    }
+
+    /** Total sample count across all sources and stacks. */
+    public long totalSamples() {
+        long total = 0L;
+        for (long v : merged.values()) {
+            total += v;
+        }
+        return total;
+    }
+}

--- a/argus-aggregator/src/test/java/io/argus/aggregator/AllocRetainedCrossLinkTest.java
+++ b/argus-aggregator/src/test/java/io/argus/aggregator/AllocRetainedCrossLinkTest.java
@@ -1,0 +1,80 @@
+package io.argus.aggregator;
+
+import io.argus.aggregator.profile.AllocRetainedCrossLink;
+import io.argus.aggregator.profile.AllocRetainedCrossLink.AllocType;
+import io.argus.aggregator.profile.AllocRetainedCrossLink.Entry;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class AllocRetainedCrossLinkTest {
+
+    @Test
+    void topAllocationType_crossLinksToItsRetainedSize_sortedByRetained() {
+        // Synthetic alloc profile: byte[] allocates the most, but char[] retains more.
+        List<AllocType> hot = List.of(
+                new AllocType("byte[]", 10_000_000L, 5_000L),
+                new AllocType("char[]", 4_000_000L, 2_000L),
+                new AllocType("java.lang.String", 1_000_000L, 8_000L));
+        // Synthetic dominator/retained map: char[] retains the most heap.
+        Map<String, Long> retained = Map.of(
+                "char[]", 9_000_000L,
+                "byte[]", 1_000_000L,
+                "java.lang.String", 500_000L);
+
+        List<Entry> entries = AllocRetainedCrossLink.link(hot, retained);
+
+        assertEquals(3, entries.size());
+        // Sorted by retained bytes desc -> char[] leads despite lower alloc bytes.
+        Entry top = entries.get(0);
+        assertEquals("char[]", top.className());
+        assertEquals(9_000_000L, top.retainedBytes());
+        assertEquals(4_000_000L, top.allocatedBytes());
+        assertEquals(2_000L, top.allocationCount());
+
+        assertEquals("byte[]", entries.get(1).className());
+        assertEquals("java.lang.String", entries.get(2).className());
+    }
+
+    @Test
+    void typeWithNoRetainedEntry_isPureChurn_zeroRetained() {
+        List<AllocType> hot = List.of(new AllocType("int[]", 3_000_000L, 1_000L));
+        Map<String, Long> retained = Map.of(); // int[] retains nothing reachable
+
+        List<Entry> entries = AllocRetainedCrossLink.link(hot, retained);
+
+        assertEquals(1, entries.size());
+        Entry e = entries.get(0);
+        assertEquals(0L, e.retainedBytes());
+        assertEquals(0.0, e.retainedRatio());
+        assertTrue(e.describe().contains("int[]"));
+        assertTrue(e.describe().contains("retains 0 bytes"));
+    }
+
+    @Test
+    void retainedRatio_signalsRetentionVsChurn() {
+        List<AllocType> hot = List.of(new AllocType("com.x.Cache$Node", 2_000_000L, 100L));
+        Map<String, Long> retained = Map.of("com.x.Cache$Node", 2_000_000L);
+
+        Entry e = AllocRetainedCrossLink.link(hot, retained).get(0);
+        assertEquals(1.0, e.retainedRatio()); // allocated bytes are fully retained
+    }
+
+    @Test
+    void skipsNullAndBlankNamedTypes() {
+        java.util.List<AllocType> hot = new java.util.ArrayList<>();
+        hot.add(null);
+        hot.add(new AllocType("  ", 1L, 1L));
+        hot.add(new AllocType("Good", 5L, 1L));
+
+        List<Entry> entries = AllocRetainedCrossLink.link(hot, Map.of("Good", 9L));
+
+        assertEquals(1, entries.size());
+        assertEquals("Good", entries.get(0).className());
+        assertEquals(9L, entries.get(0).retainedBytes());
+    }
+}

--- a/argus-aggregator/src/test/java/io/argus/aggregator/UnifiedProfileViewTest.java
+++ b/argus-aggregator/src/test/java/io/argus/aggregator/UnifiedProfileViewTest.java
@@ -1,0 +1,73 @@
+package io.argus.aggregator;
+
+import io.argus.aggregator.profile.UnifiedProfileView;
+import io.argus.aggregator.profile.UnifiedProfileView.Source;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class UnifiedProfileViewTest {
+
+    @Test
+    void mergesJfrAndAsyncProfilerStacks_bothSourcesRepresented() {
+        Map<String, Long> jfr = Map.of(
+                "main;com.x.A.run", 10L,
+                "main;com.x.B.work", 5L);
+        Map<String, Long> async = Map.of(
+                "main;com.x.A.run", 3L,   // shared stack -> summed
+                "main;com.x.C.alloc", 7L);
+
+        UnifiedProfileView view = UnifiedProfileView.of(jfr, async);
+
+        // Both sources are represented in the unified structure.
+        assertTrue(view.hasSource(Source.JFR));
+        assertTrue(view.hasSource(Source.ASYNC_PROFILER));
+
+        Map<String, Long> merged = view.merged();
+        assertEquals(3, merged.size());
+        assertEquals(13L, merged.get("main;com.x.A.run")); // 10 + 3 summed across sources
+        assertEquals(5L, merged.get("main;com.x.B.work"));
+        assertEquals(7L, merged.get("main;com.x.C.alloc"));
+
+        assertEquals(15L, view.perSourceTotals().get(Source.JFR));
+        assertEquals(10L, view.perSourceTotals().get(Source.ASYNC_PROFILER));
+        assertEquals(25L, view.totalSamples());
+    }
+
+    @Test
+    void addedSourceWithNoStacks_stillCountsAsRepresented() {
+        UnifiedProfileView view = UnifiedProfileView.of(Map.of("a;b", 4L), Map.of());
+
+        assertTrue(view.hasSource(Source.JFR));
+        assertTrue(view.hasSource(Source.ASYNC_PROFILER));
+        assertEquals(0L, view.perSourceTotals().get(Source.ASYNC_PROFILER));
+        assertEquals(4L, view.totalSamples());
+    }
+
+    @Test
+    void unaddedSource_isNotRepresented() {
+        UnifiedProfileView view = new UnifiedProfileView().add(Source.JFR, Map.of("a", 1L));
+        assertTrue(view.hasSource(Source.JFR));
+        assertFalse(view.hasSource(Source.ASYNC_PROFILER));
+    }
+
+    @Test
+    void nullAndNonPositiveCounts_ignored() {
+        java.util.HashMap<String, Long> noisy = new java.util.HashMap<>();
+        noisy.put("good", 2L);
+        noisy.put("zero", 0L);
+        noisy.put("neg", -5L);
+        noisy.put("nullcount", null);
+        noisy.put("  ", 9L);
+
+        UnifiedProfileView view = new UnifiedProfileView().add(Source.ASYNC_PROFILER, noisy);
+
+        Map<String, Long> merged = view.merged();
+        assertEquals(1, merged.size());
+        assertEquals(2L, merged.get("good"));
+    }
+}

--- a/argus-server/src/main/java/io/argus/server/analysis/AnomalyCaptureBinder.java
+++ b/argus-server/src/main/java/io/argus/server/analysis/AnomalyCaptureBinder.java
@@ -1,0 +1,151 @@
+package io.argus.server.analysis;
+
+import io.argus.server.analysis.AnomalyDetector.AnomalyType;
+import io.argus.server.analysis.AnomalyDetector.CaptureRecommendation;
+
+import java.time.Duration;
+import java.time.Instant;
+
+/**
+ * Turns an {@link AnomalyDetector} {@link CaptureRecommendation} into a concrete,
+ * reason-tagged {@link ProfileCaptureRequest}.
+ *
+ * <p>This is the W4 anomaly-triggered-capture binding: when the detector reports a
+ * capture recommendation (an anomaly fired while continuous profiling is on), this
+ * binder produces a short profile-capture request whose {@code reason} carries the
+ * triggering anomaly's reason verbatim, so the captured artifact is attributable to
+ * the anomaly that motivated it.
+ *
+ * <p>The binder is intentionally side-effect free and does not drive a live agent
+ * capture loop: it models the capture <em>request</em> (and, via
+ * {@link ProfileCaptureRequest#completed}, the resulting <em>artifact</em>) so the
+ * binding is unit testable without a JVM/agent attach. Wiring the request to an
+ * actual async-profiler capture on the agent side is the integration follow-up.
+ *
+ * <p>The async-profiler event type is chosen from the triggering signal: a CPU
+ * anomaly requests a {@code "cpu"} capture; an ALLOC anomaly requests an
+ * {@code "alloc"} capture. Capture duration defaults to {@link #DEFAULT_DURATION}.
+ */
+public final class AnomalyCaptureBinder {
+
+    /** Default short-capture duration when none is supplied. */
+    public static final Duration DEFAULT_DURATION = Duration.ofSeconds(30);
+
+    private final Duration captureDuration;
+
+    /** Creates a binder using {@link #DEFAULT_DURATION}. */
+    public AnomalyCaptureBinder() {
+        this(DEFAULT_DURATION);
+    }
+
+    /**
+     * Creates a binder with an explicit capture duration.
+     *
+     * @param captureDuration how long the requested capture should run (non-null, positive)
+     */
+    public AnomalyCaptureBinder(Duration captureDuration) {
+        if (captureDuration == null || captureDuration.isZero() || captureDuration.isNegative()) {
+            throw new IllegalArgumentException("captureDuration must be positive");
+        }
+        this.captureDuration = captureDuration;
+    }
+
+    /**
+     * Builds a reason-tagged capture request for the given recommendation.
+     *
+     * @param recommendation the active capture recommendation (must be non-null)
+     * @return a capture request carrying the recommendation's triggering reason
+     * @throws IllegalArgumentException if {@code recommendation} is null
+     */
+    public ProfileCaptureRequest bind(CaptureRecommendation recommendation) {
+        if (recommendation == null) {
+            throw new IllegalArgumentException("recommendation must not be null");
+        }
+        String eventType = eventTypeFor(recommendation.triggerType());
+        return new ProfileCaptureRequest(
+                recommendation.timestamp(),
+                recommendation.triggerType(),
+                eventType,
+                captureDuration,
+                recommendation.reason());
+    }
+
+    /**
+     * Builds a request from the detector's currently-active recommendation, if any.
+     *
+     * @param detector the anomaly detector to read from (non-null)
+     * @return the bound request, or {@code null} if no capture is currently recommended
+     */
+    public ProfileCaptureRequest bindActive(AnomalyDetector detector) {
+        if (detector == null) {
+            throw new IllegalArgumentException("detector must not be null");
+        }
+        CaptureRecommendation rec = detector.captureRecommendation();
+        return rec == null ? null : bind(rec);
+    }
+
+    private static String eventTypeFor(AnomalyType type) {
+        // CPU anomaly -> sample CPU stacks; ALLOC anomaly -> sample allocation stacks.
+        return type == AnomalyType.ALLOC ? "alloc" : "cpu";
+    }
+
+    /**
+     * A short profile-capture request produced from an anomaly capture
+     * recommendation. The {@code reason} is the triggering anomaly's reason,
+     * preserved verbatim so the eventual artifact is attributable to it.
+     */
+    public static final class ProfileCaptureRequest {
+        private final Instant requestedAt;
+        private final AnomalyType triggerType;
+        private final String eventType;
+        private final Duration duration;
+        private final String reason;
+
+        public ProfileCaptureRequest(Instant requestedAt, AnomalyType triggerType,
+                                     String eventType, Duration duration, String reason) {
+            this.requestedAt = requestedAt;
+            this.triggerType = triggerType;
+            this.eventType = eventType;
+            this.duration = duration;
+            this.reason = reason;
+        }
+
+        public Instant requestedAt() { return requestedAt; }
+        public AnomalyType triggerType() { return triggerType; }
+        public String eventType() { return eventType; }
+        public Duration duration() { return duration; }
+        public String reason() { return reason; }
+
+        /**
+         * Records the artifact that results from fulfilling this request, carrying
+         * the same triggering reason forward onto the captured artifact.
+         *
+         * @param artifactRef opaque reference to the captured profile (path, id, …)
+         * @return a reason-tagged capture result
+         */
+        public ProfileCaptureResult completed(String artifactRef) {
+            return new ProfileCaptureResult(this, artifactRef, reason);
+        }
+    }
+
+    /**
+     * The artifact produced by fulfilling a {@link ProfileCaptureRequest}. Carries
+     * the triggering {@code reason} so a stored capture remains attributable to the
+     * anomaly that motivated it.
+     */
+    public static final class ProfileCaptureResult {
+        private final ProfileCaptureRequest request;
+        private final String artifactRef;
+        private final String reason;
+
+        public ProfileCaptureResult(ProfileCaptureRequest request, String artifactRef, String reason) {
+            this.request = request;
+            this.artifactRef = artifactRef;
+            this.reason = reason;
+        }
+
+        public ProfileCaptureRequest request() { return request; }
+        public String artifactRef() { return artifactRef; }
+        public String reason() { return reason; }
+    }
+}

--- a/argus-server/src/test/java/io/argus/server/analysis/AnomalyCaptureBinderTest.java
+++ b/argus-server/src/test/java/io/argus/server/analysis/AnomalyCaptureBinderTest.java
@@ -1,0 +1,88 @@
+package io.argus.server.analysis;
+
+import io.argus.server.analysis.AnomalyCaptureBinder.ProfileCaptureRequest;
+import io.argus.server.analysis.AnomalyCaptureBinder.ProfileCaptureResult;
+import io.argus.server.analysis.AnomalyDetector.AnomalyType;
+import io.argus.server.analysis.AnomalyDetector.CaptureRecommendation;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.time.Instant;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class AnomalyCaptureBinderTest {
+
+    private static final Instant T0 = Instant.parse("2026-01-01T00:00:00Z");
+
+    @Test
+    void bind_carriesTriggeringReasonOntoRequest() {
+        String reason = "JVM CPU 97% over threshold 85% for 3 consecutive samples";
+        CaptureRecommendation rec = new CaptureRecommendation(T0, AnomalyType.CPU, reason);
+
+        ProfileCaptureRequest req = new AnomalyCaptureBinder().bind(rec);
+
+        // The capture request must carry the recommendation's reason verbatim.
+        assertEquals(reason, req.reason());
+        assertEquals(AnomalyType.CPU, req.triggerType());
+        assertEquals("cpu", req.eventType());
+        assertEquals(T0, req.requestedAt());
+        assertEquals(AnomalyCaptureBinder.DEFAULT_DURATION, req.duration());
+    }
+
+    @Test
+    void bind_allocAnomaly_requestsAllocCapture() {
+        String reason = "Allocation rate 900000 KB/s over threshold 500000 KB/s for 3 consecutive samples";
+        CaptureRecommendation rec = new CaptureRecommendation(T0, AnomalyType.ALLOC, reason);
+
+        ProfileCaptureRequest req = new AnomalyCaptureBinder(Duration.ofSeconds(10)).bind(rec);
+
+        assertEquals("alloc", req.eventType());
+        assertEquals(reason, req.reason());
+        assertEquals(Duration.ofSeconds(10), req.duration());
+    }
+
+    @Test
+    void completedArtifact_keepsTheReason() {
+        CaptureRecommendation rec = new CaptureRecommendation(T0, AnomalyType.ALLOC, "alloc spike");
+        ProfileCaptureRequest req = new AnomalyCaptureBinder().bind(rec);
+
+        ProfileCaptureResult result = req.completed("/captures/abc.collapsed");
+
+        // The captured artifact stays attributable to the triggering anomaly.
+        assertEquals("alloc spike", result.reason());
+        assertEquals("/captures/abc.collapsed", result.artifactRef());
+        assertSame(req, result.request());
+    }
+
+    @Test
+    void bindActive_usesDetectorRecommendation_endToEnd() {
+        // Use the real AnomalyDetector seam: drive it to fire, then bind its
+        // recommendation and assert the reason flows through unchanged.
+        AnomalyDetector d = new AnomalyDetector(0.85, 500_000.0, 3, 5, true);
+        for (int i = 0; i < 3; i++) {
+            d.recordCpuSample(0.95, T0.plusSeconds(i));
+        }
+        CaptureRecommendation rec = d.captureRecommendation();
+        assertEquals(rec.reason(), new AnomalyCaptureBinder().bindActive(d).reason());
+    }
+
+    @Test
+    void bindActive_returnsNullWhenNoRecommendation() {
+        AnomalyDetector d = new AnomalyDetector(0.85, 500_000.0, 3, 5, true);
+        assertNull(new AnomalyCaptureBinder().bindActive(d));
+    }
+
+    @Test
+    void bind_rejectsNullRecommendation() {
+        assertThrows(IllegalArgumentException.class, () -> new AnomalyCaptureBinder().bind(null));
+    }
+
+    @Test
+    void constructor_rejectsNonPositiveDuration() {
+        assertThrows(IllegalArgumentException.class, () -> new AnomalyCaptureBinder(Duration.ZERO));
+    }
+}


### PR DESCRIPTION
## What

Three Argus-unique profiling-intelligence components, each built on an existing seam (standalone off `master`; no dependency on unmerged branches).

### 1. Anomaly-triggered capture binding — `AnomalyCaptureBinder` (argus-server)
When `AnomalyDetector` reports a `CaptureRecommendation` (an anomaly fired while continuous profiling is on), the binder produces a short, reason-tagged `ProfileCaptureRequest`. The request carries the triggering anomaly's `reason` verbatim, and `ProfileCaptureRequest.completed(...)` carries that reason onto the resulting artifact — so a stored capture stays attributable to the anomaly that motivated it. CPU anomalies request a `cpu` capture; ALLOC anomalies request an `alloc` capture.

It reuses the real `AnomalyDetector.captureRecommendation()` / `isCaptureRecommended()` seam (`bindActive(detector)`). It is side-effect free and does **not** drive a live agent capture loop — it models the request/result so the binding is unit-testable without a JVM/agent attach. **Wiring the request to an actual async-profiler capture on the agent side is the integration follow-up.**

### 2. alloc→retained cross-link — `AllocRetainedCrossLink` (argus-aggregator)
Joins allocation-profile hot types with heap dominator / retained-size data (from the `argus-diagnostics` heapgraph dominator tree, #244), producing entries like *"allocation type X retains N bytes"* plus a retained-to-allocated ratio (a churn-vs-retention signal). Sorted by retained bytes descending so the type retaining the most heap leads.

**Why this is JVM-deep:** allocation rate alone (what a flame graph, `perf`, or an eBPF host profiler shows) cannot tell you whether hot allocations are short-lived churn or long-lived retention. Attributing allocated bytes to retained heap requires JVM object-graph dominator analysis — there is **no eBPF / host-profiler equivalent**.

### 3. Unified view — `UnifiedProfileView` (argus-aggregator)
Merges JFR-sourced and async-profiler-sourced collapsed stacks into a single `stack -> count` view, summing shared stacks while preserving per-source totals and which sources contributed. The merged map feeds straight into the existing `FlameTree.toJson`, so one flame graph / query can span both JVM profile sources.

## Design notes
- Components 2 and 3 are pure and operate on plain inputs (a hot-type list + a `className -> retainedBytes` map; two collapsed-stack maps), so they unit-test without a live JVM or heap dump and add **no new cross-module dependencies**. The thin caller-side glue that extracts those inputs from `AllocationAnalyzer.AllocationAnalysisResult` and `HeapGraphAnalysis.retainedByClass` is the integration follow-up.
- No user-facing CLI strings were added; these are analyzer-layer classes that do not use the CLI resource bundle (matching the existing analyzer/server pattern), so no i18n locale changes were required.

## Acceptance criteria — how verified
1. **Anomaly-triggered capture carries the reason** — `AnomalyCaptureBinderTest` drives the real `AnomalyDetector` to fire, binds its recommendation, and asserts the request (and the completed artifact) carry the recommendation's reason verbatim. ✅ 7 tests.
2. **alloc→retained cross-link** — `AllocRetainedCrossLinkTest` uses a synthetic fixture (a few alloc types + a retained-size map) and asserts the top entry cross-links to its retained size, sorted/attributed correctly (incl. pure-churn zero-retained and ratio cases). ✅ 4 tests.
3. **Unified view** — `UnifiedProfileViewTest` asserts both JFR and async-profiler sources are represented in the unified structure, with shared stacks summed and per-source totals preserved. ✅ 4 tests.
4. **Standalone off master** — uses only existing seams; touched modules build and tests are green.

## Test / build results
- `:argus-aggregator:test` (AllocRetainedCrossLinkTest, UnifiedProfileViewTest) — BUILD SUCCESSFUL; 4 + 4 tests, 0 failures.
- `:argus-server:test` (AnomalyCaptureBinderTest) — BUILD SUCCESSFUL; 7 tests, 0 failures.
- `:argus-aggregator:build` (incl. `jar`) + `:argus-server:compileJava`/`compileTestJava` — BUILD SUCCESSFUL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
