### PR TITLE
docs: sync command count to 71, tighten Why Argus, document rightsize

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
   <a href="https://github.com/rlaope/Argus/stargazers"><img src="https://img.shields.io/github/stars/rlaope/Argus" alt="GitHub stars"></a>
 </p>
 
-> **One CLI for all JVM diagnostics.** 70 commands, zero agent required, works on Java 11+.
+> **One CLI for all JVM diagnostics.** 71 commands, zero agent required, works on Java 11+.
 > The free alternative to GCEasy + jcmd + VisualVM + Arthas + Eclipse MAT combined — GC analysis, health diagnosis, flame graphs, async-profiler integration, MAT-class heap leak analysis, continuous profiling, distributed-tracing correlation, opt-in live method instrumentation, ZGC live monitoring, and CI/CD profile gates.
 
 ---
@@ -61,19 +61,19 @@ Full reference: [docs/harness.md](docs/harness.md)
 
 ## Why Argus?
 
-- **70 diagnostic commands** — heap, GC, threads, profiling, flame graphs, NMT, class loaders, and more. No agent required.
-- **MAT-class heap analysis** — `argus heapanalyze <file> --leak-suspects --dominators=N --path-to-root` builds a dominator tree, retained sizes, GC-roots reachability, and an automated leak-suspects report — offline, on multi-GB dumps, within a bounded analyzer heap.
-- **Continuous profiling** — disk-backed, time-windowed per-pod CPU/alloc profiles with merged-window flamegraph queries and differential flamegraphs across time ranges, no external TSDB.
-- **Distributed-tracing correlation** — GC pauses are correlated with in-flight W3C trace context and exported as OTel spans (plus Prometheus exemplars), so you can see which traces a pause stalled in Tempo/Jaeger/Grafana.
-- **Opt-in live instrumentation** — `argus instrument {watch|trace|monitor} <pid> <Class#method>` captures args/return/exception/timing on a running JVM via dynamic-attach bytecode instrumentation. Default OFF, isolated module, auto-detach with zero residual bytecode.
-- **Incident forensic bundle** — `argus snapshot <pid>` collects threads, histogram, doctor, JFR, and (optionally) a heap dump into one tar.gz for offline analysis.
-- **Connection-pool diagnostics** — `argus pool jdbc <pid>` reports HikariCP / Tomcat JDBC state; `argus pool advise` recommends thread-pool sizing from a ThreadMXBean sample.
-- **Live JVM attach** — attaches externally via `jcmd`/JMX; target JVM needs no restart and no `-javaagent` flag.
-- **OpenMetrics + Grafana** — OpenMetrics-compliant `/prometheus` export with per-collector GC pause histograms and exemplars, plus a shipped Grafana dashboard and recording/alert rules.
-- **ZGC + G1-aware** — `argus zgc` / `argus g1` give a HEALTHY/WARNING/UNHEALTHY verdict with allocation stall detection, cycle-overlap analysis, SoftMax breach detection, and diff-against-baseline in one command.
-- **Virtual thread support** — JFR-based pinning detection, carrier-thread distribution, and virtual thread monitoring on Java 21+.
+One CLI to diagnose a live JVM and watch a fleet — no agent, no restart, no `-javaagent`. It attaches externally over `jcmd`/JMX and reads the JVM right where it runs.
 
-> Full command reference: [docs/cli-commands.md](docs/cli-commands.md)
+- **Zero-install live attach** — point it at a PID; the target needs no restart and no agent flag.
+- **One-command health verdict** — `argus doctor` returns HEALTHY / WARN / CRITICAL with machine-readable exit codes for CI gates.
+- **MAT-class heap analysis, offline** — dominator tree, retained sizes, and automated leak suspects on multi-GB dumps within a bounded heap.
+- **Continuous profiling, no TSDB** — disk-backed per-pod CPU/alloc flamegraphs with time-window merges and differential views.
+- **GC ↔ trace correlation** — see which traces a GC pause stalled, exported as OTel spans and Prometheus exemplars.
+- **Opt-in live instrumentation** — watch/trace/monitor method args, returns, and timing via dynamic attach; default OFF, auto-detach, zero residual bytecode.
+- **JVM right-sizing for FinOps** — `argus rightsize` recommends `-Xmx` and container memory from observed heap high-water-mark and GC headroom.
+- **GC-aware verdicts & Loom** — `argus g1` / `argus zgc` flag allocation stalls, cycle overlap, and SoftMax breaches; virtual-thread pinning detection on Java 21+.
+- **OpenTelemetry-native** — OpenMetrics `/prometheus`, OTLP export, and a shipped Grafana dashboard.
+
+> 71 commands in total — full reference: [docs/cli-commands.md](docs/cli-commands.md)
 
 ---
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,7 +9,7 @@ Welcome to the Project Argus documentation.
 
 ## Reference
 
-- [CLI Command Reference](cli-commands.md) — Index of all 70 commands with category navigation and A–Z lookup
+- [CLI Command Reference](cli-commands.md) — Index of all 71 commands with category navigation and A–Z lookup
   - [commands/monitoring.md](commands/monitoring.md) — ps, info, env, top, watch, report, diff, alert, cluster, perfcounter, tui
   - [commands/memory-gc.md](commands/memory-gc.md) — gc, heap, histo, nmt, buffers, metaspace, gclog, gcscore, zgc, and more
   - [commands/profiling-tracing.md](commands/profiling-tracing.md) — profile, flame, jfr, jfranalyze, slowlog, trace, benchmark

--- a/docs/cli-commands.md
+++ b/docs/cli-commands.md
@@ -1,6 +1,6 @@
 # Argus CLI Command Reference
 
-Complete reference for all 70 Argus CLI commands. Commands are organized into five categories. Each category page contains full synopses, option tables, and output samples. Use the alphabetical index at the bottom to jump directly to any command.
+Complete reference for all 71 Argus CLI commands. Commands are organized into five categories. Each category page contains full synopses, option tables, and output samples. Use the alphabetical index at the bottom to jump directly to any command.
 
 ## Global Options
 
@@ -208,6 +208,7 @@ Thread state summaries, full thread dumps, deadlock detection, and thread pool d
 | `argus profile-gate` | [Profiling & Tracing](commands/profiling-tracing.md#argus-profile-gate-before-after) |
 | `argus ps` | [Monitoring](commands/monitoring.md#argus-ps) |
 | `argus report` | [Monitoring](commands/monitoring.md#argus-report-pid) |
+| `argus rightsize` | [Runtime & JVM Internals](commands/runtime-internals.md#argus-rightsize-pid) |
 | `argus sc` | [Runtime & JVM Internals](commands/runtime-internals.md#argus-sc-pid-pattern) |
 | `argus slowlog` | [Profiling & Tracing](commands/profiling-tracing.md#argus-slowlog-pid) |
 | `argus snapshot` | [Profiling & Tracing](commands/profiling-tracing.md#argus-snapshot-pid) |

--- a/docs/commands/runtime-internals.md
+++ b/docs/commands/runtime-internals.md
@@ -23,6 +23,7 @@ Commands for inspecting and modifying JVM runtime internals without a restart. T
 - [argus explain \<term\>](#argus-explain-term)
 - [argus doctor](#argus-doctor)
 - [argus suggest](#argus-suggest)
+- [argus rightsize \<pid\>](#argus-rightsize-pid)
 - [argus ci \[pid\]](#argus-ci-pid)
 - [argus compare \<pid1\> \<pid2\>](#argus-compare-pid1-pid2)
 - [argus init](#argus-init)
@@ -635,6 +636,56 @@ $ argus suggest 12345 --profile=snapshot.json
 | `RuntimeWaitHint` | HIGH | _(no flag — structural hint)_ | Wait/park methods >= 60% of all samples |
 
 When a profile rule fires for the same JVM flag area as a workload suggestion, the workload suggestion is marked `(superseded by profile evidence)` in the output.
+
+---
+
+## argus rightsize \<pid\>
+
+Right-sizes a JVM for FinOps. Recommends `-Xmx`/`-Xms`, a container memory request and limit, and a CPU request derived from the observed heap high-water-mark, the post-GC live-set floor, the allocation and promotion rate, and the metaspace plus direct-buffer footprint. The output always shows its inputs and the safety factor — never a black box — and **never recommends an `-Xmx` below the observed post-GC live-set floor**.
+
+```bash
+$ argus rightsize 39113                 # rich, human-readable recommendation
+$ argus rightsize 39113 --format=json    # structured recommendation object
+$ argus rightsize 39113 --limit=2g       # supply the real container limit for an OOMKill check
+```
+
+```
+╭─ JVM Right-Sizing ── pid:39113 ── floor:312MiB ── safety:1.5x ───────────────╮
+│                                                                              │
+│   Recommended -Xmx        -Xmx512m                                           │
+│   Recommended -Xms        -Xms512m                                           │
+│   Container mem request   640 MiB                                            │
+│   Container mem limit     800 MiB                                            │
+│   CPU request             0.50 cores                                         │
+│                                                                              │
+│   [OOMKill]  no observed container limit — pass --limit=<size> to evaluate   │
+│   ─────────────────────────────────────────────────────────────────────     │
+│   Inputs                                                                     │
+│     Heap high-water mark:   428 MiB                                          │
+│     Post-GC live-set floor: 312 MiB                                          │
+│     Metaspace:               48 MiB                                          │
+│     Direct buffers:           4 MiB                                          │
+│     Safety factor:          1.5x above the live-set floor                    │
+╰──────────────────────────────────────────────────────────────────────────────╯
+```
+
+The `-Xmx` recommendation is the live-set floor multiplied by the safety factor (`1.5x`); `-Xms` is set equal to `-Xmx` to avoid heap-resize churn. The container limit adds the off-heap native footprint (metaspace, direct buffers, code cache, thread stacks) and a native-headroom factor on top.
+
+**OOMKill risk is a three-state verdict** — it is only meaningful against a real container limit, so Argus never fakes an all-clear:
+
+| State | Meaning |
+|-------|---------|
+| `AT_RISK` | An observed limit leaves no native headroom above `-Xmx` (metaspace, threads, code cache, and direct buffers would have nowhere to live); raise the limit. |
+| `OK` | An observed limit leaves adequate native headroom above `-Xmx`. |
+| `UNKNOWN` | No `--limit` was supplied and no container limit was observed; risk cannot be evaluated honestly. Pass `--limit=<size>` to get a real answer. |
+
+When the observation window is too short to be defensible (under ~60s or fewer than 2 GC cycles), `rightsize` refuses to recommend and tells you to keep observing rather than emit an untrustworthy number.
+
+Options:
+- `--limit=<size>` — Supply the real container memory limit (e.g. `2g`, `512m`) so the OOMKill-risk check can run; without it the risk state is `UNKNOWN`.
+- `--format=json` — Structured recommendation object with all inputs, the live-set floor, the safety factor, and the `oomKillRiskState` (`AT_RISK` / `OK` / `UNKNOWN`).
+
+**Fleet roll-up:** the aggregator exposes `GET /fleet/rightsize` for a per-deployment right-sizing summary across every observed instance.
 
 ---
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -365,7 +365,7 @@ try (var executor = Executors.newVirtualThreadPerTaskExecutor()) {
 
 | Feature | Java 11+ | Java 17+ | Java 21+ |
 |---------|:--------:|:--------:|:--------:|
-| CLI (70 commands) | ✅ | ✅ | ✅ |
+| CLI (71 commands) | ✅ | ✅ | ✅ |
 | Dashboard & Web UI | — | ✅ | ✅ |
 | GC Analysis | CLI only | ✅ MXBean | ✅ JFR |
 | Virtual Thread Monitoring | — | — | ✅ JFR |

--- a/site/commands.html
+++ b/site/commands.html
@@ -91,7 +91,7 @@ argus histo 12345</code></pre>
                 <p class="video-caption">Argus CLI in action — diagnosing a running JVM process</p>
 
                 <span class="section-anchor" id="command-reference"></span>
-                <h3>All 70 Commands</h3>
+                <h3>All 71 Commands</h3>
 
                 <p>Every command follows the same pattern: <code>argus &lt;command&gt; &lt;pid&gt;</code>. All commands support <code>--format=json</code> for scripting and <code>--source=auto|agent|jdk</code> to control the data source.</p>
 

--- a/site/index.html
+++ b/site/index.html
@@ -67,7 +67,7 @@
                         <span class="badge green">Java 11+ CLI</span>
                         <span class="badge green">Java 17+ Dashboard</span>
                         <span class="badge green">Java 21+ Full Features</span>
-                        <span class="badge">70 Commands</span>
+                        <span class="badge">71 Commands</span>
                         <span class="badge">Zero Dependencies</span>
                         <span class="badge green">v1.5.0</span>
                     </div>
@@ -75,7 +75,7 @@
 
                 <p>Argus gives you two tools for JVM diagnostics:</p>
                 <ul>
-                    <li><strong>Argus CLI</strong> — 70 diagnostic commands that work on any running JVM. No agent, no restart, no configuration. Point at a PID and get answers in seconds.</li>
+                    <li><strong>Argus CLI</strong> — 71 diagnostic commands that work on any running JVM. No agent, no restart, no configuration. Point at a PID and get answers in seconds.</li>
                     <li><strong>Argus Agent</strong> — Attach as a Java agent and get a live web dashboard with GC timelines, CPU graphs, heap usage, flame graphs, and thread analysis, all streaming in real time.</li>
                 </ul>
 
@@ -98,7 +98,7 @@
                 <div class="feature-grid">
                     <div class="feature-card">
                         <h4>Instant CLI Diagnostics</h4>
-                        <p>70 commands that work on any running JVM. No agent, no restart, no configuration. Just point at a PID and get answers in seconds.</p>
+                        <p>71 commands that work on any running JVM. No agent, no restart, no configuration. Just point at a PID and get answers in seconds.</p>
                     </div>
                     <div class="feature-card">
                         <h4>Real-time Dashboard</h4>

--- a/site/reference.html
+++ b/site/reference.html
@@ -65,7 +65,7 @@
                             <tr><th>Feature</th><th>Java 11+</th><th>Java 17+</th><th>Java 21+</th></tr>
                         </thead>
                         <tbody>
-                            <tr><td>CLI (70 commands)</td><td>Yes</td><td>Yes</td><td>Yes</td></tr>
+                            <tr><td>CLI (71 commands)</td><td>Yes</td><td>Yes</td><td>Yes</td></tr>
                             <tr><td>Dashboard &amp; Web UI</td><td>—</td><td>Yes (MXBean)</td><td>Yes (JFR)</td></tr>
                             <tr><td>GC / CPU / Memory</td><td>CLI only</td><td>Yes</td><td>Yes</td></tr>
                             <tr><td>Allocation Tracking</td><td>—</td><td>—</td><td>Yes</td></tr>
@@ -100,7 +100,7 @@
                             <tr><td><code>argus-agent</code></td><td>Java agent entry point, JFR streaming engine, MXBean polling engine</td></tr>
                             <tr><td><code>argus-server</code></td><td>Netty HTTP/WebSocket server, 10 analyzers, metrics export</td></tr>
                             <tr><td><code>argus-frontend</code></td><td>Dashboard web UI (vanilla JS, Chart.js, D3 flame graph)</td></tr>
-                            <tr><td><code>argus-cli</code></td><td>70 diagnostic commands using jcmd/jstat</td></tr>
+                            <tr><td><code>argus-cli</code></td><td>71 diagnostic commands using jcmd/jstat</td></tr>
                             <tr><td><code>argus-micrometer</code></td><td>Framework-agnostic Micrometer MeterBinder</td></tr>
                             <tr><td><code>argus-spring-boot-starter</code></td><td>Spring Boot auto-configuration</td></tr>
                         </tbody>


### PR DESCRIPTION
## Command-count drift (70 → 71)

A new `rightsize` command landed, so the documented CLI command count was stale at 70. Updated to **71** everywhere:

- `README.md` — tagline
- `docs/getting-started.md` — Java compatibility table
- `docs/README.md` — reference index
- `docs/cli-commands.md` — reference intro
- `site/index.html` — badge + two prose mentions
- `site/commands.html` — section heading
- `site/reference.html` — compatibility table + module table

## "Why Argus?" compression (README)

Rewrote the README `## Why Argus?` highlight list into a tighter, value-first set led by a one-line positioning statement. `rightsize` is now surfaced as a highlight; `snapshot`/`pool` detail was relocated out of the headline list but remains fully documented under `docs/`.

## New `rightsize` command docs

`rightsize` was previously undocumented. Added it to:

- the **A–Z index** in `docs/cli-commands.md` (alphabetical, under Runtime & JVM Internals)
- a full entry in `docs/commands/runtime-internals.md` matching the page's existing format — synopsis, example output, options table, and accurate behavior: recommends `-Xmx`/`-Xms`, container memory request/limit, and CPU request from the observed heap high-water-mark / post-GC live-set floor / alloc & promotion rate / metaspace + direct-buffer footprint; never recommends below the live-set floor; the OOMKill-risk tri-state (`AT_RISK` / `OK` / `UNKNOWN`, where `UNKNOWN` = no observed container limit); `--limit=<size>`; `--format=json`; and the `GET /fleet/rightsize` aggregator roll-up.

## Verification

- Re-scan confirms every count reads 71 with no remaining "70 ... commands".
- `./gradlew :argus-cli:test --quiet` → exit 0.
- No locale files or `gradle.properties` touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)