### PR TITLE
docs(site): content audit + refresh across all pages for 1.5.0 accuracy

### DIFF
--- a/site/commands.html
+++ b/site/commands.html
@@ -105,14 +105,46 @@ argus histo 12345</code></pre>
                             </tr>
                         </thead>
                         <tbody>
-                            <tr><td>Process</td><td><code>ps</code>, <code>info</code>, <code>init</code></td><td>Find and identify JVM processes</td></tr>
-                            <tr><td>Memory</td><td><code>heap</code>, <code>histo</code>, <code>heapdump</code>, <code>diff</code>, <code>nmt</code></td><td>Heap usage, object distribution, native memory</td></tr>
-                            <tr><td>GC</td><td><code>gc</code>, <code>gcutil</code>, <code>gccause</code>, <code>gcnew</code>, <code>zgc</code></td><td>GC frequency, pause times, causes, generation stats; ZGC live diagnosis (allocation stalls, soft-max breach, cycle overlap) + trend tracking</td></tr>
-                            <tr><td>Threads</td><td><code>threads</code>, <code>deadlock</code>, <code>pool</code></td><td>Thread states, deadlocks, pool analysis</td></tr>
-                            <tr><td>CPU</td><td><code>profile</code>, <code>jfr</code></td><td>CPU profiling, flight recording</td></tr>
-                            <tr><td>Classes</td><td><code>classloader</code>, <code>classstat</code>, <code>stringtable</code>, <code>symboltable</code></td><td>Class loading, interned strings, symbols</td></tr>
-                            <tr><td>Runtime</td><td><code>sysprops</code>, <code>vmflag</code>, <code>vmset</code>, <code>vmlog</code>, <code>env</code>, <code>dynlibs</code></td><td>Configuration, flags, environment</td></tr>
-                            <tr><td>Advanced</td><td><code>metaspace</code>, <code>compiler</code>, <code>finalizer</code>, <code>jmx</code>, <code>report</code>, <code>top</code></td><td>Metaspace, JIT, finalizers, diagnostics</td></tr>
+                            <tr>
+                                <td>Health &amp; triage</td>
+                                <td><code>doctor</code>, <code>suggest</code>, <code>report</code>, <code>snapshot</code>, <code>compare</code>, <code>top</code>, <code>tui</code>, <code>info</code>, <code>ps</code>, <code>init</code>, <code>env</code>, <code>watch</code></td>
+                                <td>One-click JVM health diagnosis; flag tuning recommendations; full diagnostic report; forensic bundle; side-by-side two-PID comparison; real-time agent dashboard; interactive terminal UI; JVM version/uptime/flags; list running JVM processes; first-time setup wizard; launch environment (classpath, VM args); htop-style live JVM dashboard</td>
+                            </tr>
+                            <tr>
+                                <td>GC</td>
+                                <td><code>gc</code>, <code>gcutil</code>, <code>gccause</code>, <code>gcnew</code>, <code>gcwhy</code>, <code>gcscore</code>, <code>gclog</code>, <code>gclogdiff</code>, <code>gcrun</code>, <code>gcprofile</code>, <code>g1</code>, <code>zgc</code></td>
+                                <td>GC stats (heap usage, pause time, collector); generation utilization % (jstat-style); last/current GC cause with gen utilization; young-gen detail (eden, survivor, tenuring); plain-English narration of the worst GC pause; A–F GC health scorecard (live PID or GC-log file); analyze GC log files (pauses, causes, tuning); compare two GC log files; trigger System.gc() remotely; JFR-based allocation profiling; G1GC live health verdict; ZGC live health verdict</td>
+                            </tr>
+                            <tr>
+                                <td>Memory &amp; heap</td>
+                                <td><code>heap</code>, <code>histo</code>, <code>heapdump</code>, <code>heapanalyze</code>, <code>diff</code>, <code>nmt</code>, <code>buffers</code>, <code>metaspace</code></td>
+                                <td>Detailed heap usage with space breakdown; heap object histogram (count + size); generate heap dump (.hprof); offline HPROF analysis — dominator tree, retained sizes, leak suspects; heap snapshot comparison (leak detection); native memory tracking by category; NIO direct/mapped buffer pools; metaspace usage by space type</td>
+                            </tr>
+                            <tr>
+                                <td>Threads &amp; concurrency</td>
+                                <td><code>threads</code>, <code>threaddump</code>, <code>deadlock</code>, <code>pool</code></td>
+                                <td>Thread state summary with distribution bars; full thread dump (jstack replacement); automated deadlock detection; thread pool grouping with state distribution</td>
+                            </tr>
+                            <tr>
+                                <td>CPU &amp; profiling</td>
+                                <td><code>profile</code>, <code>profile-gate</code>, <code>flame</code>, <code>benchmark</code>, <code>jfr</code>, <code>jfranalyze</code>, <code>events</code>, <code>slowlog</code>, <code>trace</code></td>
+                                <td>CPU/alloc/lock/wall profiling (async-profiler); CI/CD CPU regression gate comparing a profile snapshot against a baseline; one-shot flame graph (HTML, opens browser); sampling-based throughput estimate for a method; JFR start/stop/check/dump; analyze JFR recording file; VM internal event log (safepoints, deoptimizations); real-time slow method detection (JFR streaming); method call tree from thread-dump sampling</td>
+                            </tr>
+                            <tr>
+                                <td>Classes</td>
+                                <td><code>classstat</code>, <code>classloader</code>, <code>classleak</code>, <code>searchclass</code>, <code>stringtable</code>, <code>symboltable</code></td>
+                                <td>Class loading throughput; class loader hierarchy + class counts; classloader-level metaspace leak attribution (--top/--save/--diff/--watch); search loaded classes by pattern; interned string table statistics; JVM symbol table statistics</td>
+                            </tr>
+                            <tr>
+                                <td>Runtime &amp; VM</td>
+                                <td><code>sysprops</code>, <code>vmflag</code>, <code>vmset</code>, <code>vmlog</code>, <code>compiler</code>, <code>compilerqueue</code>, <code>perfcounter</code>, <code>finalizer</code>, <code>dynlibs</code>, <code>logger</code>, <code>mbean</code>, <code>jmx</code></td>
+                                <td>JVM system properties (-D flags); show/filter non-default VM flags; set a manageable VM flag at runtime; control JVM unified logging at runtime; JIT compiler status + code cache usage; current JIT compilation queue; low-level JVM performance counters; finalizer queue status; native libraries loaded in the JVM; view/change log levels at runtime; MBean browser (domains, attributes); JMX management agent control</td>
+                            </tr>
+                            <tr>
+                                <td>Diagnostics &amp; ops</td>
+                                <td><code>rightsize</code>, <code>explain</code>, <code>instrument</code>, <code>harness</code>, <code>alert</code>, <code>ci</code>, <code>cluster</code>, <code>spring</code></td>
+                                <td>JVM right-sizing recommendations (-Xmx/-Xms, container request/limit) from observed heap HWM/live-set; plain-English lookup of GC causes, flags, and metrics (--llm adds opt-in LLM advisory with BYO key); opt-in live method instrumentation (watch/trace/monitor) — requires --enable-instrument and the agent JAR; continuous trend-aware health watch (doctor + 4 trend rules over a window); threshold-based webhook alerting; CI/CD health gate with exit codes; multi-instance aggregated health; Spring Boot app inspection via JMX</td>
+                            </tr>
                         </tbody>
                     </table>
                 </div>
@@ -127,7 +159,7 @@ argus histo 12345</code></pre>
                     <p><strong>ZGC monitoring in one command.</strong> <code>argus zgc &lt;PID&gt;</code> runs a 30-second live JFR capture and returns a HEALTHY/WARNING/UNHEALTHY verdict driven by allocation stalls, SoftMaxHeapSize breach, and cycle overlap — the signals JDK Mission Control surfaces with three GUI clicks, in a one-line CLI.</p>
                 </div>
 
-                <p>The command pre-checks the target JVM via JMX to confirm ZGC is the active collector, then captures a JFR profile recording, parses ZGC-specific events, and prints a verdict with concrete tuning recommendations. Use <code>--duration=N</code> to override the default 30-second window (5–120 seconds). Allocation stalls now ship with the top-5 allocator call sites from the same JFR capture, so you see <em>what</em> allocated and <em>who</em> stalled in one shot. Use <code>--save</code>/<code>--diff</code> to track ZGC health across deploys, or <code>--watch</code> for live load tests.</p>
+                <p>The command pre-checks the target JVM via JMX to confirm ZGC is the active collector, then captures a JFR profile recording, parses ZGC-specific events, and prints a verdict with concrete tuning recommendations. Use <code>--duration=N</code> to override the default 30-second capture window (clamped 5–120 seconds). Allocation stalls now ship with the top-5 allocator call sites from the same JFR capture, so you see <em>what</em> allocated and <em>who</em> stalled in one shot. Use <code>--save</code>/<code>--diff</code> to track ZGC health across deploys, or <code>--watch</code> for live load tests.</p>
 
 <pre><code>$ argus zgc 12345
 ZGC Diagnosis (PID 12345, JDK 21, Generational)
@@ -154,7 +186,7 @@ ZGC Diff (baseline 2026-05-08T12:00:00Z → now 2026-05-08T12:30:00Z, +30 min)
   Allocation stalls  0     → 7         (NEW) ✘
   Pause Mark End     0.30ms → 0.42ms   (+0.12ms ⚠)
 
-# Or watch live during a load test
+# Or watch live during a load test (10 iterations, 60 s between captures)
 $ argus zgc 12345 --watch=10 --interval=60</code></pre>
 
             </div>

--- a/site/comparison.html
+++ b/site/comparison.html
@@ -63,7 +63,7 @@
                 <span class="section-anchor" id="comparison"></span>
                 <h2>Argus vs Traditional JVM Tools</h2>
 
-                <p>Argus's value proposition is brutally simple: replace the JFR-capture-then-GUI-then-grep workflow with one CLI command. Below are five real production scenarios where Argus collapses 5–10 manual steps into one or two commands.</p>
+                <p>Argus's value proposition is brutally simple: collapse the multi-tool, multi-step JVM diagnostic workflow into one or two commands. Argus covers GC analysis, MAT-class heap analysis (<code>heapanalyze</code>), CPU/continuous profiling, virtual-thread and Loom diagnostics, FinOps right-sizing (<code>rightsize</code>), and OTel-native metrics export — not just GC or ZGC. Below are five real production scenarios where Argus collapses 5–10 manual steps into one or two commands.</p>
 
                 <div class="table-wrap">
                     <table>
@@ -89,10 +89,10 @@
                                 <td>scan → banner + top growers</td>
                             </tr>
                             <tr>
-                                <td>Lock contention</td>
-                                <td><code>jstack</code> × 3 + manual <code>waiting to lock</code> aggregation</td>
-                                <td><code>argus pool &lt;PID&gt;</code></td>
-                                <td>1 cmd vs 3 jstacks + grep</td>
+                                <td>Lock contention / pool state</td>
+                                <td><code>jstack</code> × 3 + manual <code>waiting to lock</code> aggregation; no built-in JDBC or thread-pool view</td>
+                                <td><code>argus pool &lt;PID&gt;</code> (thread-pool contention); <code>argus pool jdbc &lt;PID&gt;</code> (HikariCP/Tomcat JDBC pool state); <code>argus pool advise &lt;PID&gt;</code> (thread-pool sizing advisor)</td>
+                                <td>1–2 cmds vs 3 jstacks + grep + manual analysis</td>
                             </tr>
                             <tr>
                                 <td>ZGC allocation stalls</td>

--- a/site/dashboard.html
+++ b/site/dashboard.html
@@ -103,7 +103,7 @@
                     </div>
                     <div class="feature-card">
                         <h4>Virtual Threads</h4>
-                        <p>Thread creation rate, active count, pinning detection with stack traces, carrier thread distribution. Java 21+ only.</p>
+                        <p>Thread creation rate, active count, pinning detection with stack traces (<code>jdk.VirtualThreadPinned</code>), carrier-pool saturation (<code>jdk.VirtualThreadSubmitFailed</code>), and carrier thread distribution. Java 21+ only.</p>
                     </div>
                     <div class="feature-card">
                         <h4>Recommendations</h4>
@@ -129,14 +129,20 @@
                             <tr><th>Property</th><th>Default</th><th>Description</th></tr>
                         </thead>
                         <tbody>
+                            <tr><td><code>argus.server.enabled</code></td><td>true</td><td>Start the built-in HTTP dashboard/metrics server</td></tr>
                             <tr><td><code>argus.server.port</code></td><td>9202</td><td>Dashboard HTTP port</td></tr>
                             <tr><td><code>argus.gc.enabled</code></td><td>true</td><td>GC event collection</td></tr>
                             <tr><td><code>argus.cpu.enabled</code></td><td>true</td><td>CPU load sampling</td></tr>
+                            <tr><td><code>argus.cpu.interval</code></td><td>1000</td><td>CPU sampling interval (ms)</td></tr>
                             <tr><td><code>argus.allocation.enabled</code></td><td>false</td><td>Object allocation tracking (higher overhead)</td></tr>
                             <tr><td><code>argus.profiling.enabled</code></td><td>false</td><td>CPU method profiling (higher overhead)</td></tr>
+                            <tr><td><code>argus.profiling.interval</code></td><td>20</td><td>Profiling sampling interval (ms)</td></tr>
                             <tr><td><code>argus.contention.enabled</code></td><td>false</td><td>Lock contention monitoring</td></tr>
+                            <tr><td><code>argus.contention.threshold</code></td><td>50</td><td>Minimum contention time to record (ms)</td></tr>
                             <tr><td><code>argus.metaspace.enabled</code></td><td>true</td><td>Metaspace usage tracking</td></tr>
                             <tr><td><code>argus.metrics.prometheus.enabled</code></td><td>true</td><td>Prometheus metrics endpoint at <code>/prometheus</code></td></tr>
+                            <tr><td><code>argus.metrics.legacyNames</code></td><td>true</td><td>Emit legacy <code>argus_*</code> series alongside OTel-semconv <code>jvm_*</code> series</td></tr>
+                            <tr><td><code>argus.anomaly.mode</code></td><td>fixed</td><td>Anomaly detection mode: <code>fixed</code>, <code>learned</code>, or <code>both</code></td></tr>
                         </tbody>
                     </table>
                 </div>

--- a/site/index.html
+++ b/site/index.html
@@ -73,10 +73,12 @@
                     </div>
                 </div>
 
-                <p>Argus gives you two tools for JVM diagnostics:</p>
+                <p>Argus ships in four deployment forms:</p>
                 <ul>
                     <li><strong>Argus CLI</strong> — 71 diagnostic commands that work on any running JVM. No agent, no restart, no configuration. Point at a PID and get answers in seconds.</li>
                     <li><strong>Argus Agent</strong> — Attach as a Java agent and get a live web dashboard with GC timelines, CPU graphs, heap usage, flame graphs, and thread analysis, all streaming in real time.</li>
+                    <li><strong>Spring Boot Starter</strong> — Drop <code>argus-spring-boot-starter</code> into any Spring Boot app to get diagnostics mode (<code>argus.mode=full|diagnostics|off</code>), a scheduled doctor, and <code>/actuator/argus-doctor</code> and <code>/actuator/argus-gc</code> endpoints.</li>
+                    <li><strong>argus-diagnostics library</strong> — A framework-agnostic embeddable library that exposes the same <code>DoctorService</code>, <code>GcLogAnalyzerService</code>, and <code>GcScoreService</code> beans in any JVM app, without Spring.</li>
                 </ul>
 
                 <div class="callout">
@@ -106,7 +108,7 @@
                     </div>
                     <div class="feature-card">
                         <h4>Virtual Thread Aware</h4>
-                        <p>First-class support for Java 21 virtual threads. Detect pinning, analyze carrier thread distribution, and monitor thread lifecycle events as they happen.</p>
+                        <p>First-class support for Java 21+ virtual threads. Pinning events are classified into three buckets per JEP 491 — native-frame, foreign-call, and object-monitor pins. The agent dashboard renders the StructuredTaskScope (structured-concurrency) tree from a VT-aware thread dump, and a carrier-saturation rule in <code>argus doctor</code> fires when the carrier pool saturates.</p>
                     </div>
                     <div class="feature-card">
                         <h4>Zero Overhead Design</h4>
@@ -132,6 +134,22 @@
                         <h4>OpenMetrics &amp; Grafana</h4>
                         <p>OpenMetrics-compliant <code>/prometheus</code> export with per-collector GC pause histograms and trace-ID exemplars, plus a shipped Grafana dashboard and recording/alert rules.</p>
                     </div>
+                    <div class="feature-card">
+                        <h4>OTel-Native Metrics</h4>
+                        <p>Metrics are dual-emitted under standard OpenTelemetry JVM semantic-convention names (<code>jvm.gc.duration</code>, <code>jvm.memory.used</code>, …) alongside the legacy <code>argus_*</code> series. Toggle legacy names off with <code>argus.metrics.legacyNames=false</code> to drop into an OTel-native stack without renaming dashboards.</p>
+                    </div>
+                    <div class="feature-card">
+                        <h4>JVM Right-Sizing (FinOps)</h4>
+                        <p><code>argus rightsize &lt;pid&gt;</code> derives <code>-Xmx</code>/<code>-Xms</code> and container memory request/limit recommendations from observed heap high-water-mark, post-GC live-set floor, and alloc/promotion rate — with the inputs and safety factor shown, plus an OOMKill-risk flag. A fleet roll-up is available via the aggregator's <code>/fleet/rightsize</code> endpoint.</p>
+                    </div>
+                    <div class="feature-card">
+                        <h4>Learned Anomaly Detection</h4>
+                        <p>The agent can baseline each signal online (z-score, EWMA, and IQR over a rolling window) and fire on sustained regime shifts. Configured via <code>argus.anomaly.mode=fixed|learned|both</code>; defaults to <code>fixed</code> for back-compat. <code>learned</code> and <code>both</code> are opt-in.</p>
+                    </div>
+                    <div class="feature-card">
+                        <h4>Opt-in LLM Root-Cause</h4>
+                        <p><code>argus explain --llm</code> and <code>argus doctor --rca</code> attach an LLM advisory to the deterministic findings. Default OFF; requires a bring-your-own-key API credential. Only the deterministic findings payload is sent — raw heap or profile data is never forwarded — and the deterministic output is always shown alongside.</p>
+                    </div>
                 </div>
             </div>
 
@@ -156,7 +174,7 @@
                     <li><a href="comparison.html">vs Traditional JVM Tools</a> — what changes when Argus replaces a 5-tool chain in five production scenarios.</li>
                     <li><a href="scenarios.html">Real-World Scenarios</a> — twelve production incidents (humongous allocations, TTSP, OOMKilled, deopt storms, …) walked through end-to-end.</li>
                     <li><a href="dashboard.html">Dashboard</a> — agent setup, the JVM-health-first layout, interactive console, configuration knobs.</li>
-                    <li><a href="integrations.html">Integrations</a> — Spring Boot starter and Micrometer metrics.</li>
+                    <li><a href="integrations.html">Integrations</a> — Spring Boot starter, <code>argus-diagnostics</code> embedded library, Micrometer metrics, OTel/OpenMetrics export, and Pyroscope / OTLP continuous-profile push.</li>
                     <li><a href="reference.html">Reference</a> — Java version compatibility matrix, module architecture, full configuration reference.</li>
                 </ul>
             </div>

--- a/site/integrations.html
+++ b/site/integrations.html
@@ -70,7 +70,8 @@ implementation("io.argus:argus-spring-boot-starter:1.5.0")</code></pre>
                 <ul>
                     <li>Start the JFR streaming engine automatically</li>
                     <li>Launch the dashboard on port 9202</li>
-                    <li>Register with Spring Boot Actuator at <code>/actuator/health/argus</code></li>
+                    <li>Register with Spring Boot Actuator at <code>/actuator/argus-doctor</code>, <code>/actuator/argus-doctor/{pid}</code>, and <code>/actuator/argus-gc</code> (all modes except <code>off</code>)</li>
+                    <li>Register <code>/actuator/health/argus</code> reporting JFR engine + server status (<code>mode=full</code> only)</li>
                     <li>Export ~25 Micrometer metrics to your configured backend (Prometheus, Datadog, etc.)</li>
                 </ul>
 
@@ -78,17 +79,23 @@ implementation("io.argus:argus-spring-boot-starter:1.5.0")</code></pre>
                 <h3>Configuration via application.yml</h3>
 
                 <pre><code>argus:
-  buffer-size: 131072
+  mode: full                         # full | diagnostics | off
+  buffer-size: 65536
   server:
     port: 9202
   gc:
     enabled: true
   cpu:
     enabled: true
-    interval-ms: 500
+    interval-ms: 1000
   allocation:
     enabled: true
-    threshold: 524288</code></pre>
+    threshold: 1048576
+  doctor:
+    gc-log-path: /var/log/app/gc.log # required for /actuator/argus-gc to return data
+  metrics:
+    prometheus:
+      enabled: true                  # default true; exposes /prometheus scrape endpoint</code></pre>
 
                 <p>All properties have IDE autocomplete support. The defaults match the standard agent configuration.</p>
 
@@ -109,6 +116,8 @@ management:
       exposure:
         include: argus-doctor,argus-gc</code></pre>
 
+                <p>The scheduled doctor requires <code>argus.doctor.schedule.enabled=true</code>. The starter's auto-configuration activates Spring scheduling automatically when this flag is set — no <code>@EnableScheduling</code> annotation is needed in your application code.</p>
+
                 <span class="section-anchor" id="spring-api"></span>
                 <h3>Programmatic API beans</h3>
 
@@ -122,7 +131,7 @@ public List&lt;Finding&gt; jvmHealth() {
 }</code></pre>
 
                 <ul>
-                    <li><code>DoctorService</code> — diagnoseLocal / diagnoseRemote(pid) / diagnose(snapshot)</li>
+                    <li><code>DoctorService</code> — diagnoseLocal / diagnoseRemote(pid) / diagnose(snapshot) / lastCollectionWarnings()</li>
                     <li><code>GcLogAnalyzerService</code> — analyze(Path) / analyze(List&lt;GcEvent&gt;)</li>
                     <li><code>GcScoreService</code> — score(analysis [, gcAlgorithm]) / inferAlgorithm</li>
                 </ul>

--- a/site/reference.html
+++ b/site/reference.html
@@ -88,7 +88,7 @@
                 <span class="section-anchor" id="architecture"></span>
                 <h2>Architecture</h2>
 
-                <p>Argus is organized into seven modules, each with a clear responsibility:</p>
+                <p>Argus is organized into eleven modules, each with a clear responsibility:</p>
 
                 <div class="table-wrap">
                     <table>
@@ -102,7 +102,11 @@
                             <tr><td><code>argus-frontend</code></td><td>Dashboard web UI (vanilla JS, Chart.js, D3 flame graph)</td></tr>
                             <tr><td><code>argus-cli</code></td><td>71 diagnostic commands using jcmd/jstat</td></tr>
                             <tr><td><code>argus-micrometer</code></td><td>Framework-agnostic Micrometer MeterBinder</td></tr>
-                            <tr><td><code>argus-spring-boot-starter</code></td><td>Spring Boot auto-configuration</td></tr>
+                            <tr><td><code>argus-spring-boot-starter</code></td><td>Spring Boot auto-configuration: <code>argus.mode=full|diagnostics|off</code>, injectable <code>DoctorService</code> / <code>GcLogAnalyzerService</code> / <code>GcScoreService</code> beans, <code>/actuator/argus-doctor</code> and <code>/actuator/argus-gc</code> endpoints, and a scheduled doctor — all delegating to <code>argus-diagnostics</code></td></tr>
+                            <tr><td><code>argus-diagnostics</code></td><td>Framework-agnostic diagnostics library (DoctorEngine, GC-log analysis, health rules) that non-Spring JVM apps can embed; the Spring starter's service beans delegate to it</td></tr>
+                            <tr><td><code>argus-aggregator</code></td><td>Fleet-level aggregation server: multi-JVM health roll-up, alert evaluation, <code>/fleet/rightsize</code>, and profile push (Pyroscope / OTLP Profiles)</td></tr>
+                            <tr><td><code>argus-operator</code></td><td>Kubernetes operator (ArgusFleet / ArgusTarget CRDs + reconcilers)</td></tr>
+                            <tr><td><code>argus-instrument</code></td><td>Opt-in live bytecode instrumentation agent (ByteBuddy-based), default OFF, used by <code>argus instrument</code></td></tr>
                         </tbody>
                     </table>
                 </div>
@@ -126,16 +130,26 @@
                         </thead>
                         <tbody>
                             <tr><td><code>argus.server.port</code></td><td>9202</td><td>Dashboard HTTP port</td></tr>
+                            <tr><td><code>argus.server.enabled</code></td><td>true</td><td>Start the built-in HTTP dashboard/metrics server</td></tr>
                             <tr><td><code>argus.gc.enabled</code></td><td>true</td><td>GC event collection via JFR</td></tr>
                             <tr><td><code>argus.cpu.enabled</code></td><td>true</td><td>CPU load sampling</td></tr>
-                            <tr><td><code>argus.cpu.interval-ms</code></td><td>500</td><td>CPU sampling interval in milliseconds</td></tr>
+                            <tr><td><code>argus.cpu.interval</code></td><td>1000</td><td>CPU sampling interval in milliseconds</td></tr>
                             <tr><td><code>argus.allocation.enabled</code></td><td>false</td><td>Object allocation tracking (higher overhead)</td></tr>
-                            <tr><td><code>argus.allocation.threshold</code></td><td>524288</td><td>Minimum allocation size to track (bytes)</td></tr>
+                            <tr><td><code>argus.allocation.threshold</code></td><td>1048576</td><td>Minimum allocation size to track (bytes)</td></tr>
                             <tr><td><code>argus.profiling.enabled</code></td><td>false</td><td>CPU method profiling via JFR</td></tr>
+                            <tr><td><code>argus.profiling.interval</code></td><td>20</td><td>CPU profiling sampling interval in milliseconds</td></tr>
                             <tr><td><code>argus.contention.enabled</code></td><td>false</td><td>Lock contention monitoring</td></tr>
+                            <tr><td><code>argus.contention.threshold</code></td><td>50</td><td>Minimum lock contention duration to record (milliseconds)</td></tr>
                             <tr><td><code>argus.metaspace.enabled</code></td><td>true</td><td>Metaspace usage tracking</td></tr>
-                            <tr><td><code>argus.buffer-size</code></td><td>131072</td><td>Ring buffer size in bytes</td></tr>
+                            <tr><td><code>argus.buffer.size</code></td><td>65536</td><td>Ring buffer size in bytes</td></tr>
+                            <tr><td><code>argus.correlation.enabled</code></td><td>true</td><td>Cross-metric correlation analysis</td></tr>
+                            <tr><td><code>argus.anomaly.mode</code></td><td>fixed</td><td>Anomaly detection mode: <code>fixed</code> | <code>learned</code> | <code>both</code> (<code>learned</code> uses z-score/EWMA/IQR baselines)</td></tr>
                             <tr><td><code>argus.metrics.prometheus.enabled</code></td><td>true</td><td>Expose Prometheus endpoint at <code>/prometheus</code></td></tr>
+                            <tr><td><code>argus.metrics.legacyNames</code></td><td>true</td><td>Emit legacy <code>argus_*</code> series alongside OTel semconv <code>jvm.*</code> names; set <code>false</code> to emit only the standard names</td></tr>
+                            <tr><td><code>argus.otlp.enabled</code></td><td>false</td><td>Export metrics via OTLP</td></tr>
+                            <tr><td><code>argus.otlp.endpoint</code></td><td>http://localhost:4318/v1/metrics</td><td>OTLP HTTP endpoint for metrics export</td></tr>
+                            <tr><td><code>argus.otlp.interval</code></td><td>15000</td><td>OTLP export interval in milliseconds</td></tr>
+                            <tr><td><code>argus.otlp.service.name</code></td><td>argus</td><td>Service name reported in OTLP resource attributes</td></tr>
                         </tbody>
                     </table>
                 </div>

--- a/site/scenarios.html
+++ b/site/scenarios.html
@@ -55,6 +55,7 @@
                 <li class="sub"><a href="#s10-lock" data-target="s10-lock">10. Lock Contention</a></li>
                 <li class="sub"><a href="#s11-false-sharing" data-target="s11-false-sharing">11. False Sharing</a></li>
                 <li class="sub"><a href="#s12-direct-buffer" data-target="s12-direct-buffer">12. Direct Buffer</a></li>
+                <li class="sub"><a href="#s13-vt-pinning" data-target="s13-vt-pinning">13. VT Carrier Saturation</a></li>
             </ul>
         </div>
     </nav>
@@ -260,6 +261,24 @@ $ argus nmt 12345 --diff baseline.json
 ╰──────────────────────────────────────────────────────────────╯
 </code></pre>
 
+                <p>Once you have identified the growing NMT category, cross-check whether the current heap sizing itself puts the pod at OOMKill risk:</p>
+
+<pre><code>$ argus rightsize 12345 --limit=2g
+╭─ argus rightsize ───────────────────────────────────────────╮
+│ JVM Right-Sizing   floor:312MiB  safety:1.5x                 │
+│                                                              │
+│   -Xmx                   -Xmx768m                            │
+│   -Xms                   -Xms256m                            │
+│   Container request       900 MiB                            │
+│   Container limit        1100 MiB                            │
+│   CPU request            0.50 cores                          │
+│                                                              │
+│   [OOMKILL RISK] total footprint (heap + off-heap) exceeds   │
+│     container limit 2g — kernel OOMKill likely               │
+│                                                              │
+╰──────────────────────────────────────────────────────────────╯
+</code></pre>
+
                 <p><strong>Verdict.</strong></p>
                 <div class="table-wrap">
                     <table>
@@ -268,6 +287,7 @@ $ argus nmt 12345 --diff baseline.json
                         </thead>
                         <tbody>
                             <tr><td>NMT baseline + diff</td><td>⚠️ manual scan of 18 categories</td><td>✅ banner + sorted growers</td></tr>
+                            <tr><td>OOMKill risk check</td><td>⚠️ manual math from kubectl + jcmd</td><td>✅ <code>argus rightsize --limit=&lt;mem&gt;</code></td></tr>
                             <tr><td>Container working-set</td><td>✅ <code>kubectl top</code> / cAdvisor</td><td>❌ out of scope</td></tr>
                             <tr><td>Kernel kill event</td><td>✅ <code>dmesg</code></td><td>❌ out of scope — still need shell</td></tr>
                         </tbody>
@@ -452,7 +472,7 @@ $ jcmd 12345 GC.heap_dump /tmp/heap.hprof
 │                                                              │
 ╰──────────────────────────────────────────────────────────────╯
 
-$ argus classloader 12345 --top 5
+$ argus classleak 12345 --top 5
   ClassLoader                                  Classes    Δ since boot
   ─────────────────────────────────────────────────────────────────────
   AppClassLoader                                 24,118        +18
@@ -469,7 +489,7 @@ $ argus classloader 12345 --top 5
                         </thead>
                         <tbody>
                             <tr><td>Metaspace usage trend</td><td>✅ <code>VM.metaspace</code></td><td>✅ progress bar + warning</td></tr>
-                            <tr><td>Loaded class growth</td><td>⚠️ <code>GC.class_histogram</code> only</td><td>✅ <code>argus classloader</code></td></tr>
+                            <tr><td>Loaded class growth</td><td>⚠️ <code>GC.class_histogram</code> only</td><td>✅ <code>argus classleak</code></td></tr>
                             <tr><td>Offending ClassLoader</td><td>❌ heap dump + MAT (20 min)</td><td>✅ top-N by class count</td></tr>
                         </tbody>
                     </table>
@@ -680,6 +700,17 @@ $ argus profile 12345 --event lock --duration 20
                     </table>
                 </div>
 
+                <p><strong>Optional: confirm the exact hot synchronized path.</strong> Once <code>profile --event lock</code> names the suspect method, use <code>argus instrument watch</code> to capture per-invocation args, return value, and wall-clock cost without restarting the process:</p>
+
+<pre><code># Requires --enable-instrument and ~/.argus/lib/argus-instrument.jar
+$ argus instrument watch 12345 com.acme.Foo#method --enable-instrument
+[argus-instrument]  com.acme.Foo#method  args=[...]  return=...  duration=4ms
+[argus-instrument]  com.acme.Foo#method  args=[...]  return=...  duration=6ms
+# Ctrl-C — bytecode restored automatically on detach
+</code></pre>
+
+                <p>The agent is default-OFF, attaches on demand, and resets all transformed bytecode on detach — no residual instrumentation is left in the target JVM.</p>
+
                 <span class="section-anchor" id="s11-false-sharing"></span>
                 <h3>11. False Sharing in the Multi-Core Era</h3>
 
@@ -797,7 +828,94 @@ $ argus doctor 12345
                     </table>
                 </div>
 
-                <p><strong>Closing.</strong> Argus collapses roughly nine of these twelve scenarios into a single command answer (1, 4, 5, 6, 8, 10, 12, plus the JVM-side of 3 and the application-side of 9). The remaining cases — TTSP safepoint logs, OS swap, and FD/socket exhaustion — sit below the JVM boundary, where Argus consciously stops. The intended workflow is to run Argus alongside the host shell, not in place of it.</p>
+                <span class="section-anchor" id="s13-vt-pinning"></span>
+                <h3>13. Virtual-Thread Carrier Saturation / Pinning</h3>
+
+                <p><strong>Symptom.</strong> A Java 21+ service migrated to virtual threads shows healthy request counts under low load but throughput collapses under concurrency. Heap, GC, and CPU look fine. The root cause is that <code>synchronized</code> blocks or legacy blocking I/O inside virtual threads pin them to their carrier platform threads. Once all carriers are pinned, the scheduler cannot mount new virtual threads and the entire pool stalls — even though hundreds of virtual threads are nominally "runnable".</p>
+
+                <p><strong>Metrics required to diagnose:</strong></p>
+                <ul>
+                    <li>Virtual thread count vs. carrier (platform) thread count</li>
+                    <li>Carrier thread states — all WAITING/BLOCKED means they are all pinned</li>
+                    <li>Pinning event rate and taxonomy: native-frame pinning, foreign-call pinning, or object-monitor pinning (post-JEP-491 JDK 24+ breakdown)</li>
+                    <li><code>jdk.VirtualThreadPinned</code> and <code>jdk.VirtualThreadSubmitFailed</code> JFR events</li>
+                </ul>
+
+                <h4>Traditional toolchain</h4>
+<pre><code># Enable JVM pinning trace at startup and tail the log
+$ java -Djdk.tracePinnedThreads=full -jar service.jar 2&gt;&amp;1 | grep -A4 'PinnedThreads'
+Thread[#42,ForkJoinPool-1-worker-1,5,CarrierThreads]
+    com.acme.PaymentService.charge(PaymentService.java:88) &lt;== monitors:1&gt;
+    com.acme.PaymentService$$Lambda.run(...)
+# Requires restart; output is noisy with no count/rate aggregation.
+
+# Capture a JFR recording and open in JMC
+$ jcmd 12345 JFR.start name=vt duration=60s settings=profile
+$ jcmd 12345 JFR.stop name=vt filename=/tmp/vt.jfr
+$ jmc /tmp/vt.jfr   # Events tab → filter jdk.VirtualThreadPinned
+</code></pre>
+
+                <h4>Argus</h4>
+<pre><code>$ argus threads 12345
+╭─ argus threads ─────────────────────────────────────────────╮
+│ Thread Dump   pid:12345  source:jdk                          │
+│                                                              │
+│ Total: 1,284    Virtual: 1,240    Platform: 44    Peak: 48   │
+│                                                              │
+│ RUNNABLE      ██░░░░░░░░░░░░░░     44  (  3%)   ← carriers  │
+│ WAITING       █████████████░░░  1,228  ( 96%)   ← vt queue  │
+│ TIMED_WAITING ░░░░░░░░░░░░░░░░      8  (  1%)               │
+│ BLOCKED       ░░░░░░░░░░░░░░░░      4  (  0%)               │
+│                                                              │
+│ ⚠ All carrier threads busy — virtual thread scheduler        │
+│   stall likely. Check for pinning events.                    │
+│                                                              │
+╰──────────────────────────────────────────────────────────────╯
+
+$ argus doctor 12345
+╭─ argus doctor ──────────────────────────────────────────────╮
+│ JVM Health Report     pid:12345  HotSpot  uptime:22m         │
+│                                                              │
+│   Heap: 1.1 GB/4.0 GB (28%)  |  CPU: 18%  |  Threads: 1,284  │
+│   GC: 1.2% overhead                                          │
+│ ──────────────────────────────────────────────────────────── │
+│                                                              │
+│   1 critical                                                  │
+│                                                              │
+│   ✘ CRITICAL: Virtual-thread carrier saturation              │
+│     44 carriers all active; 1,228 virtual threads waiting    │
+│     Pinning rate: 312/min (jdk.VirtualThreadPinned)          │
+│     Pinning taxonomy: object-monitor (287), native-frame (25) │
+│     → Replace synchronized blocks with ReentrantLock in      │
+│       pinning hot paths (see Dashboard → Virtual Threads)    │
+│     → Or raise carrier parallelism:                          │
+│       -Djdk.virtualThreadScheduler.parallelism=N             │
+│                                                              │
+╰─ ✘ critical ────────────────────────────────────────────────╯
+</code></pre>
+
+                <p>The dashboard's <strong>Virtual Threads panel</strong> shows the <code>jdk.VirtualThreadPinned</code> event stream with stack traces (identifying the offending <code>synchronized</code> block) and the <code>jdk.VirtualThreadSubmitFailed</code> rate (carrier-pool submission failures, which appear when all carriers are saturated and cannot accept new mounts).</p>
+
+                <p><strong>Fix.</strong> Replace <code>synchronized</code> with <code>java.util.concurrent.locks.ReentrantLock</code> (or <code>ReentrantReadWriteLock</code>) in the pinning hot paths — virtual threads unmount cleanly at <code>lock.lock()</code> whereas <code>synchronized</code> pins the carrier. On JDK 24+ with JEP 491, object-monitor operations no longer pin; updating the runtime eliminates the largest pinning category without code changes.</p>
+
+                <p><strong>Verdict.</strong></p>
+                <div class="table-wrap">
+                    <table>
+                        <thead>
+                            <tr><th>Metric</th><th>Traditional</th><th>Argus</th></tr>
+                        </thead>
+                        <tbody>
+                            <tr><td>Carrier saturation</td><td>⚠️ inferred from <code>jstack</code> + carrier thread names</td><td>✅ <code>threads</code> shows virtual vs. carrier counts + warning</td></tr>
+                            <tr><td>Pinning event rate</td><td>⚠️ JFR + JMC or restart with <code>tracePinnedThreads</code></td><td>✅ <code>doctor</code> surfaces rate + taxonomy inline</td></tr>
+                            <tr><td>Pinning stack traces</td><td>✅ <code>-Djdk.tracePinnedThreads=full</code> (requires restart)</td><td>✅ dashboard Virtual Threads panel (<code>jdk.VirtualThreadPinned</code>)</td></tr>
+                            <tr><td><code>VirtualThreadSubmitFailed</code></td><td>⚠️ JFR + manual event filter</td><td>✅ dashboard Virtual Threads panel</td></tr>
+                        </tbody>
+                    </table>
+                </div>
+
+                <p>Honest gap: Argus surfaces the pinning rate and taxonomy live; confirming the exact line of the offending <code>synchronized</code> block still requires inspecting the stack traces in the dashboard's Virtual Threads panel or in a JFR recording.</p>
+
+                <p><strong>Closing.</strong> Argus collapses roughly ten of these thirteen scenarios into a single command answer (1, 4, 5, 6, 8, 10, 12, 13, plus the JVM-side of 3 and the application-side of 9). The remaining cases — TTSP safepoint logs, OS swap, and FD/socket exhaustion — sit below the JVM boundary, where Argus consciously stops. The intended workflow is to run Argus alongside the host shell, not in place of it.</p>
             </div>
 
         </div><!-- .content-inner -->


### PR DESCRIPTION
## What

A **content** audit + refresh of the documentation site (design/structure unchanged — this is about what the pages *say*). Every page was audited against the actual code/docs via parallel review, and each finding was re-verified against source before editing.

## Factual corrections (verified against source)

| Page | Fix |
|---|---|
| reference.html | Module architecture **7 → 11** (adds `argus-diagnostics`, `argus-aggregator`, `argus-operator`, `argus-instrument`). Config table: `argus.buffer.size`=**65536** (was `argus.buffer-size`=131072), `argus.cpu.interval`=**1000** (was `.interval-ms`=500), `argus.allocation.threshold`=**1048576** (was 524288); **+12 missing knobs** (server.enabled, profiling.interval, contention.threshold, correlation.enabled, otlp.*, metrics.legacyNames, anomaly.mode). |
| integrations.html | Spring YAML defaults fixed (65536/1000/1048576); add `argus.mode`; complete the actuator surface (`argus-doctor`, `argus-gc`, + `mode=full`-only health caveat); `doctor.gc-log-path` requirement; scheduling note; `DoctorService.lastCollectionWarnings()`. |
| dashboard.html | `argus.server.enabled` default is **true** (was documented `false`); +missing config rows; note `jdk.VirtualThreadSubmitFailed`. |
| scenarios.html | S6 used `argus classloader --top` (no such flag) → **`argus classleak`**. |
| commands.html | ZGC `--watch=N` is **iterations**, not seconds. |

## Completeness

- **commands.html**: the "All 71 Commands" reference listed only ~24 — now covers **all 71** across 8 categories, with the newer commands documented (`rightsize`, `instrument`, `explain --llm`, `heapanalyze`, `gcscore`, `profile-gate`, …).
- **index.html**: new capability cards — JVM right-sizing (FinOps), learned anomaly detection, OTel-native semconv metrics, opt-in LLM root-cause; corrected the virtual-thread card (JEP-491 taxonomy, structured-concurrency view, carrier-saturation `argus doctor` rule); broadened "two tools" → CLI/Agent/Spring starter/diagnostics library.
- **comparison.html**: framing broadened beyond GC; `pool jdbc` / `pool advise` surfaced.
- **scenarios.html**: `argus rightsize` added to the OOMKilled scenario, an `argus instrument` confirmation step to lock contention, and a **new scenario 13** (virtual-thread carrier saturation) — a flagship 1.5 capability that previously had no scenario home.

## Honesty / accuracy guards

- Opt-in features (LLM, `instrument`, learned anomaly) are labelled opt-in (honest-value-framing rule).
- A proposed Micrometer "legacyNames" note was **dropped** — that dual-emit lives in `argus-server`, not `argus-micrometer`; adding it would be a false claim.
- Verified: every `argus <cmd>` invocation resolves to a real command (caught + fixed one hallucinated `argus vthread`); `v1.5.0` and `71 commands` consistent across all pages; HTML tag balance OK on all 7 pages; the GitHub Pages assembly reproduces with assets resolving.

🤖 Generated with [Claude Code](https://claude.com/claude-code)