### PR TITLE
fix: bound diagnostic subprocess timeout behavior

### DIFF
--- a/argus-cli/src/main/java/io/argus/cli/provider/jdk/AsProfExecutor.java
+++ b/argus-cli/src/main/java/io/argus/cli/provider/jdk/AsProfExecutor.java
@@ -105,24 +105,31 @@ public final class AsProfExecutor {
         stderrThread.setName("asprof-stderr");
         stderrThread.start();
 
-        // Progress loop: runs on calling thread until process exits or timeout
-        long startMs = System.currentTimeMillis();
+        // Progress loop: runs on calling thread until process exits or timeout.
+        long timeoutNanos = timeoutSeconds <= 0 ? 0L : TimeUnit.SECONDS.toNanos(timeoutSeconds);
+        long startNanos = System.nanoTime();
+        boolean interrupted = false;
         while (process.isAlive()) {
-            int elapsedSeconds = (int) ((System.currentTimeMillis() - startMs) / 1000L);
-            if (elapsedSeconds >= timeoutSeconds) {
+            long elapsedNanos = System.nanoTime() - startNanos;
+            long remainingNanos = timeoutNanos - elapsedNanos;
+            if (remainingNanos <= 0L) {
                 break;
             }
             if (callback != null) {
                 try {
+                    int elapsedSeconds = (int) Math.min(
+                            Integer.MAX_VALUE,
+                            TimeUnit.NANOSECONDS.toSeconds(elapsedNanos));
                     callback.onProgress(elapsedSeconds, timeoutSeconds);
                 } catch (Exception ignored) {
                     // never let a callback kill the executor
                 }
             }
             try {
-                Thread.sleep(1000);
+                TimeUnit.NANOSECONDS.sleep(Math.min(TimeUnit.SECONDS.toNanos(1), remainingNanos));
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
+                interrupted = true;
                 break;
             }
         }
@@ -130,7 +137,15 @@ public final class AsProfExecutor {
         // Wait for process to finish within remaining timeout
         boolean finished;
         try {
-            finished = process.waitFor(timeoutSeconds, TimeUnit.SECONDS);
+            if (!process.isAlive()) {
+                finished = true;
+            } else if (interrupted) {
+                finished = false;
+            } else {
+                long elapsedNanos = System.nanoTime() - startNanos;
+                long remainingNanos = timeoutNanos - elapsedNanos;
+                finished = remainingNanos > 0L && process.waitFor(remainingNanos, TimeUnit.NANOSECONDS);
+            }
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
             finished = false;
@@ -138,6 +153,11 @@ public final class AsProfExecutor {
 
         if (!finished) {
             process.destroyForcibly();
+            try {
+                process.waitFor(2, TimeUnit.SECONDS);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
         }
 
         // Join I/O threads so their buffers are fully populated

--- a/argus-cli/src/test/java/io/argus/cli/provider/jdk/AsProfExecutorTest.java
+++ b/argus-cli/src/test/java/io/argus/cli/provider/jdk/AsProfExecutorTest.java
@@ -1,0 +1,54 @@
+package io.argus.cli.provider.jdk;
+
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Path;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class AsProfExecutorTest {
+
+    @Test
+    void capturesFastCommandOutput() {
+        AsProfExecutor.Result result = AsProfExecutor.execute(
+                new String[]{javaExecutable(), "-version"},
+                5,
+                null);
+
+        assertEquals(0, result.exitCode());
+        assertTrue((result.stdout() + result.stderr()).contains("version"));
+    }
+
+    @Test
+    void timeoutDoesNotWaitForTheFullBudgetTwice() {
+        long startNanos = System.nanoTime();
+
+        AsProfExecutor.Result result = AsProfExecutor.execute(
+                new String[]{
+                        javaExecutable(),
+                        "-cp",
+                        System.getProperty("java.class.path"),
+                        Sleeper.class.getName(),
+                        "8000"
+                },
+                2,
+                null);
+
+        long elapsedMillis = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startNanos);
+        assertTrue(elapsedMillis < 3000,
+                "expected timeout near 2s, but executor returned after " + elapsedMillis + "ms");
+        assertNotEquals(0, result.exitCode());
+    }
+
+    private static String javaExecutable() {
+        boolean windows = System.getProperty("os.name").toLowerCase().contains("win");
+        return Path.of(System.getProperty("java.home"), "bin", windows ? "java.exe" : "java").toString();
+    }
+
+    public static final class Sleeper {
+        public static void main(String[] args) throws Exception {
+            Thread.sleep(Long.parseLong(args[0]));
+        }
+    }
+}

--- a/argus-server/src/main/java/io/argus/server/command/impl/CompilerQueueDiagnosticCommand.java
+++ b/argus-server/src/main/java/io/argus/server/command/impl/CompilerQueueDiagnosticCommand.java
@@ -14,12 +14,10 @@ public final class CompilerQueueDiagnosticCommand implements DiagnosticCommand {
     @Override
     public String execute(CommandContext ctx) {
         try {
-            long pid = ((CommandContext.InProcess) ctx).pid();
-            ProcessBuilder pb = new ProcessBuilder("jcmd", String.valueOf(pid), "Compiler.queue");
-            pb.redirectErrorStream(true);
-            Process proc = pb.start();
-            String output = new String(proc.getInputStream().readAllBytes());
-            proc.waitFor();
+            String output = DiagnosticUtil.executeJcmd(
+                    ((CommandContext.InProcess) ctx).pid(),
+                    "Compiler.queue",
+                    null);
             return output.isBlank() ? "Compilation queue is empty" : output;
         } catch (Exception e) {
             return "Error: " + e.getMessage();

--- a/argus-server/src/main/java/io/argus/server/command/impl/DiagnosticUtil.java
+++ b/argus-server/src/main/java/io/argus/server/command/impl/DiagnosticUtil.java
@@ -1,6 +1,12 @@
 package io.argus.server.command.impl;
 
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 
 /**
  * Shared utility methods for diagnostic command implementations.
@@ -59,23 +65,53 @@ public final class DiagnosticUtil {
     }
 
     public static String executeJcmd(String command, String arg) {
+        return executeJcmd(ProcessHandle.current().pid(), command, arg);
+    }
+
+    static String executeJcmd(long pid, String command, String arg) {
         try {
-            long pid = ProcessHandle.current().pid();
             String jcmd = System.getProperty("java.home") + "/bin/jcmd";
-            var cmdList = new java.util.ArrayList<>(java.util.List.of(jcmd, String.valueOf(pid), command));
+            var cmdList = new ArrayList<>(List.of(jcmd, String.valueOf(pid), command));
             if (arg != null && !arg.isBlank()) cmdList.add(arg);
-            ProcessBuilder pb = new ProcessBuilder(cmdList);
-            pb.redirectErrorStream(true);
-            Process proc = pb.start();
-            String output = new String(proc.getInputStream().readAllBytes());
-            boolean finished = proc.waitFor(10, java.util.concurrent.TimeUnit.SECONDS);
-            if (!finished) {
-                proc.destroyForcibly();
-                return "Command timed out after 10 seconds: jcmd " + command;
-            }
-            return output;
+            return executeProcess(cmdList, 10, "Command timed out after 10 seconds: jcmd " + command);
         } catch (Exception e) {
             return "Failed to execute jcmd " + command + ": " + e.getMessage();
+        }
+    }
+
+    static String executeProcess(List<String> command, long timeoutSeconds, String timeoutMessage)
+            throws InterruptedException, IOException {
+        List<String> outputLines = new ArrayList<>();
+        ProcessBuilder pb = new ProcessBuilder(command);
+        pb.redirectErrorStream(true);
+        Process proc = pb.start();
+
+        Thread outputThread = new Thread(() -> {
+            try (BufferedReader reader = new BufferedReader(new InputStreamReader(proc.getInputStream()))) {
+                String line;
+                while ((line = reader.readLine()) != null) {
+                    synchronized (outputLines) {
+                        outputLines.add(line);
+                    }
+                }
+            } catch (Exception ignored) {
+                // Process termination closes the stream; the timeout path handles the result.
+            }
+        }, "argus-diagnostic-output");
+        outputThread.setDaemon(true);
+        outputThread.start();
+
+        boolean finished = proc.waitFor(timeoutSeconds, TimeUnit.SECONDS);
+        if (!finished) {
+            proc.destroyForcibly();
+            proc.waitFor(2, TimeUnit.SECONDS);
+            outputThread.join(2000);
+            return timeoutMessage;
+        }
+
+        outputThread.join(2000);
+        synchronized (outputLines) {
+            return String.join("\n", outputLines);
         }
     }
 

--- a/argus-server/src/test/java/io/argus/server/command/impl/DiagnosticUtilTest.java
+++ b/argus-server/src/test/java/io/argus/server/command/impl/DiagnosticUtilTest.java
@@ -2,6 +2,10 @@ package io.argus.server.command.impl;
 
 import org.junit.jupiter.api.Test;
 
+import java.nio.file.Path;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -96,5 +100,36 @@ class DiagnosticUtilTest {
         // Values too short to slice are replaced wholesale.
         assertEquals("****", mask("PASSWORD", "abc"));
         assertEquals("****", mask("PASSWORD", ""));
+    }
+
+    @Test
+    void executeProcessTimesOutEvenWhenChildProducesNoOutput() throws Exception {
+        long startNanos = System.nanoTime();
+
+        String result = DiagnosticUtil.executeProcess(
+                List.of(
+                        javaExecutable(),
+                        "-cp",
+                        System.getProperty("java.class.path"),
+                        Sleeper.class.getName(),
+                        "5000"),
+                1,
+                "timed out");
+
+        long elapsedMillis = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startNanos);
+        assertEquals("timed out", result);
+        assertTrue(elapsedMillis < 2500,
+                "expected timeout near 1s, but diagnostic process returned after " + elapsedMillis + "ms");
+    }
+
+    private static String javaExecutable() {
+        boolean windows = System.getProperty("os.name").toLowerCase().contains("win");
+        return Path.of(System.getProperty("java.home"), "bin", windows ? "java.exe" : "java").toString();
+    }
+
+    public static final class Sleeper {
+        public static void main(String[] args) throws Exception {
+            Thread.sleep(Long.parseLong(args[0]));
+        }
     }
 }


### PR DESCRIPTION
## Summary
- Bound `AsProfExecutor` to a single timeout budget using `System.nanoTime()` and remaining-time waits.
- Drain jcmd diagnostic subprocess output on a daemon reader thread so no-output children cannot bypass the 10s timeout.
- Route `compilerqueue` through the shared jcmd timeout path while preserving its in-process pid and error-return behavior.

## Performance/Reliability Impact
- Prevents async-profiler CLI captures from waiting nearly 2x the configured timeout when the child process outlives the progress loop.
- Prevents web-console/server jcmd diagnostics from hanging on `readAllBytes()` before timeout enforcement.
- Adds regression guards that fail on the old timeout-overrun/no-output-child patterns.

## Validation
- `./gradlew :argus-cli:test --tests io.argus.cli.provider.jdk.AsProfExecutorTest --quiet`
- `./gradlew :argus-server:test --tests io.argus.server.command.impl.DiagnosticUtilTest --tests io.argus.server.command.ServerCommandExecutorTest --quiet`
- `./gradlew :argus-cli:test :argus-diagnostics:test :argus-server:test :argus-agent:test :argus-aggregator:test :argus-spring-boot-starter:test :argus-instrument:test :argus-cli:fatJar --quiet`

## Notes
- Work was done in clean worktree `/Users/rlaope/Desktop/khope/Argus-performance-clean`; the original worktree has pre-existing untracked duplicate Java files that block Gradle baseline evaluation there.