### PR TITLE
docs: align setup docs with release surfaces

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN chmod +x gradlew && ./gradlew :argus-cli:fatJar -x test --no-daemon
 FROM eclipse-temurin:21-jre-alpine
 
 LABEL org.opencontainers.image.title="Argus" \
-      org.opencontainers.image.description="Lightweight JVM Diagnostic Toolkit — 50+ CLI commands" \
+      org.opencontainers.image.description="Lightweight JVM Diagnostic Toolkit — 71 CLI commands" \
       org.opencontainers.image.url="https://github.com/rlaope/Argus" \
       org.opencontainers.image.source="https://github.com/rlaope/Argus"
 

--- a/deploy/sdkman/argus-candidate.json
+++ b/deploy/sdkman/argus-candidate.json
@@ -1,7 +1,7 @@
 {
   "candidate": "argus",
   "name": "Argus JVM Diagnostic Toolkit",
-  "description": "70 CLI commands for JVM diagnostics — health diagnosis, GC analysis, flame graphs, interactive TUI",
+  "description": "71 CLI commands for JVM diagnostics — health diagnosis, GC analysis, flame graphs, interactive TUI",
   "websiteUrl": "https://github.com/rlaope/Argus",
   "distribution": "PLATFORM_SPECIFIC",
   "platform": {

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -4,7 +4,7 @@ This document describes the internal architecture of Project Argus.
 
 ## Overview
 
-Project Argus consists of seven modules that work together to capture, analyze, and visualize JVM metrics.
+Project Argus consists of eleven primary modules that work together to capture, analyze, embed, and visualize JVM diagnostics.
 
 ```
 ┌─────────────────┐    ┌─────────────────┐    ┌─────────────────┐
@@ -31,14 +31,36 @@ Project Argus consists of seven modules that work together to capture, analyze, 
 └──────────────────────────┘    └──────────────────────────────────┘
 ```
 
+Current module inventory:
+
+| Module | Purpose |
+|---|---|
+| `argus-core` | Shared event, config, buffer, command, and model primitives |
+| `argus-agent` | Java agent entry point and JFR streaming runtime |
+| `argus-server` | Netty HTTP/WebSocket API, analysis endpoints, and Prometheus export |
+| `argus-frontend` | Embedded dashboard UI assets |
+| `argus-cli` | Standalone Java 11+ diagnostic CLI |
+| `argus-diagnostics` | Framework-agnostic doctor, GC log, and GC score services |
+| `argus-micrometer` | Micrometer bridge for Argus server metrics |
+| `argus-spring-boot-starter` | Spring Boot auto-configuration, actuator endpoints, and scheduled doctor |
+| `argus-aggregator` | Fleet scrape, alert, profile, and Prometheus aggregation service |
+| `argus-operator` | Kubernetes controller and discovery integration |
+| `argus-instrument` | Opt-in dynamic attach instrumentation agent |
+
+Sample projects under `samples:*` exercise these modules but are intentionally outside the primary module count.
+
 ### Module Dependency Direction (NEVER violate)
 
 ```
-argus-agent → argus-server → argus-core
-                           → argus-frontend
-argus-cli → argus-core (standalone, no server dependency)
-argus-micrometer → argus-core (MeterBinder, no server dependency)
-argus-spring-boot-starter → argus-agent, argus-micrometer
+argus-agent → argus-server
+argus-server → argus-core, argus-cli, argus-frontend
+argus-cli → argus-core, argus-diagnostics (standalone, no server dependency)
+argus-diagnostics → argus-core
+argus-micrometer → argus-server → argus-core
+argus-spring-boot-starter → argus-core, argus-agent, argus-server, argus-micrometer, argus-diagnostics
+argus-aggregator → argus-core
+argus-operator → Kubernetes client APIs (no dependency on runtime modules)
+argus-instrument → ByteBuddy only; loaded on demand, no compile dependency from the CLI/core path
 ```
 
 ## Module Details
@@ -500,12 +522,12 @@ argus-core/command/
 
 Server commands register via `META-INF/services/io.argus.core.command.DiagnosticCommand`. Adding a new server command = 1 class + 1 line.
 
-### Doctor Engine (argus-cli)
+### Doctor Engine (argus-diagnostics, CLI adapters in argus-cli)
 
 Health diagnosis with pluggable rules:
 
 ```
-argus-cli/doctor/
+argus-diagnostics/doctor/
 ├── DoctorEngine.java         — runs all rules, sorts by severity
 ├── JvmSnapshot.java          — immutable snapshot of all JVM metrics
 ├── JvmSnapshotCollector.java — local (MXBean) or remote (jcmd) collection
@@ -513,24 +535,23 @@ argus-cli/doctor/
 ├── Finding.java              — severity + title + recommendations + flags
 ├── Severity.java             — CRITICAL, WARNING, INFO
 └── rules/
-    ├── GcOverheadRule.java        — skips uptime < 60s
-    ├── HeapPressureRule.java      — old gen cross-check
-    ├── ThreadContentionRule.java  — ratio-based (blocked/total %)
-    ├── DirectBufferRule.java      — heap-relative threshold
-    ├── CpuUsageRule.java
-    ├── MetaspaceRule.java
-    ├── FinalizerQueueRule.java
-    └── GcAlgorithmRule.java
+    ├── GC, heap, CPU, thread, direct-buffer, code-cache, and metaspace rules
+    ├── ZGC soft-max and cycle-overlap rules
+    └── G1 full-GC, region-size, IHOP, evacuation, mixed, and humongous rules
 ```
 
-### GC Log Analyzer (argus-cli)
+`argus-cli` owns command/rendering adapters such as `DoctorCommand` and profile-snapshot doctor rules; the reusable engine lives in `argus-diagnostics`.
+
+### GC Log Analyzer (argus-diagnostics, CLI rendering in argus-cli)
 
 ```
-argus-cli/gclog/
+argus-diagnostics/gclog/
 ├── GcLogParser.java    — streaming BufferedReader, G1/ZGC/Shenandoah/Legacy
 ├── GcEvent.java        — double pauseMs (sub-ms precision)
 └── GcLogAnalyzer.java  — percentiles, throughput, 7 tuning rules
 ```
+
+CLI-specific timeline rendering remains under `argus-cli/gclog/`.
 
 ### TUI (argus-cli)
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -50,8 +50,9 @@ curl -fsSL https://raw.githubusercontent.com/rlaope/argus/master/install.sh | ba
 
 ```bash
 # Download JARs from GitHub Releases
-curl -LO https://github.com/rlaope/argus/releases/latest/download/argus-agent-1.5.0.jar
-curl -LO https://github.com/rlaope/argus/releases/latest/download/argus-cli-1.5.0-all.jar
+ARGUS_VERSION=1.5.0
+curl -LO https://github.com/rlaope/argus/releases/download/v${ARGUS_VERSION}/argus-agent.jar
+curl -LO https://github.com/rlaope/argus/releases/download/v${ARGUS_VERSION}/argus-cli-${ARGUS_VERSION}-all.jar
 ```
 
 ### Option 3: Build from Source

--- a/docs/kubernetes.md
+++ b/docs/kubernetes.md
@@ -12,10 +12,12 @@ Add Argus to an existing Kubernetes Deployment in three steps.
 
 ```dockerfile
 FROM eclipse-temurin:21-jre
-COPY argus-cli-all.jar /argus/argus-cli.jar
+COPY argus-agent.jar /argus/argus-agent.jar
 COPY app.jar /app/app.jar
-ENTRYPOINT ["java", "-javaagent:/argus/argus-cli.jar", "-jar", "/app/app.jar"]
+ENTRYPOINT ["java", "-javaagent:/argus/argus-agent.jar", "-jar", "/app/app.jar"]
 ```
+
+Use the `argus-agent.jar` release artifact for `-javaagent`. The CLI fat JAR is for the `argus` command and is not a Java agent.
 
 **Step 2 — Expose the metrics port and add scrape annotations.**
 
@@ -23,11 +25,11 @@ ENTRYPOINT ["java", "-javaagent:/argus/argus-cli.jar", "-jar", "/app/app.jar"]
 metadata:
   annotations:
     argus.io/scrape: "true"
-    argus.io/port: "4040"
+    argus.io/port: "9202"
 spec:
   containers:
     - ports:
-        - containerPort: 4040
+        - containerPort: 9202
           name: argus-metrics
 ```
 
@@ -37,7 +39,7 @@ spec:
 kubectl annotate namespace my-app argus.io/monitored=true
 ```
 
-Prometheus will now scrape `http://<pod-ip>:4040/prometheus` automatically.
+Prometheus will now scrape `http://<pod-ip>:9202/prometheus` automatically.
 
 ---
 
@@ -51,13 +53,13 @@ Bundle the agent directly in your application image. This is the simplest approa
 FROM eclipse-temurin:21-jre
 
 # Copy agent and application
-COPY --from=builder /build/argus-cli-all.jar /argus/argus-cli.jar
-COPY --from=builder /build/app.jar /app/app.jar
+COPY argus-agent.jar /argus/argus-agent.jar
+COPY app.jar /app/app.jar
 
 # Agent starts automatically with the JVM
 ENTRYPOINT ["java", \
-  "-javaagent:/argus/argus-cli.jar", \
-  "-Dargus.server.port=4040", \
+  "-javaagent:/argus/argus-agent.jar", \
+  "-Dargus.server.port=9202", \
   "-jar", "/app/app.jar"]
 ```
 
@@ -68,8 +70,8 @@ Use an init container to inject the agent JAR via a shared volume. This avoids m
 ```yaml
 initContainers:
   - name: argus-init
-    image: ghcr.io/rlaope/argus:1.5.0
-    command: ["cp", "/opt/argus/argus-cli.jar", "/argus-volume/argus-cli.jar"]
+    image: ghcr.io/rlaope/argus-agent:1.5.0
+    command: ["cp", "/opt/argus/argus-agent.jar", "/argus-volume/argus-agent.jar"]
     volumeMounts:
       - name: argus-volume
         mountPath: /argus-volume
@@ -79,7 +81,7 @@ containers:
     image: my-app:latest
     env:
       - name: JAVA_TOOL_OPTIONS
-        value: "-javaagent:/argus/argus-cli.jar"
+        value: "-javaagent:/argus/argus-agent.jar"
     volumeMounts:
       - name: argus-volume
         mountPath: /argus
@@ -160,7 +162,7 @@ Add these annotations to your Pod or Deployment template. Prometheus scrapes any
 metadata:
   annotations:
     argus.io/scrape: "true"       # Enable scraping
-    argus.io/port: "4040"         # Argus metrics port (default: 4040)
+    argus.io/port: "9202"         # Argus metrics port (default: 9202)
     argus.io/path: "/prometheus"  # Metrics path (default: /prometheus)
 ```
 
@@ -183,8 +185,8 @@ spec:
     app: my-app
   ports:
     - name: argus-metrics
-      port: 4040
-      targetPort: 4040
+      port: 9202
+      targetPort: 9202
 ```
 
 Then create the `ServiceMonitor`:
@@ -225,7 +227,7 @@ helm install argus argus/argus \
 # Install with custom values
 helm install argus argus/argus \
   --namespace monitoring \
-  --set agent.port=4040 \
+  --set agent.port=9202 \
   --set prometheus.serviceMonitor.enabled=true \
   --set grafana.dashboards.enabled=true
 ```
@@ -234,7 +236,7 @@ Key chart values:
 
 | Value | Default | Description |
 |---|---|---|
-| `agent.port` | `4040` | Argus metrics server port |
+| `agent.port` | `9202` | Argus metrics server port |
 | `agent.jvmArgs` | `""` | Additional JVM arguments |
 | `prometheus.serviceMonitor.enabled` | `false` | Create a ServiceMonitor |
 | `grafana.dashboards.enabled` | `false` | Auto-provision Grafana dashboard |
@@ -281,7 +283,7 @@ spec:
         app: my-app
       annotations:
         argus.io/scrape: "true"
-        argus.io/port: "4040"
+        argus.io/port: "9202"
     spec:
       containers:
         - name: my-app
@@ -289,11 +291,11 @@ spec:
           ports:
             - containerPort: 8080
               name: http
-            - containerPort: 4040
+            - containerPort: 9202
               name: argus-metrics
           env:
             - name: JAVA_TOOL_OPTIONS
-              value: "-javaagent:/argus/argus-cli.jar -Dargus.server.port=4040"
+              value: "-javaagent:/argus/argus-agent.jar -Dargus.server.port=9202"
             # Downward API: exposes K8s identity to Argus for metric labels
             - name: ARGUS_POD_NAME
               valueFrom:
@@ -310,7 +312,7 @@ spec:
           readinessProbe:
             httpGet:
               path: /argus/health
-              port: 4040
+              port: 9202
             initialDelaySeconds: 10
             periodSeconds: 15
           volumeMounts:
@@ -318,8 +320,8 @@ spec:
               mountPath: /argus
       initContainers:
         - name: argus-init
-          image: ghcr.io/rlaope/argus:1.5.0
-          command: ["cp", "/opt/argus/argus-cli.jar", "/argus-volume/argus-cli.jar"]
+          image: ghcr.io/rlaope/argus-agent:1.5.0
+          command: ["cp", "/opt/argus/argus-agent.jar", "/argus-volume/argus-agent.jar"]
           volumeMounts:
             - name: argus-volume
               mountPath: /argus-volume
@@ -407,12 +409,12 @@ roleRef:
 
 ### Argus metrics port not reachable
 
-**Symptom:** `curl http://<pod-ip>:4040/prometheus` times out or is refused.
+**Symptom:** `curl http://<pod-ip>:9202/prometheus` times out or is refused.
 
 **Causes and fixes:**
-- The agent is not loaded. Verify `JAVA_TOOL_OPTIONS` or `-javaagent` is set and the JAR path is correct. Check pod logs for `Argus agent started`.
-- The port is not declared in the container spec. Add `containerPort: 4040` to the container ports list.
-- A network policy is blocking the port. Add an ingress rule allowing traffic on port 4040 from the Prometheus namespace.
+- The agent is not loaded. Verify `JAVA_TOOL_OPTIONS` or `-javaagent` points at `argus-agent.jar`. Check pod logs for `Argus agent started`.
+- The port is not declared in the container spec. Add `containerPort: 9202` to the container ports list.
+- A network policy is blocking the port. Add an ingress rule allowing traffic on port 9202 from the Prometheus namespace.
 
 ### JFR not available — metrics are empty
 
@@ -424,7 +426,7 @@ roleRef:
 
 ### Bind address conflict
 
-**Symptom:** `Address already in use: 0.0.0.0:4040` in pod logs.
+**Symptom:** `Address already in use: 0.0.0.0:9202` in pod logs.
 
 **Fix:** Change the port with `-Dargus.server.port=<free-port>` and update the pod annotations and `containerPort` accordingly.
 


### PR DESCRIPTION
## Summary
- Replace Kubernetes CLI-as-javaagent examples with the real `argus-agent.jar` artifact and `ghcr.io/rlaope/argus-agent` image.
- Align Kubernetes scrape/service examples on the actual 9202 agent/server default.
- Refresh public release metadata: 71 command count in Docker/SDKMAN, 11-module architecture inventory, dependency edges, diagnostics ownership, and versioned manual download URLs.

## Verification
- `git diff --check`
- `./gradlew :argus-cli:test --quiet`
- `./gradlew :argus-agent:jar :argus-cli:fatJar --quiet`
- Drift scans for command-count claims, stale Kubernetes CLI-agent references, 4040 port drift, and stale architecture ownership.

## Review
- code-reviewer: APPROVE after recheck; no remaining CRITICAL/HIGH/MEDIUM/LOW findings.
- architect: CLEAR. Confirmed command count, artifact names, module/dependency graph, and 9202 default match code/release evidence.

## Known risks
- Did not run a live Kubernetes deployment.
- Did not download artifacts from an actual GitHub Release during this pass.