### PR TITLE
feat: emit argus-unique diagnostics over OTLP for Prometheus parity

### DIFF
--- a/argus-server/src/main/java/io/argus/server/metrics/OtlpJsonBuilder.java
+++ b/argus-server/src/main/java/io/argus/server/metrics/OtlpJsonBuilder.java
@@ -143,6 +143,9 @@ public final class OtlpJsonBuilder {
         var carrierAnalysis = carrierAnalyzer.getAnalysis();
         first = appendGauge(sb, first, "argus_carrier_threads",
                 "Total carrier threads", nowNano, carrierAnalysis.totalCarriers());
+        first = appendSum(sb, first, "argus_carrier_threads_virtual_handled_total",
+                "Total virtual threads handled by carrier threads", nowNano,
+                carrierAnalysis.totalVirtualThreadsHandled());
         first = appendGaugeDouble(sb, first, "argus_carrier_threads_avg_per_carrier",
                 "Average virtual threads per carrier", nowNano, carrierAnalysis.avgVirtualThreadsPerCarrier());
         return first;
@@ -174,6 +177,24 @@ public final class OtlpJsonBuilder {
                 "Maximum GC pause time", nowNano, analysis.maxPauseTimeMs() / 1000.0);
         first = appendGaugeDouble(sb, first, "argus_gc_overhead_ratio",
                 "GC overhead percentage", nowNano, analysis.gcOverheadPercent());
+        // Argus-unique GC diagnostics (no semconv equivalent) — always emitted, in
+        // parity with the Prometheus collector. Values match the Prometheus path.
+        first = appendGaugeDouble(sb, first, "argus_gc_pause_time_seconds_avg",
+                "Average GC pause time in seconds", nowNano, analysis.avgPauseTimeMs() / 1000.0);
+        first = appendGauge(sb, first, "argus_gc_overhead_warning",
+                "GC overhead warning (1 = overhead > 10%)", nowNano, analysis.isOverheadWarning() ? 1 : 0);
+        first = appendGaugeDouble(sb, first, "argus_gc_allocation_rate_kbps",
+                "Allocation rate in KB/s from recent GC events", nowNano, analysis.allocationRateKBPerSec());
+        first = appendGaugeDouble(sb, first, "argus_gc_promotion_rate_kbps",
+                "Promotion rate (young to old gen) in KB/s", nowNano, analysis.promotionRateKBPerSec());
+        first = appendGauge(sb, first, "argus_gc_leak_suspected",
+                "Memory leak suspected (1 = leak detected)", nowNano, analysis.leakSuspected() ? 1 : 0);
+        first = appendGaugeDouble(sb, first, "argus_gc_leak_confidence",
+                "Memory leak detection confidence (R-squared 0-1)", nowNano, analysis.leakConfidencePercent() / 100.0);
+        first = appendGaugeDouble(sb, first, "argus_heap_usage_ratio",
+                "Heap usage ratio (used/committed)", nowNano,
+                analysis.currentHeapCommitted() > 0
+                        ? (double) analysis.currentHeapUsed() / analysis.currentHeapCommitted() : 0);
         // Legacy duplicates of jvm.memory.used / jvm.memory.committed (pool=heap) —
         // gated so legacyNames=false does not double OTLP series.
         if (config.isLegacyMetricNames()) {
@@ -240,6 +261,10 @@ public final class OtlpJsonBuilder {
             first = appendGaugeWithPool(sb, first, SemconvMetrics.MEMORY_COMMITTED.otelName(),
                     SemconvMetrics.MEMORY_COMMITTED.description(), nowNano, analysis.currentCommitted(), "Metaspace");
         }
+        // Argus-unique: no semconv reserved-memory metric — always emitted, in parity
+        // with the Prometheus collector.
+        first = appendGauge(sb, first, "argus_metaspace_reserved_bytes",
+                "Metaspace memory reserved in bytes", nowNano, analysis.currentReserved());
         // Legacy duplicates of jvm.memory.used / jvm.memory.committed (pool=Metaspace)
         // and jvm.class.count — gated so legacyNames=false does not double OTLP series.
         if (config.isLegacyMetricNames()) {

--- a/argus-server/src/test/java/io/argus/server/metrics/OtlpJsonBuilderMetricsTest.java
+++ b/argus-server/src/test/java/io/argus/server/metrics/OtlpJsonBuilderMetricsTest.java
@@ -134,6 +134,28 @@ class OtlpJsonBuilderMetricsTest {
     }
 
     @Test
+    void otlp_emits_argus_unique_diagnostics_regardless_of_legacy_flag() {
+        // These series have no semconv equivalent, so they must ship on the OTLP path
+        // in parity with the Prometheus collector — and must NOT be gated by legacyNames.
+        AgentConfig noLegacy = AgentConfig.builder().legacyMetricNames(false).build();
+        String json = builder(noLegacy).build();
+
+        for (String name : new String[]{
+                "argus_gc_pause_time_seconds_avg",
+                "argus_gc_overhead_warning",
+                "argus_gc_allocation_rate_kbps",
+                "argus_gc_promotion_rate_kbps",
+                "argus_gc_leak_suspected",
+                "argus_gc_leak_confidence",
+                "argus_heap_usage_ratio",
+                "argus_metaspace_reserved_bytes",
+                "argus_carrier_threads_virtual_handled_total"}) {
+            assertTrue(json.contains("\"name\":\"" + name + "\""),
+                    "argus-unique series " + name + " must ship over OTLP even when legacyNames=false");
+        }
+    }
+
+    @Test
     void otlp_gc_duration_skipped_when_no_pauses() {
         GCAnalyzer gc = new GCAnalyzer(); // no events recorded
         OtlpJsonBuilder b = new OtlpJsonBuilder(


### PR DESCRIPTION
## What

Follow-up to the #262 code review. Several **argus-unique** series (no OTel semconv equivalent) shipped on the Prometheus scrape but were missing from the OTLP export — so an operator moving from Prometheus scrape to OTLP push silently lost leak detection and GC-rate diagnostics.

This adds the **scalar** argus-unique series to `OtlpJsonBuilder`, in parity with `PrometheusMetricsCollector` and with matching values/units:

- `argus_gc_pause_time_seconds_avg`, `argus_gc_overhead_warning`
- `argus_gc_allocation_rate_kbps`, `argus_gc_promotion_rate_kbps`
- `argus_gc_leak_suspected`, `argus_gc_leak_confidence`
- `argus_heap_usage_ratio`
- `argus_metaspace_reserved_bytes`
- `argus_carrier_threads_virtual_handled_total`

These have no semconv equivalent, so they are **always emitted** (not gated by `argus.metrics.legacyNames`). New test `otlp_emits_argus_unique_diagnostics_regardless_of_legacy_flag` asserts they ship even when `legacyNames=false`.

## Intentionally still Prometheus-only (documented, not a regression)

- **Legacy `argus_gc_pause_seconds_*` histogram** — the OTLP path already carries the semconv `jvm.gc.duration` histogram as the equivalent; duplicating the legacy histogram over OTLP would contradict the `legacyNames` design.
- **Label-dimensioned breakdown series** — `argus_gc_pause_breakdown_seconds_total`, `argus_gc_events_breakdown_total`, `argus_allocation_class_bytes`, `argus_profiling_method_samples`, `argus_contention_hotspot_events`. These need per-series OTLP attribute encoding (the current OTLP helpers are scalar gauges/sums); a separate, larger change.

After this PR the only Prometheus↔OTLP series gap is exactly those two intentional categories.

## Verification

`./gradlew :argus-server:test` → **BUILD SUCCESSFUL** (`OtlpJsonBuilderMetricsTest` 8/8). Commit `-s`, no `Co-Authored-By`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)