### PR TITLE
fix: harden 2026-roadmap features for large-scale fleet use

### DIFF
--- a/argus-aggregator/src/main/java/io/argus/aggregator/profile/ProfileTraceContext.java
+++ b/argus-aggregator/src/main/java/io/argus/aggregator/profile/ProfileTraceContext.java
@@ -20,6 +20,9 @@ public final class ProfileTraceContext {
 
     private static final ProfileTraceContext NONE = new ProfileTraceContext(null, null);
 
+    /** All-lowercase-hex matcher, compiled once (the length is checked separately). */
+    private static final java.util.regex.Pattern HEX = java.util.regex.Pattern.compile("[0-9a-f]+");
+
     private final String traceId;
     private final String spanId;
 
@@ -65,7 +68,7 @@ public final class ProfileTraceContext {
             return null;
         }
         String t = id.trim().toLowerCase(java.util.Locale.ROOT);
-        if (t.length() == hexLen && t.matches("[0-9a-f]{" + hexLen + "}") && !t.equals("0".repeat(hexLen))) {
+        if (t.length() == hexLen && HEX.matcher(t).matches() && !t.equals("0".repeat(hexLen))) {
             return t;
         }
         return null;

--- a/argus-server/src/main/java/io/argus/server/analysis/AnomalyDetector.java
+++ b/argus-server/src/main/java/io/argus/server/analysis/AnomalyDetector.java
@@ -1,6 +1,7 @@
 package io.argus.server.analysis;
 
 import java.time.Instant;
+import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -91,8 +92,9 @@ public final class AnomalyDetector {
     private int cpuOverStreak = 0;
     private int allocOverStreak = 0;
 
-    // Bounded ring of recent anomaly events (oldest first).
-    private final ArrayList<AnomalyEvent> recent = new ArrayList<>();
+    // Bounded ring of recent anomaly events (oldest first). ArrayDeque gives O(1)
+    // eviction from the head; ArrayList.remove(0) was O(ringSize) per fire.
+    private final ArrayDeque<AnomalyEvent> recent = new ArrayDeque<>();
 
     // Latest "profile capture recommended" recommendation; null when none active.
     private final AtomicReference<CaptureRecommendation> recommendation = new AtomicReference<>();
@@ -327,9 +329,9 @@ public final class AnomalyDetector {
     }
 
     private AnomalyEvent fire(AnomalyEvent event) {
-        recent.add(event);
+        recent.addLast(event);
         while (recent.size() > ringSize) {
-            recent.remove(0);
+            recent.removeFirst();
         }
         if (captureRecommendationEnabled) {
             recommendation.set(new CaptureRecommendation(event.timestamp(), event.type(), event.reason()));
@@ -357,7 +359,7 @@ public final class AnomalyDetector {
      * @return the latest anomaly, or null
      */
     public synchronized AnomalyEvent latest() {
-        return recent.isEmpty() ? null : recent.get(recent.size() - 1);
+        return recent.isEmpty() ? null : recent.getLast();
     }
 
     /**

--- a/argus-server/src/main/java/io/argus/server/analysis/PinningAnalyzer.java
+++ b/argus-server/src/main/java/io/argus/server/analysis/PinningAnalyzer.java
@@ -158,6 +158,12 @@ public final class PinningAnalyzer {
         long[] counts = hotspotsByHash.values().stream()
                 .mapToLong(d -> d.count.get())
                 .toArray();
+        // The map can shrink between the size() guard above and this snapshot (a
+        // concurrent clear() or overlapping eviction). Re-check against the snapshot
+        // so counts[counts.length - MAX_HOTSPOTS] can never index negative.
+        if (counts.length <= MAX_HOTSPOTS) {
+            return;
+        }
         java.util.Arrays.sort(counts); // ascending
         // Threshold = the count at the MAX_HOTSPOTS-th highest position.
         long threshold = counts[counts.length - MAX_HOTSPOTS];

--- a/argus-server/src/main/java/io/argus/server/analysis/PinningAnalyzer.java
+++ b/argus-server/src/main/java/io/argus/server/analysis/PinningAnalyzer.java
@@ -72,7 +72,7 @@ public final class PinningAnalyzer {
 
         // Sort by count descending
         List<Map.Entry<String, HotspotData>> sorted = hotspotsByHash.entrySet().stream()
-                .sorted(Comparator.comparingLong((Map.Entry<String, HotspotData> e) -> e.getValue().count)
+                .sorted(Comparator.comparingLong((Map.Entry<String, HotspotData> e) -> e.getValue().count.get())
                         .reversed())
                 .limit(10)
                 .toList();
@@ -81,11 +81,12 @@ public final class PinningAnalyzer {
         for (Map.Entry<String, HotspotData> entry : sorted) {
             String hash = entry.getKey();
             HotspotData data = entry.getValue();
-            double percentage = total > 0 ? (data.count * 100.0 / total) : 0;
+            long count = data.count.get();
+            double percentage = total > 0 ? (count * 100.0 / total) : 0;
 
             hotspots.add(new PinningHotspot(
                     rank++,
-                    data.count,
+                    count,
                     percentage,
                     hash,
                     data.topFrame,
@@ -97,7 +98,7 @@ public final class PinningAnalyzer {
         // Tally events per post-JEP-491 bucket across all recorded stack traces.
         Map<PinningTaxonomy, Long> byTaxonomy = new EnumMap<>(PinningTaxonomy.class);
         for (HotspotData data : hotspotsByHash.values()) {
-            byTaxonomy.merge(PinningTaxonomy.classify(data.fullStackTrace), data.count, Long::sum);
+            byTaxonomy.merge(PinningTaxonomy.classify(data.fullStackTrace), data.count.get(), Long::sum);
         }
 
         return new PinningAnalysisResult(total, uniqueCount, hotspots, byTaxonomy);
@@ -148,8 +149,32 @@ public final class PinningAnalyzer {
     }
 
     private void evictLowCountEntries() {
-        // Remove entries with count = 1 to make room
-        hotspotsByHash.entrySet().removeIf(entry -> entry.getValue().count <= 1);
+        // Retain the MAX_HOTSPOTS highest-count entries and drop the rest. The old
+        // removeIf(count <= 1) wiped the entire map whenever every site had been seen
+        // exactly once — losing all hotspots precisely when pinning was widely spread.
+        if (hotspotsByHash.size() <= MAX_HOTSPOTS) {
+            return;
+        }
+        long[] counts = hotspotsByHash.values().stream()
+                .mapToLong(d -> d.count.get())
+                .toArray();
+        java.util.Arrays.sort(counts); // ascending
+        // Threshold = the count at the MAX_HOTSPOTS-th highest position.
+        long threshold = counts[counts.length - MAX_HOTSPOTS];
+        // Drop entries strictly below the threshold — keeps every heavy hitter.
+        hotspotsByHash.entrySet().removeIf(entry -> entry.getValue().count.get() < threshold);
+        // Ties at the threshold can still leave us over capacity (e.g. every site seen
+        // exactly once → all counts equal). Trim the tied entries until bounded so the
+        // map can never grow without limit; heavier hitters above the threshold are
+        // never touched.
+        if (hotspotsByHash.size() > MAX_HOTSPOTS) {
+            java.util.Iterator<Map.Entry<String, HotspotData>> it = hotspotsByHash.entrySet().iterator();
+            while (hotspotsByHash.size() > MAX_HOTSPOTS && it.hasNext()) {
+                if (it.next().getValue().count.get() == threshold) {
+                    it.remove();
+                }
+            }
+        }
     }
 
     /**
@@ -158,16 +183,16 @@ public final class PinningAnalyzer {
     private static class HotspotData {
         final String fullStackTrace;
         final String topFrame;
-        volatile long count;
+        final AtomicLong count;
 
         HotspotData(String fullStackTrace, String topFrame, long count) {
             this.fullStackTrace = fullStackTrace;
             this.topFrame = topFrame;
-            this.count = count;
+            this.count = new AtomicLong(count);
         }
 
         void incrementCount() {
-            count++;
+            count.incrementAndGet();
         }
     }
 

--- a/argus-server/src/main/java/io/argus/server/analysis/StructuredConcurrencyView.java
+++ b/argus-server/src/main/java/io/argus/server/analysis/StructuredConcurrencyView.java
@@ -25,6 +25,13 @@ public final class StructuredConcurrencyView {
 
     private static final String SCOPE_PREFIX = "java.util.concurrent.StructuredTaskScope";
 
+    /**
+     * Depth cap for the recursive render. A pathological or adversarially-crafted
+     * dump (e.g. a very long parent chain) must not overflow the call stack; beyond
+     * this depth the subtree is elided with a notice instead.
+     */
+    private static final int MAX_RENDER_DEPTH = 512;
+
     /** A forked subtask running inside a scope. */
     public record Subtask(long tid, String name, List<String> stack) {
     }
@@ -107,6 +114,12 @@ public final class StructuredConcurrencyView {
     }
 
     private static void renderNode(ScopeNode node, int depth, StringBuilder sb) {
+        if (depth > MAX_RENDER_DEPTH) {
+            sb.append("  ".repeat(MAX_RENDER_DEPTH))
+              .append("… (scope nesting exceeds ").append(MAX_RENDER_DEPTH)
+              .append(" levels; subtree elided)\n");
+            return;
+        }
         String indent = "  ".repeat(depth);
         sb.append(indent)
           .append("Scope ").append(shortName(node.name()))

--- a/argus-server/src/main/java/io/argus/server/analysis/StructuredConcurrencyView.java
+++ b/argus-server/src/main/java/io/argus/server/analysis/StructuredConcurrencyView.java
@@ -115,8 +115,9 @@ public final class StructuredConcurrencyView {
 
     private static void renderNode(ScopeNode node, int depth, StringBuilder sb) {
         if (depth > MAX_RENDER_DEPTH) {
-            sb.append("  ".repeat(MAX_RENDER_DEPTH))
-              .append("… (scope nesting exceeds ").append(MAX_RENDER_DEPTH)
+            // Modest fixed indent for the notice — repeating to the actual (huge)
+            // depth would allocate a multi-KB blank prefix per elided node.
+            sb.append("    … (scope nesting exceeds ").append(MAX_RENDER_DEPTH)
               .append(" levels; subtree elided)\n");
             return;
         }

--- a/argus-server/src/main/java/io/argus/server/metrics/OtlpJsonBuilder.java
+++ b/argus-server/src/main/java/io/argus/server/metrics/OtlpJsonBuilder.java
@@ -121,8 +121,12 @@ public final class OtlpJsonBuilder {
         // Standard OTel semconv name, emitted alongside the legacy argus_* series.
         first = appendGauge(sb, first, SemconvMetrics.THREAD_COUNT.otelName(),
                 SemconvMetrics.THREAD_COUNT.description(), nowNano, activeThreads.size());
-        first = appendGauge(sb, first, "argus_virtual_threads_active",
-                "Currently active virtual threads", nowNano, activeThreads.size());
+        // Legacy duplicate of jvm.thread.count — gated like the Prometheus path so
+        // legacyNames=false does not double OTLP series.
+        if (config.isLegacyMetricNames()) {
+            first = appendGauge(sb, first, "argus_virtual_threads_active",
+                    "Currently active virtual threads", nowNano, activeThreads.size());
+        }
         first = appendSum(sb, first, "argus_virtual_threads_started_total",
                 "Total virtual threads started", nowNano, metrics.getStartEvents());
         first = appendSum(sb, first, "argus_virtual_threads_ended_total",
@@ -170,10 +174,14 @@ public final class OtlpJsonBuilder {
                 "Maximum GC pause time", nowNano, analysis.maxPauseTimeMs() / 1000.0);
         first = appendGaugeDouble(sb, first, "argus_gc_overhead_ratio",
                 "GC overhead percentage", nowNano, analysis.gcOverheadPercent());
-        first = appendGauge(sb, first, "argus_heap_used_bytes",
-                "Current heap used", nowNano, analysis.currentHeapUsed());
-        first = appendGauge(sb, first, "argus_heap_committed_bytes",
-                "Current heap committed", nowNano, analysis.currentHeapCommitted());
+        // Legacy duplicates of jvm.memory.used / jvm.memory.committed (pool=heap) —
+        // gated so legacyNames=false does not double OTLP series.
+        if (config.isLegacyMetricNames()) {
+            first = appendGauge(sb, first, "argus_heap_used_bytes",
+                    "Current heap used", nowNano, analysis.currentHeapUsed());
+            first = appendGauge(sb, first, "argus_heap_committed_bytes",
+                    "Current heap committed", nowNano, analysis.currentHeapCommitted());
+        }
         return first;
     }
 
@@ -186,12 +194,16 @@ public final class OtlpJsonBuilder {
         // Standard OTel semconv name, emitted alongside the legacy argus_* ratios.
         first = appendGaugeDouble(sb, first, SemconvMetrics.CPU_RECENT_UTILIZATION.otelName(),
                 SemconvMetrics.CPU_RECENT_UTILIZATION.description(), nowNano, analysis.currentJvmTotal());
-        first = appendGaugeDouble(sb, first, "argus_cpu_jvm_user_ratio",
-                "JVM user CPU ratio", nowNano, analysis.currentJvmUser());
-        first = appendGaugeDouble(sb, first, "argus_cpu_jvm_system_ratio",
-                "JVM system CPU ratio", nowNano, analysis.currentJvmSystem());
-        first = appendGaugeDouble(sb, first, "argus_cpu_machine_total_ratio",
-                "Machine total CPU ratio", nowNano, analysis.currentMachineTotal());
+        // Legacy ratios replaced by jvm.cpu.recent_utilization — gated as a block,
+        // matching the Prometheus collector's appendCPUMetrics early-return.
+        if (config.isLegacyMetricNames()) {
+            first = appendGaugeDouble(sb, first, "argus_cpu_jvm_user_ratio",
+                    "JVM user CPU ratio", nowNano, analysis.currentJvmUser());
+            first = appendGaugeDouble(sb, first, "argus_cpu_jvm_system_ratio",
+                    "JVM system CPU ratio", nowNano, analysis.currentJvmSystem());
+            first = appendGaugeDouble(sb, first, "argus_cpu_machine_total_ratio",
+                    "Machine total CPU ratio", nowNano, analysis.currentMachineTotal());
+        }
         return first;
     }
 
@@ -228,12 +240,16 @@ public final class OtlpJsonBuilder {
             first = appendGaugeWithPool(sb, first, SemconvMetrics.MEMORY_COMMITTED.otelName(),
                     SemconvMetrics.MEMORY_COMMITTED.description(), nowNano, analysis.currentCommitted(), "Metaspace");
         }
-        first = appendGauge(sb, first, "argus_metaspace_used_bytes",
-                "Metaspace used", nowNano, analysis.currentUsed());
-        first = appendGauge(sb, first, "argus_metaspace_committed_bytes",
-                "Metaspace committed", nowNano, analysis.currentCommitted());
-        first = appendGauge(sb, first, "argus_metaspace_classes_loaded",
-                "Loaded classes", nowNano, analysis.currentClassCount());
+        // Legacy duplicates of jvm.memory.used / jvm.memory.committed (pool=Metaspace)
+        // and jvm.class.count — gated so legacyNames=false does not double OTLP series.
+        if (config.isLegacyMetricNames()) {
+            first = appendGauge(sb, first, "argus_metaspace_used_bytes",
+                    "Metaspace used", nowNano, analysis.currentUsed());
+            first = appendGauge(sb, first, "argus_metaspace_committed_bytes",
+                    "Metaspace committed", nowNano, analysis.currentCommitted());
+            first = appendGauge(sb, first, "argus_metaspace_classes_loaded",
+                    "Loaded classes", nowNano, analysis.currentClassCount());
+        }
         return first;
     }
 

--- a/argus-server/src/main/java/io/argus/server/metrics/PrometheusMetricsCollector.java
+++ b/argus-server/src/main/java/io/argus/server/metrics/PrometheusMetricsCollector.java
@@ -161,27 +161,29 @@ public final class PrometheusMetricsCollector {
      * regardless of the {@code argus.metrics.legacyNames} flag.
      */
     private void appendSemconvMetrics(StringBuilder sb, boolean openMetrics) {
-        emittedSemconvHeaders.clear();
+        // Per-scrape header-dedup set: a method-local avoids the data race that a
+        // shared instance field would suffer under concurrent scrapes.
+        java.util.Set<String> emitted = new java.util.HashSet<>();
         // jvm.thread.count — best available signal is the active virtual-thread count.
-        appendSemconvGauge(sb, SemconvMetrics.THREAD_COUNT, null, activeThreads.size());
+        appendSemconvGauge(sb, emitted, SemconvMetrics.THREAD_COUNT, null, activeThreads.size());
 
         if (config.isGcEnabled()) {
             var analysis = gcAnalyzer.getAnalysis();
             // Heap pool memory. The GC analyzer tracks post-GC heap, so jvm.memory.used
             // and jvm.memory.used_after_last_gc share the same source here.
             String heapPool = "{" + poolLabel("heap") + "}";
-            appendSemconvGauge(sb, SemconvMetrics.MEMORY_USED, heapPool, analysis.currentHeapUsed());
-            appendSemconvGauge(sb, SemconvMetrics.MEMORY_COMMITTED, heapPool, analysis.currentHeapCommitted());
-            appendSemconvGauge(sb, SemconvMetrics.MEMORY_USED_AFTER_LAST_GC, heapPool, analysis.currentHeapUsed());
-            appendSemconvGcDurationHistogram(sb, openMetrics);
+            appendSemconvGauge(sb, emitted, SemconvMetrics.MEMORY_USED, heapPool, analysis.currentHeapUsed());
+            appendSemconvGauge(sb, emitted, SemconvMetrics.MEMORY_COMMITTED, heapPool, analysis.currentHeapCommitted());
+            appendSemconvGauge(sb, emitted, SemconvMetrics.MEMORY_USED_AFTER_LAST_GC, heapPool, analysis.currentHeapUsed());
+            appendSemconvGcDurationHistogram(sb, emitted, openMetrics);
         }
 
         if (config.isMetaspaceEnabled() && metaspaceAnalyzer != null) {
             var ms = metaspaceAnalyzer.getAnalysis();
             String metaPool = "{" + poolLabel("Metaspace") + "}";
-            appendSemconvGauge(sb, SemconvMetrics.MEMORY_USED, metaPool, ms.currentUsed());
-            appendSemconvGauge(sb, SemconvMetrics.MEMORY_COMMITTED, metaPool, ms.currentCommitted());
-            appendSemconvGauge(sb, SemconvMetrics.CLASS_COUNT, null, ms.currentClassCount());
+            appendSemconvGauge(sb, emitted, SemconvMetrics.MEMORY_USED, metaPool, ms.currentUsed());
+            appendSemconvGauge(sb, emitted, SemconvMetrics.MEMORY_COMMITTED, metaPool, ms.currentCommitted());
+            appendSemconvGauge(sb, emitted, SemconvMetrics.CLASS_COUNT, null, ms.currentClassCount());
         }
 
         if (config.isCpuEnabled()) {
@@ -189,7 +191,7 @@ public final class PrometheusMetricsCollector {
             // jvm.cpu.time has no JFR-derived source in Argus today; only the recent
             // utilization ratio is available. cpu.time stays in the mapping table as
             // the documented contract but is not exported.
-            appendSemconvGauge(sb, SemconvMetrics.CPU_RECENT_UTILIZATION, null, cpu.currentJvmTotal());
+            appendSemconvGauge(sb, emitted, SemconvMetrics.CPU_RECENT_UTILIZATION, null, cpu.currentJvmTotal());
         }
     }
 
@@ -204,12 +206,13 @@ public final class PrometheusMetricsCollector {
      * Memory-pool metrics share one HELP/TYPE header across pools, so the header is
      * only written once per metric name within a scrape.
      */
-    private void appendSemconvGauge(StringBuilder sb, SemconvMetrics.Metric metric, String labels, double value) {
+    private void appendSemconvGauge(StringBuilder sb, java.util.Set<String> emitted,
+                                    SemconvMetrics.Metric metric, String labels, double value) {
         String name = metric.prometheusName();
-        if (!emittedSemconvHeaders.contains(name)) {
+        if (!emitted.contains(name)) {
             sb.append("# HELP ").append(name).append(' ').append(metric.description()).append('\n');
             sb.append("# TYPE ").append(name).append(' ').append(metric.type().prometheusType()).append('\n');
-            emittedSemconvHeaders.add(name);
+            emitted.add(name);
         }
         sb.append(name).append(mergeBaseLabels(labels)).append(' ');
         if (value == (long) value) {
@@ -234,7 +237,7 @@ public final class PrometheusMetricsCollector {
      * {@code jvm_gc_duration_seconds}, reusing the same aggregate histogram as the
      * legacy series. The aggregate is not split per {@code jvm.gc.name}/{@code jvm.gc.action}.
      */
-    private void appendSemconvGcDurationHistogram(StringBuilder sb, boolean openMetrics) {
+    private void appendSemconvGcDurationHistogram(StringBuilder sb, java.util.Set<String> emitted, boolean openMetrics) {
         var hist = gcAnalyzer.getPauseHistogram();
         if (hist.count() == 0) return;
 
@@ -242,7 +245,7 @@ public final class PrometheusMetricsCollector {
         sb.append("# HELP ").append(name).append(' ')
                 .append(SemconvMetrics.GC_DURATION.description()).append('\n');
         sb.append("# TYPE ").append(name).append(" histogram\n");
-        emittedSemconvHeaders.add(name);
+        emitted.add(name);
 
         String baseLabels = KubernetesLabels.prometheusLabelSuffix();
         double[] bounds = hist.upperBounds();
@@ -267,9 +270,6 @@ public final class PrometheusMetricsCollector {
         sb.append(name).append("_count").append(baseLabels).append(' ')
                 .append(hist.count()).append('\n');
     }
-
-    /** Tracks which semconv HELP/TYPE headers have been written in the current scrape. */
-    private final java.util.Set<String> emittedSemconvHeaders = new java.util.HashSet<>();
 
     private void appendVirtualThreadMetrics(StringBuilder sb) {
         // Argus-unique counters (no semconv equivalent) — always emitted.

--- a/argus-server/src/test/java/io/argus/server/analysis/PinningAnalyzerTest.java
+++ b/argus-server/src/test/java/io/argus/server/analysis/PinningAnalyzerTest.java
@@ -1,0 +1,64 @@
+package io.argus.server.analysis;
+
+import io.argus.core.event.EventType;
+import io.argus.core.event.VirtualThreadEvent;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Regression coverage for the pinning hotspot eviction policy. The earlier
+ * {@code removeIf(count <= 1)} eviction wiped the entire map whenever pinning was
+ * spread across many distinct call sites each seen exactly once — losing all
+ * hotspots precisely when the data mattered most. Eviction must instead retain the
+ * highest-count sites.
+ */
+class PinningAnalyzerTest {
+
+    private static VirtualThreadEvent pinned(String stack) {
+        return new VirtualThreadEvent(EventType.VIRTUAL_THREAD_PINNED, 1L, "vt", 2L,
+                Instant.now(), 1_000_000L, stack);
+    }
+
+    @Test
+    void eviction_does_not_wipe_all_singleton_hotspots() {
+        PinningAnalyzer analyzer = new PinningAnalyzer();
+
+        // 250 distinct call sites, each pinned exactly once → all count==1. This is
+        // past the 2× capacity eviction trigger (MAX_HOTSPOTS=100).
+        for (int i = 0; i < 250; i++) {
+            analyzer.recordPinnedEvent(pinned("at com.example.Site" + i + ".call(Site.java:" + i + ")"));
+        }
+
+        var result = analyzer.getAnalysis();
+        // Every event was recorded against the total counter regardless of eviction.
+        assertEquals(250, result.totalPinnedEvents(), "total pinned events must count every recorded event");
+        // The map must NOT have been emptied; it stays bounded but non-empty.
+        assertTrue(result.uniqueStackTraces() > 0, "eviction must not wipe all singleton hotspots");
+        assertTrue(result.uniqueStackTraces() <= 200,
+                "unique stack traces must stay bounded under sustained distinct pinning");
+    }
+
+    @Test
+    void high_count_hotspot_survives_eviction() {
+        PinningAnalyzer analyzer = new PinningAnalyzer();
+
+        // One dominant hotspot, hit many times.
+        String hot = "at com.example.HotSpot.blocking(HotSpot.java:42)";
+        for (int i = 0; i < 50; i++) {
+            analyzer.recordPinnedEvent(pinned(hot));
+        }
+        // Plus a flood of distinct singletons that triggers eviction.
+        for (int i = 0; i < 250; i++) {
+            analyzer.recordPinnedEvent(pinned("at com.example.Noise" + i + ".x(N.java:" + i + ")"));
+        }
+
+        var result = analyzer.getAnalysis();
+        assertFalse(result.hotspots().isEmpty(), "hotspots must remain after eviction");
+        // The dominant site must survive and rank first with its full count.
+        var top = result.hotspots().get(0);
+        assertEquals(50, top.count(), "the high-count hotspot must survive eviction with its count intact");
+    }
+}

--- a/argus-server/src/test/java/io/argus/server/metrics/OtlpJsonBuilderMetricsTest.java
+++ b/argus-server/src/test/java/io/argus/server/metrics/OtlpJsonBuilderMetricsTest.java
@@ -91,6 +91,49 @@ class OtlpJsonBuilderMetricsTest {
     }
 
     @Test
+    void otlp_dual_emits_legacy_argus_series_by_default() {
+        // legacyNames defaults to true → both the semconv and the legacy series ship.
+        String json = builder(AgentConfig.defaults()).build();
+
+        assertTrue(json.contains("\"name\":\"jvm.memory.used\""), "semconv jvm.memory.used must be present");
+        assertTrue(json.contains("\"name\":\"argus_heap_used_bytes\""),
+                "legacy argus_heap_used_bytes must ship when legacyNames=true (back-compat)");
+        assertTrue(json.contains("\"name\":\"argus_metaspace_used_bytes\""),
+                "legacy argus_metaspace_used_bytes must ship when legacyNames=true");
+        assertTrue(json.contains("\"name\":\"argus_cpu_jvm_user_ratio\""),
+                "legacy argus_cpu_jvm_user_ratio must ship when legacyNames=true");
+    }
+
+    @Test
+    void otlp_drops_legacy_argus_duplicates_when_legacy_names_disabled() {
+        // legacyNames=false → the OTLP stream must NOT double every series with the
+        // argus_* duplicate, matching the Prometheus collector's gating.
+        AgentConfig noLegacy = AgentConfig.builder().legacyMetricNames(false).build();
+        String json = builder(noLegacy).build();
+
+        // Standard semconv series remain.
+        assertTrue(json.contains("\"name\":\"jvm.memory.used\""),
+                "semconv jvm.memory.used must remain when legacyNames=false");
+        // Legacy duplicates of semconv series must be gone.
+        assertFalse(json.contains("\"name\":\"argus_heap_used_bytes\""),
+                "argus_heap_used_bytes must be gated off when legacyNames=false");
+        assertFalse(json.contains("\"name\":\"argus_heap_committed_bytes\""),
+                "argus_heap_committed_bytes must be gated off when legacyNames=false");
+        assertFalse(json.contains("\"name\":\"argus_metaspace_used_bytes\""),
+                "argus_metaspace_used_bytes must be gated off when legacyNames=false");
+        assertFalse(json.contains("\"name\":\"argus_cpu_jvm_user_ratio\""),
+                "argus_cpu_jvm_user_ratio must be gated off when legacyNames=false");
+        assertFalse(json.contains("\"name\":\"argus_virtual_threads_active\""),
+                "argus_virtual_threads_active must be gated off when legacyNames=false");
+
+        // Argus-unique series (no semconv equivalent) are NOT renamed/dropped.
+        assertTrue(json.contains("\"name\":\"argus_virtual_threads_started_total\""),
+                "argus-unique series must always ship regardless of legacyNames");
+        assertTrue(json.contains("\"name\":\"argus_gc_events_total\""),
+                "argus-unique GC counter must always ship regardless of legacyNames");
+    }
+
+    @Test
     void otlp_gc_duration_skipped_when_no_pauses() {
         GCAnalyzer gc = new GCAnalyzer(); // no events recorded
         OtlpJsonBuilder b = new OtlpJsonBuilder(


### PR DESCRIPTION
## What

Large-scale / real-world usability QA over the newly-merged 2026-roadmap features (W1–W8, #252–#259). Four parallel scenario reviews hypothesized fleet-sized situations (hundreds–thousands of pods, huge VT dumps, slow/down backends, concurrent scrapes) and checked the code against them. This PR fixes the **six confirmed correctness/scale defects** with mechanism-level fixes; the remaining findings are triaged below with rationale.

## Fixed (this PR)

| # | Sev | Area | Defect → Fix |
|---|-----|------|--------------|
| 1 | **CRITICAL** | W1 OTLP | `OtlpJsonBuilder` ignored `argus.metrics.legacyNames` and dual-emitted every `argus_*` duplicate over OTLP unconditionally — `legacyNames=false` halved Prometheus cardinality but never the OTLP stream, silently doubling every downstream series at fleet scale. **Fix:** mirror the Prometheus gating exactly (vt-active, heap used/committed, all three CPU ratios, metaspace used/committed/classes). Argus-unique series with no semconv equivalent still always ship. |
| 2 | **HIGH** | W1 Prom | `PrometheusMetricsCollector.emittedSemconvHeaders` was a shared instance field mutated during a scrape — two concurrent scrapers (Prometheus + Grafana agent) race and corrupt the HELP/TYPE headers. **Fix:** per-scrape method-local set. |
| 3 | **HIGH** | W7 Pinning | `PinningAnalyzer` used `volatile count++` (non-atomic, lost updates under concurrent pinning) and evicted with `removeIf(count <= 1)` — which **wiped the entire hotspot map** whenever pinning was spread across many distinct sites each seen once. **Fix:** `AtomicLong` + retain top-N by count with a tie-break that guarantees bounded growth (verified by the all-singletons scale case). |
| 4 | **CRITICAL** | W7 SC view | `StructuredConcurrencyView.renderNode` recursed with no depth bound — a deeply nested `StructuredTaskScope` tree (or an adversarial dump with a long parent chain) overflows the stack. **Fix:** cap render depth (512) and elide beyond it. |
| 5 | MEDIUM | W6 Anomaly | `AnomalyDetector` evicted its recent-anomaly ring via `ArrayList.remove(0)` — O(ring) per fire, on the synchronized path that blocks every JFR drain, with a user-configurable ring size. **Fix:** `ArrayDeque` for O(1) head eviction. |
| 6 | LOW | W5 Profiles | `ProfileTraceContext.normalize()` compiled a regex on every call on the OTLP encode hot path. **Fix:** static `Pattern`. |

New tests: `OtlpJsonBuilderMetricsTest` legacyNames gating (on→dual-emit, off→no `argus_*` duplicates but semconv + argus-unique remain); `PinningAnalyzerTest` eviction policy (singletons not wiped; heavy hitter survives).

## Deferred — triaged, not fixed here (rationale)

These are real but need a product/design decision or sit behind a default-off flag; fixing them silently here would over-reach:

- **Pyroscope push is synchronous (W2)** — `PyroscopePusher` → `PyroscopeTransport.send()` blocks the caller for up to the 3s+10s timeout, and has no backoff/circuit-breaker (thundering-herd on a recovering Pyroscope). Timeouts *are* set, and the pusher is **not yet wired into a capture loop** (documented follow-up), so there's no live stall today. Needs an async dispatch + bounded queue + backoff design before wire-up.
- **`argus rightsize` uses JVM uptime as the observation window (W3)** — `RightsizeCommand` passes `s.uptimeMs()` to the short-window refusal gate. Heap HWM is a lifetime peak so recommendations stay peak-anchored, but an idle long-running replica can still pass the gate. Changing "observation window" semantics for a single-snapshot attach is a product call.
- **LLM RCA: no prompt-size cap; raw error message could echo a URL-embedded key (W8)** — opt-in, default-OFF, BYO-key. Default-OFF enforcement and `Authorization`-header key handling are clean. A prompt cap + error scrubbing are worth adding but are a separate hardening pass.
- **OTLP Profiles encoder buffers whole payload (W5)** — fine behind the experimental default-off flag; would need a streaming writer if promoted to GA.
- **`BundleFindings` `(int)` cast on tar entry size (W8)** — offline bundle parsing; a >2 GiB single entry is implausible. Cheap guard, low priority.
- **Fleet rightsize aggregate savings unweighted by pod count (W3)** — a reporting-semantics choice to document, not a crash.

## Verification

`./gradlew :argus-server:test :argus-cli:test :argus-aggregator:test` → **BUILD SUCCESSFUL** (incl. new regression tests). Commit `-s`, no `Co-Authored-By`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)