### PR TITLE
feat: make JVM dashboards incident-drilldown ready

### DIFF
--- a/argus-frontend/src/main/resources/public/console.html
+++ b/argus-frontend/src/main/resources/public/console.html
@@ -8,6 +8,7 @@
     <link rel="stylesheet" href="/css/theme.css">
     <script src="/js/theme-preboot.js"></script>
     <script src="/js/theme.js"></script>
+    <script src="/js/pod-context.js"></script>
 </head>
 <body>
 
@@ -99,7 +100,7 @@
         let clusterMode = false;
         let selectedPodId = null;
 
-        const POD_STORAGE_KEY = 'argus.console.pod';
+        const podContext = window.ArgusPodContext;
 
         async function detectClusterMode() {
             try {
@@ -130,16 +131,8 @@
                 return;
             }
 
-            // Group by deployment (fallback: namespace) so large fleets stay readable.
-            const byGroup = {};
-            pods.forEach(p => {
-                const key = p.deployment || p.namespace || 'other';
-                (byGroup[key] = byGroup[key] || []).push(p);
-            });
-
-            const stored = readStoredPod();
-            const knownIds = new Set(pods.map(p => p.podId));
-            const initial = (stored && knownIds.has(stored)) ? stored : pods[0].podId;
+            const byGroup = podContext.groupPods(pods);
+            const initial = podContext.selectInitialPod(pods);
 
             Object.keys(byGroup).sort().forEach(group => {
                 const og = document.createElement('optgroup');
@@ -156,23 +149,15 @@
             });
 
             selectedPodId = initial;
-            writeStoredPod(initial);
+            podContext.writeStoredPod(initial);
 
             select.addEventListener('change', async () => {
                 selectedPodId = select.value;
-                writeStoredPod(selectedPodId);
+                podContext.writeStoredPod(selectedPodId);
+                podContext.writePodParam(selectedPodId);
                 await loadCommands();
                 updateTerminalTitle();
             });
-        }
-
-        function readStoredPod() {
-            try { return window.localStorage.getItem(POD_STORAGE_KEY); }
-            catch (e) { return null; }
-        }
-        function writeStoredPod(podId) {
-            try { window.localStorage.setItem(POD_STORAGE_KEY, podId); }
-            catch (e) { /* localStorage disabled — selection just doesn't persist */ }
         }
 
         function commandsEndpoint() {

--- a/argus-frontend/src/main/resources/public/css/fleet.css
+++ b/argus-frontend/src/main/resources/public/css/fleet.css
@@ -566,6 +566,35 @@
     padding: 0.25rem 0;
 }
 
+.fleet-panel-reasons {
+    display: flex;
+    flex-direction: column;
+    gap: 0.4rem;
+}
+
+.fleet-panel-reason {
+    border-left: 3px solid var(--border);
+    background: var(--off-white);
+    border-radius: 0 3px 3px 0;
+    padding: 0.5rem 0.75rem;
+}
+
+.fleet-panel-reason--critical { border-left-color: var(--red); }
+.fleet-panel-reason--warning  { border-left-color: var(--amber); }
+.fleet-panel-reason--info     { border-left-color: var(--blue); }
+
+.fleet-panel-reason-title {
+    font-size: 0.8125rem;
+    font-weight: 700;
+    color: var(--ink);
+}
+
+.fleet-panel-reason-detail {
+    font-size: 0.75rem;
+    color: var(--ink-3);
+    line-height: 1.4;
+}
+
 /* Scrape info table */
 .fleet-panel-scrape-info {
     display: flex;
@@ -609,6 +638,29 @@
 .fleet-panel-drill-btn {
     width: 100%;
     justify-content: center;
+}
+
+.fleet-panel-link-grid {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 0.375rem;
+    margin-top: 0.5rem;
+}
+
+.fleet-panel-link {
+    border: 1px solid var(--border);
+    border-radius: 3px;
+    color: var(--ink-2);
+    font-size: 0.75rem;
+    padding: 0.35rem 0.4rem;
+    text-align: center;
+    text-decoration: none;
+    white-space: nowrap;
+}
+
+.fleet-panel-link:hover {
+    border-color: var(--ink-3);
+    color: var(--ink);
 }
 
 /* ----------------------------------------------------------------

--- a/argus-frontend/src/main/resources/public/css/style.css
+++ b/argus-frontend/src/main/resources/public/css/style.css
@@ -271,6 +271,61 @@ main {
 }
 
 /* ----------------------------------------------------------------
+   DASHBOARD MODE STRIP
+---------------------------------------------------------------- */
+.dashboard-mode-strip {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+    padding: 0.625rem 0;
+    border-bottom: 1px solid var(--border-light);
+    margin-bottom: 0.75rem;
+}
+
+.dashboard-mode-copy {
+    display: flex;
+    align-items: baseline;
+    gap: 0.75rem;
+    min-width: 0;
+}
+
+.dashboard-mode-title {
+    font-size: 0.6875rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.07em;
+    color: var(--ink-3);
+    white-space: nowrap;
+}
+
+.dashboard-mode-detail {
+    font-family: var(--font-mono);
+    font-size: 0.8125rem;
+    color: var(--ink);
+    overflow-wrap: anywhere;
+}
+
+.dashboard-mode-links {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    flex-wrap: wrap;
+    flex-shrink: 0;
+}
+
+.dashboard-mode-links a {
+    color: var(--blue);
+    font-size: 0.8125rem;
+    text-decoration: none;
+    border-bottom: 1px solid rgba(21,101,192,0.28);
+}
+
+.dashboard-mode-links a:hover {
+    border-bottom-color: var(--blue);
+}
+
+/* ----------------------------------------------------------------
    FEATURE FLAGS
 ---------------------------------------------------------------- */
 #feature-flags {
@@ -419,6 +474,76 @@ main {
     font-weight: 600;
     font-family: var(--font-mono);
     font-size: 0.875rem;
+}
+
+/* ----------------------------------------------------------------
+   INCIDENT SYNOPSIS
+---------------------------------------------------------------- */
+.incident-synopsis-section {
+    --incident-gap: 0.75rem;
+}
+
+.incident-synopsis-list {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(230px, 1fr));
+    gap: var(--incident-gap);
+}
+
+.incident-card {
+    border-left: 3px solid var(--border);
+    background: var(--off-white);
+    border-radius: 0 4px 4px 0;
+    padding: 0.875rem 1rem;
+    min-height: 8.5rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.4rem;
+}
+
+.incident-card--critical { border-left-color: var(--red); }
+.incident-card--warning  { border-left-color: var(--amber); }
+.incident-card--info     { border-left-color: var(--blue); }
+.incident-card--ok       { border-left-color: var(--green); }
+
+.incident-card-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.75rem;
+}
+
+.incident-card-title {
+    font-size: 0.8125rem;
+    font-weight: 700;
+    color: var(--ink);
+}
+
+.incident-card-severity {
+    font-size: 0.625rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--ink-3);
+    white-space: nowrap;
+}
+
+.incident-card-metric {
+    font-family: var(--font-mono);
+    font-size: 1.0625rem;
+    font-weight: 700;
+    color: var(--ink);
+}
+
+.incident-card-body {
+    font-size: 0.8125rem;
+    color: var(--ink-2);
+    line-height: 1.45;
+}
+
+.incident-card-action {
+    margin-top: auto;
+    font-size: 0.75rem;
+    color: var(--ink-3);
 }
 
 /* ----------------------------------------------------------------
@@ -1345,6 +1470,15 @@ footer {
     .summary-value {
         font-size: 1.25rem;
     }
+    .dashboard-mode-strip {
+        align-items: flex-start;
+        flex-direction: column;
+    }
+    .dashboard-mode-copy {
+        align-items: flex-start;
+        flex-direction: column;
+        gap: 0.25rem;
+    }
     .filter-row {
         flex-direction: column;
         gap: 0.875rem;
@@ -1929,4 +2063,3 @@ canvas {
 .jfr-status--recording { color: var(--red);   background: rgba(198,40,40,0.07); }
 .jfr-status--available { color: var(--green); background: rgba(46,125,50,0.07); }
 .jfr-status--error     { color: var(--amber); }
-

--- a/argus-frontend/src/main/resources/public/fleet.html
+++ b/argus-frontend/src/main/resources/public/fleet.html
@@ -22,6 +22,7 @@
     </style>
     <script src="/js/theme-preboot.js"></script>
     <script src="/js/theme.js"></script>
+    <script src="/js/pod-context.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.min.js"></script>
 </head>
 <body>
@@ -200,6 +201,14 @@
                     </div>
                 </div>
 
+                <!-- Status drivers -->
+                <div class="fleet-panel-section">
+                    <h3 class="fleet-panel-section-title">Top Reasons</h3>
+                    <div id="panel-reasons" class="fleet-panel-reasons">
+                        <div class="fleet-panel-empty">No threshold drivers</div>
+                    </div>
+                </div>
+
                 <!-- Scrape info -->
                 <div class="fleet-panel-section">
                     <h3 class="fleet-panel-section-title">Scrape Info</h3>
@@ -224,6 +233,11 @@
                     <a id="panel-drill-link" href="#" class="btn btn-primary fleet-panel-drill-btn">
                         Open JVM Dashboard
                     </a>
+                    <div class="fleet-panel-link-grid">
+                        <a id="panel-profiles-cpu-link" href="/profiles.html?event=cpu&range=3600" class="fleet-panel-link">CPU Profile</a>
+                        <a id="panel-profiles-alloc-link" href="/profiles.html?event=alloc&range=3600" class="fleet-panel-link">Alloc Profile</a>
+                        <a id="panel-console-link" href="/console.html" class="fleet-panel-link">Console</a>
+                    </div>
                 </div>
 
             </div>

--- a/argus-frontend/src/main/resources/public/index.html
+++ b/argus-frontend/src/main/resources/public/index.html
@@ -12,6 +12,7 @@
     <link rel="stylesheet" href="/css/theme.css">
     <script src="/js/theme-preboot.js"></script>
     <script src="/js/theme.js"></script>
+    <script src="/js/pod-context.js"></script>
     <script src="/js/dashboard-cluster.js" defer></script>
 </head>
 <body>
@@ -98,6 +99,18 @@
             </div>
         </div>
 
+        <div id="dashboard-mode-strip" class="dashboard-mode-strip" role="status" aria-live="polite">
+            <div class="dashboard-mode-copy">
+                <span id="dashboard-mode-title" class="dashboard-mode-title">Live stream</span>
+                <span id="dashboard-mode-detail" class="dashboard-mode-detail">Connecting...</span>
+            </div>
+            <div class="dashboard-mode-links">
+                <a id="dashboard-mode-fleet-link" href="/fleet.html">Fleet</a>
+                <a id="dashboard-mode-profiles-link" href="/profiles.html">Profiles</a>
+                <a id="dashboard-mode-console-link" href="/console.html">Console</a>
+            </div>
+        </div>
+
         <!-- Feature Flags -->
         <div id="feature-flags" class="feature-flags">
             <span class="feature-flags-label">Features:</span>
@@ -122,6 +135,19 @@
             <div class="page-section-heading">
                 <h2>JVM Health</h2>
             </div>
+
+            <section class="content-section incident-synopsis-section">
+                <div class="section-header">
+                    <h3>Incident Synopsis</h3>
+                    <div class="section-header-right stats-row">
+                        <span class="stat-inline">Mode: <strong id="incident-mode">—</strong></span>
+                        <span class="stat-inline">Pod: <strong id="incident-pod">—</strong></span>
+                    </div>
+                </div>
+                <div id="incident-synopsis-list" class="incident-synopsis-list">
+                    <div class="empty-state">Waiting for JVM signals...</div>
+                </div>
+            </section>
 
             <!-- Memory & GC -->
             <section class="content-section">

--- a/argus-frontend/src/main/resources/public/js/app.js
+++ b/argus-frontend/src/main/resources/public/js/app.js
@@ -160,6 +160,9 @@ const elements = {
     // Recommendations
     recommendationsList: document.getElementById('recommendations-list'),
     refreshRecommendationsBtn: document.getElementById('refresh-recommendations'),
+    incidentMode: document.getElementById('incident-mode'),
+    incidentPod: document.getElementById('incident-pod'),
+    incidentSynopsisList: document.getElementById('incident-synopsis-list'),
 
     // Flame graph
     flamegraphContainer: document.getElementById('flamegraph-container'),
@@ -182,6 +185,16 @@ const elements = {
 };
 
 const maxEvents = 500;
+const latestSignals = {
+    metrics: null,
+    gc: null,
+    cpu: null,
+    allocation: null,
+    metaspace: null,
+    profiling: null,
+    contention: null,
+    pinning: null
+};
 
 // Initialize modules
 function init() {
@@ -457,7 +470,9 @@ async function fetchMetrics() {
             counts.PINNED = data.pinnedEvents || 0;
             counts.SUBMIT_FAILED = data.submitFailedEvents || 0;
             counts.active = data.activeThreads || 0;
+            latestSignals.metrics = data;
             updateCounters();
+            updateIncidentSynopsis();
         }
     } catch (e) {
         console.error('[Argus] Failed to fetch metrics:', e);
@@ -469,7 +484,9 @@ async function fetchPinningAnalysis() {
         const response = await f('/pinning-analysis');
         if (response.ok) {
             const data = await response.json();
+            latestSignals.pinning = data;
             renderHotspots(data);
+            updateIncidentSynopsis();
         }
     } catch (e) {
         console.error('[Argus] Failed to fetch pinning analysis:', e);
@@ -481,9 +498,11 @@ async function fetchGCAnalysis() {
         const response = await f('/gc-analysis');
         if (response.ok) {
             const data = await response.json();
+            latestSignals.gc = data;
             updateGCDisplay(data);
             updateGCCharts(data);
             updateGCTimeline(data);
+            updateIncidentSynopsis();
         }
     } catch (e) {
         console.error('[Argus] Failed to fetch GC analysis:', e);
@@ -495,8 +514,10 @@ async function fetchCPUMetrics() {
         const response = await f('/cpu-metrics');
         if (response.ok) {
             const data = await response.json();
+            latestSignals.cpu = data;
             updateCPUDisplay(data);
             updateCPUCharts(data);
+            updateIncidentSynopsis();
         }
     } catch (e) {
         console.error('[Argus] Failed to fetch CPU metrics:', e);
@@ -807,8 +828,10 @@ async function fetchAllocationAnalysis() {
         if (response.ok) {
             const data = await response.json();
             if (!data.error) {
+                latestSignals.allocation = data;
                 updateAllocationDisplay(data);
                 updateAllocationCharts(data);
+                updateIncidentSynopsis();
             }
         }
     } catch (e) {
@@ -822,8 +845,10 @@ async function fetchMetaspaceMetrics() {
         if (response.ok) {
             const data = await response.json();
             if (!data.error) {
+                latestSignals.metaspace = data;
                 updateMetaspaceDisplay(data);
                 updateMetaspaceCharts(data);
+                updateIncidentSynopsis();
             }
         }
     } catch (e) {
@@ -837,8 +862,10 @@ async function fetchMethodProfiling() {
         if (response.ok) {
             const data = await response.json();
             if (!data.error) {
+                latestSignals.profiling = data;
                 updateProfilingDisplay(data);
                 updateProfilingCharts(data);
+                updateIncidentSynopsis();
             }
         }
     } catch (e) {
@@ -852,8 +879,10 @@ async function fetchContentionAnalysis() {
         if (response.ok) {
             const data = await response.json();
             if (!data.error) {
+                latestSignals.contention = data;
                 updateContentionDisplay(data);
                 updateContentionCharts(data);
+                updateIncidentSynopsis();
             }
         }
     } catch (e) {
@@ -1047,6 +1076,120 @@ function updateRecommendations(data) {
             </div>
         `;
     }).join('');
+}
+
+function updateIncidentSynopsis() {
+    if (!elements.incidentSynopsisList) return;
+    const cluster = window.__argusCluster;
+    const podInfo = cluster?.selectedPodInfo?.() || null;
+    const selectedPod = cluster?.selectedPod?.() || null;
+    const mode = cluster?.isClusterMode?.() ? 'Snapshot' : 'Live';
+
+    if (elements.incidentMode) {
+        elements.incidentMode.textContent = mode;
+    }
+    if (elements.incidentPod) {
+        elements.incidentPod.textContent = selectedPod || 'local';
+    }
+
+    const insights = buildIncidentInsights(podInfo);
+    if (insights.length === 0) {
+        elements.incidentSynopsisList.innerHTML =
+            '<div class="incident-card incident-card--ok">' +
+            '<div class="incident-card-header"><span class="incident-card-title">No active pressure</span>' +
+            '<span class="incident-card-severity">OK</span></div>' +
+            '<div class="incident-card-metric">steady</div>' +
+            '<div class="incident-card-body">Current signals are under the dashboard thresholds.</div>' +
+            '<div class="incident-card-action">Continue watching Fleet and local charts.</div>' +
+            '</div>';
+        return;
+    }
+
+    elements.incidentSynopsisList.innerHTML = insights.slice(0, 5).map(card => {
+        return '<div class="incident-card incident-card--' + card.severity + '">' +
+            '<div class="incident-card-header"><span class="incident-card-title">' + escapeHtml(card.title) + '</span>' +
+            '<span class="incident-card-severity">' + escapeHtml(card.severity) + '</span></div>' +
+            '<div class="incident-card-metric">' + escapeHtml(card.metric) + '</div>' +
+            '<div class="incident-card-body">' + escapeHtml(card.body) + '</div>' +
+            '<div class="incident-card-action">' + escapeHtml(card.action) + '</div>' +
+            '</div>';
+    }).join('');
+}
+
+function buildIncidentInsights(podInfo) {
+    const cards = [];
+    if (podInfo && podInfo.scrapeOk === false) {
+        cards.push({
+            severity: 'critical',
+            rank: 100,
+            title: 'Scrape failed',
+            metric: podInfo.lastError || 'offline',
+            body: 'Aggregator cannot refresh the selected pod snapshot.',
+            action: 'Open Fleet or Console for pod reachability checks.'
+        });
+    }
+
+    const gc = latestSignals.gc || {};
+    const cpu = latestSignals.cpu || {};
+    const allocation = latestSignals.allocation || {};
+    const contention = latestSignals.contention || {};
+    const pinning = latestSignals.pinning || {};
+
+    const heapCommitted = Number(gc.currentHeapCommitted) || 0;
+    const heapUsed = Number(gc.currentHeapUsed) || 0;
+    const heapPct = heapCommitted > 0 ? heapUsed / heapCommitted * 100 : 0;
+    if (heapPct >= 90) {
+        cards.push(card('critical', 92, 'Heap saturation', heapPct.toFixed(1) + '%', 'Heap used is above the critical threshold.', 'Open GC and heap charts, then compare allocation sources.'));
+    } else if (heapPct >= 80) {
+        cards.push(card('warning', 72, 'Heap pressure', heapPct.toFixed(1) + '%', 'Heap used is nearing the warning threshold.', 'Watch GC overhead and allocation rate.'));
+    }
+
+    const overhead = Number(gc.gcOverheadPercent) || 0;
+    if (overhead >= 10 || gc.isOverheadWarning) {
+        cards.push(card('critical', 90, 'GC overhead', overhead.toFixed(1) + '%', 'GC time is above the incident budget.', 'Check pause timeline and collector breakdown.'));
+    } else if (overhead >= 5) {
+        cards.push(card('warning', 70, 'GC overhead rising', overhead.toFixed(1) + '%', 'GC time is consuming noticeable runtime.', 'Compare heap growth and promotion rate.'));
+    }
+
+    const maxPause = Number(gc.maxPauseTimeMs) || 0;
+    if (maxPause >= 1000) {
+        cards.push(card('critical', 86, 'Long GC pause', maxPause.toFixed(0) + 'ms', 'A recent pause exceeded one second.', 'Inspect pause timeline and recent GC causes.'));
+    } else if (maxPause >= 200) {
+        cards.push(card('warning', 62, 'GC pause spike', maxPause.toFixed(0) + 'ms', 'A recent pause crossed the warning threshold.', 'Check if the spike aligns with allocation bursts.'));
+    }
+
+    const pinnedStacks = Number(pinning.uniqueStackTraces) || 0;
+    const pinnedEvents = Number(pinning.totalPinnedEvents) || counts.PINNED || 0;
+    if (pinnedStacks > 0 || pinnedEvents > 0) {
+        cards.push(card(pinnedStacks > 2 ? 'critical' : 'warning', 84, 'Virtual thread pinning', formatNumber(pinnedEvents) + ' events', 'Pinned virtual threads can stall carrier throughput.', 'Open pinning hotspots and inspect the top stack.'));
+    }
+
+    const contentionTime = Number(contention.totalContentionTimeMs) || 0;
+    if (contentionTime >= 1000) {
+        cards.push(card('critical', 82, 'Lock contention', formatNumber(contentionTime) + 'ms', 'Contention time is accumulating quickly.', 'Open contention hotspots and inspect the monitor class.'));
+    } else if ((Number(contention.totalContentionEvents) || 0) > 0) {
+        cards.push(card('warning', 55, 'Contention present', formatNumber(contention.totalContentionEvents) + ' events', 'Lock contention events are present in the window.', 'Review top monitors before chasing CPU.'));
+    }
+
+    const allocRate = Number(allocation.allocationRateMBPerSec) || 0;
+    if (allocRate >= 100) {
+        cards.push(card('critical', 78, 'Allocation spike', allocRate.toFixed(1) + ' MB/s', 'Allocation rate is high enough to drive GC pressure.', 'Open allocation profile for the selected pod.'));
+    } else if (allocRate >= 25) {
+        cards.push(card('warning', 52, 'Allocation elevated', allocRate.toFixed(1) + ' MB/s', 'Allocation rate is above the normal dashboard band.', 'Compare top allocating classes.'));
+    }
+
+    const jvmCpu = Number(cpu.currentJvmPercent) || 0;
+    if (jvmCpu >= 90) {
+        cards.push(card('critical', 76, 'JVM CPU saturated', jvmCpu.toFixed(1) + '%', 'JVM CPU is at or above the critical threshold.', 'Open CPU profile and check hot methods.'));
+    } else if (jvmCpu >= 70) {
+        cards.push(card('warning', 50, 'JVM CPU high', jvmCpu.toFixed(1) + '%', 'JVM CPU is elevated.', 'Compare CPU with GC and contention cards.'));
+    }
+
+    return cards.sort((a, b) => b.rank - a.rank);
+}
+
+function card(severity, rank, title, metric, body, action) {
+    return { severity, rank, title, metric, body, action };
 }
 
 async function fetchCarrierThreads() {

--- a/argus-frontend/src/main/resources/public/js/dashboard-cluster.js
+++ b/argus-frontend/src/main/resources/public/js/dashboard-cluster.js
@@ -8,10 +8,8 @@
 // Cluster mode is decided by the presence of /api/pods on the same
 // origin. When present:
 //   - Unhide the header pod picker (populated, grouped by deployment).
-//   - Render an above-the-fold banner explaining that live per-pod
-//     widgets need the aggregator metrics proxy (a follow-up graduate).
-//     This prevents the operator from staring at frozen widgets and
-//     thinking the page is broken.
+//   - Render an above-the-fold banner explaining that selected-pod REST
+//     snapshots are active while per-pod WebSocket streaming is not.
 //   - Persist the selection across pages (via window.localStorage key
 //     'argus.console.pod', shared with /console.html and /fleet.html)
 //     and the URL (`?pod=<id>` so a tile drill-down from /fleet lands
@@ -23,27 +21,30 @@
     'use strict';
     if (window.__argusCluster) return; // idempotent
 
-    var POD_STORAGE_KEY = 'argus.console.pod';
+    var podContext = window.ArgusPodContext;
+    if (!podContext) return;
     var state = { clusterMode: false, selectedPod: null, pods: [] };
 
-    function readStored() {
-        try { return window.localStorage.getItem(POD_STORAGE_KEY); }
-        catch (e) { return null; }
-    }
-    function writeStored(podId) {
-        try { window.localStorage.setItem(POD_STORAGE_KEY, podId); }
-        catch (e) { /* localStorage disabled — URL is still authoritative */ }
-    }
-
-    function readUrlPod() {
-        var m = new URLSearchParams(window.location.search).get('pod');
-        return m ? m : null;
-    }
-
-    function writeUrlPod(podId) {
-        var url = new URL(window.location.href);
-        url.searchParams.set('pod', podId);
-        window.history.replaceState({}, '', url.toString());
+    function updateModeStrip(podId, pod) {
+        var title = document.getElementById('dashboard-mode-title');
+        var detail = document.getElementById('dashboard-mode-detail');
+        var fleet = document.getElementById('dashboard-mode-fleet-link');
+        var profiles = document.getElementById('dashboard-mode-profiles-link');
+        var consoleLink = document.getElementById('dashboard-mode-console-link');
+        if (!title || !detail) return;
+        if (!podId || !pod) {
+            title.textContent = 'Snapshot polling';
+            detail.textContent = 'No selected pod';
+            return;
+        }
+        var links = podContext.contextUrls(podId);
+        var scrape = pod.scrapeOk ? 'scrape OK' : 'scrape failed';
+        var last = pod.lastScrapeAt ? new Date(pod.lastScrapeAt).toLocaleTimeString() : 'never scraped';
+        title.textContent = 'Snapshot polling';
+        detail.textContent = podContext.podLabel(podId, pod) + ' - ' + scrape + ', last scrape ' + last;
+        if (fleet) fleet.href = links.fleet;
+        if (profiles) profiles.href = links.profilesCpu;
+        if (consoleLink) consoleLink.href = links.console;
     }
 
     function ensureBanner() {
@@ -67,15 +68,17 @@
         }
         b.hidden = false;
         var status = pod.scrapeOk ? 'online' : 'offline';
+        var links = podContext.contextUrls(podId);
+        updateModeStrip(podId, pod);
         b.innerHTML =
             '<strong>Cluster mode</strong> &middot; ' +
             'Selected: <code>' + escapeHtml(podId) + '</code> (' + status + '). ' +
-            'Live widgets below show this JVM only when the dashboard data proxy ' +
-            'graduate lands. For now use ' +
-            '<a href="/console.html" title="Run diagnostic commands against the selected pod">Console</a> ' +
-            'to run commands against the selected pod, or ' +
-            '<a href="/fleet.html#pod/' + encodeURIComponent(podId) + '">Fleet</a> ' +
-            'for fleet-level summary metrics.';
+            'Selected-pod REST snapshots are active; WebSocket event streaming is ' +
+            'disabled in cluster mode. Use ' +
+            '<a href="' + links.console + '" title="Run diagnostic commands against the selected pod">Console</a>, ' +
+            '<a href="' + links.profilesCpu + '" title="Open profiles for the selected pod">Profiles</a>, or ' +
+            '<a href="' + links.fleet + '">Fleet</a> ' +
+            'for pod-specific drilldowns.';
     }
 
     function escapeHtml(s) {
@@ -101,19 +104,10 @@
             return;
         }
 
-        var grouped = {};
-        pods.forEach(function (p) {
-            var k = p.deployment || p.namespace || 'other';
-            (grouped[k] = grouped[k] || []).push(p);
-        });
+        var grouped = podContext.groupPods(pods);
 
         var knownIds = new Set(pods.map(function (p) { return p.podId; }));
-        var stored = readStored();
-        var url = readUrlPod();
-        // Priority: URL > localStorage > pods[0].
-        var initial = (url && knownIds.has(url)) ? url
-                    : (stored && knownIds.has(stored)) ? stored
-                    : pods[0].podId;
+        var initial = podContext.selectInitialPod(pods);
 
         Object.keys(grouped).sort().forEach(function (group) {
             var og = document.createElement('optgroup');
@@ -138,7 +132,7 @@
 
         // Cross-tab sync from /console.html and /fleet.html.
         window.addEventListener('storage', function (e) {
-            if (e.key !== POD_STORAGE_KEY || !e.newValue) return;
+            if (e.key !== podContext.storageKey || !e.newValue) return;
             if (e.newValue === state.selectedPod) return;
             if (!knownIds.has(e.newValue)) return;
             select.value = e.newValue;
@@ -148,8 +142,8 @@
 
     function applySelection(podId, pods) {
         state.selectedPod = podId;
-        writeStored(podId);
-        writeUrlPod(podId);
+        podContext.writeStoredPod(podId);
+        podContext.writePodParam(podId);
         var pod = pods.find(function (p) { return p.podId === podId; }) || null;
         setBannerForPod(podId, pod);
     }
@@ -187,6 +181,9 @@
     window.__argusCluster = Object.freeze({
         isClusterMode: function () { return state.clusterMode; },
         selectedPod: function () { return state.selectedPod; },
+        selectedPodInfo: function () {
+            return state.pods.find(function (p) { return p.podId === state.selectedPod; }) || null;
+        },
         fetch: clusterFetchImpl
     });
 

--- a/argus-frontend/src/main/resources/public/js/fleet.js
+++ b/argus-frontend/src/main/resources/public/js/fleet.js
@@ -6,37 +6,7 @@
  * Click a tile to show side panel; drill-down navigates to single-JVM dashboard.
  */
 
-/* ----------------------------------------------------------------
-   localStorage helpers (shared key with console.html)
----------------------------------------------------------------- */
-const POD_STORAGE_KEY = 'argus.console.pod';
-let warnedNoStorage = false;
-
-function readStoredPod() {
-    try {
-        return window.localStorage.getItem(POD_STORAGE_KEY);
-    } catch (e) {
-        if (!warnedNoStorage) {
-            warnedNoStorage = true;
-            console.warn('[argus-fleet] localStorage unavailable (' + (e && e.name) +
-                '); cross-tab pod sync disabled.');
-        }
-        return null;
-    }
-}
-
-function writeStoredPod(podId) {
-    try {
-        window.localStorage.setItem(POD_STORAGE_KEY, podId);
-    } catch (e) {
-        if (!warnedNoStorage) {
-            warnedNoStorage = true;
-            console.warn('[argus-fleet] localStorage unavailable (' + (e && e.name) +
-                '); cross-tab pod sync disabled.');
-        }
-    }
-}
-
+const podContext = window.ArgusPodContext;
 const POLL_INTERVAL_MS = 5000;
 const AGGREGATOR_BASE = '';  // same origin; aggregator serves this frontend
 
@@ -91,6 +61,10 @@ const panelScrapeUrl   = document.getElementById('panel-scrape-url');
 const panelLastScrape  = document.getElementById('panel-last-scrape');
 const panelScrapeOk    = document.getElementById('panel-scrape-ok');
 const panelDrillLink   = document.getElementById('panel-drill-link');
+const panelReasons     = document.getElementById('panel-reasons');
+const panelProfilesCpu = document.getElementById('panel-profiles-cpu-link');
+const panelProfilesAlloc = document.getElementById('panel-profiles-alloc-link');
+const panelConsoleLink = document.getElementById('panel-console-link');
 
 /* ----------------------------------------------------------------
    Polling
@@ -306,8 +280,8 @@ function selectTile(tile) {
     const el = grid.querySelector(`[data-pod-id="${CSS.escape(tile.podId)}"]`);
     if (el) el.classList.add('selected');
 
-    /* Sync pod selection to localStorage so console.html cross-tab picks it up */
-    writeStoredPod(tile.podId);
+    /* Sync pod selection so Console/Profile/Dashboard pick it up. */
+    podContext.writeStoredPod(tile.podId);
 
     showPanel(tile);
     fetchPodDetail(tile.podId);
@@ -351,8 +325,12 @@ function showPanel(tile) {
     }
 
     /* Drill-down URL: navigate to single-JVM dashboard with pod query param */
-    const drillUrl = buildDrillUrl(tile);
-    panelDrillLink.href = drillUrl;
+    const urls = podContext.contextUrls(tile.podId, { dashboard: tile.drillDownUrl });
+    panelDrillLink.href = urls.dashboard;
+    if (panelProfilesCpu) panelProfilesCpu.href = urls.profilesCpu;
+    if (panelProfilesAlloc) panelProfilesAlloc.href = urls.profilesAlloc;
+    if (panelConsoleLink) panelConsoleLink.href = urls.console;
+    renderPanelReasons(tile);
 
     sidePanel.hidden = false;
 }
@@ -373,13 +351,51 @@ function setMetricValue(el, val, suffix) {
     }
 }
 
-function buildDrillUrl(tile) {
-    /* The aggregator's drillDownUrl field is authoritative if present */
-    if (tile.drillDownUrl) {
-        return tile.drillDownUrl;
+function renderPanelReasons(tile) {
+    if (!panelReasons) return;
+    const reasons = buildTopReasons(tile).slice(0, 3);
+    if (reasons.length === 0) {
+        panelReasons.innerHTML = '<div class="fleet-panel-empty">No threshold drivers</div>';
+        return;
     }
-    /* Fallback: /?pod=<podId> on the aggregator's own frontend */
-    return `/?pod=${encodeURIComponent(tile.podId)}`;
+    panelReasons.innerHTML = reasons.map(r =>
+        `<div class="fleet-panel-reason fleet-panel-reason--${r.severity}">` +
+        `<div class="fleet-panel-reason-title">${escHtml(r.title)}</div>` +
+        `<div class="fleet-panel-reason-detail">${escHtml(r.detail)}</div>` +
+        `</div>`
+    ).join('');
+}
+
+function buildTopReasons(tile) {
+    const target = tile.target || {};
+    const m = tile.metrics || {};
+    const reasons = [];
+    if (target.scrapeOk === false || tile.color === 'grey') {
+        reasons.push(reason('critical', 100, 'Scrape unavailable', target.lastError || 'The aggregator cannot refresh this pod.'));
+    }
+    if ((tile.alertCount || 0) > 0) {
+        reasons.push(reason('critical', 95, 'Active alerts', tile.alertCount + ' alert' + (tile.alertCount === 1 ? '' : 's') + ' firing.'));
+    }
+    if (m.heapPercent != null) {
+        if (m.heapPercent >= 90) reasons.push(reason('critical', 90, 'Heap saturation', fmt1(m.heapPercent) + '% used.'));
+        else if (m.heapPercent >= 80) reasons.push(reason('warning', 70, 'Heap pressure', fmt1(m.heapPercent) + '% used.'));
+    }
+    if (m.gcOverheadPercent != null) {
+        if (m.gcOverheadPercent >= 10) reasons.push(reason('critical', 88, 'GC overhead', fmt1(m.gcOverheadPercent) + '% of runtime.'));
+        else if (m.gcOverheadPercent >= 5) reasons.push(reason('warning', 68, 'GC overhead rising', fmt1(m.gcOverheadPercent) + '% of runtime.'));
+    }
+    if (m.cpuPercent != null) {
+        if (m.cpuPercent >= 90) reasons.push(reason('critical', 84, 'CPU saturation', fmt1(m.cpuPercent) + '% JVM CPU.'));
+        else if (m.cpuPercent >= 70) reasons.push(reason('warning', 60, 'CPU high', fmt1(m.cpuPercent) + '% JVM CPU.'));
+    }
+    if (m.activeVThreads != null && m.activeVThreads > 10000) {
+        reasons.push(reason('warning', 50, 'Virtual thread backlog', fmt1(m.activeVThreads) + ' active virtual threads.'));
+    }
+    return reasons.sort((a, b) => b.rank - a.rank);
+}
+
+function reason(severity, rank, title, detail) {
+    return { severity, rank, title, detail };
 }
 
 async function fetchPodDetail(podId) {
@@ -492,22 +508,6 @@ function escHtml(str) {
 ---------------------------------------------------------------- */
 
 /**
- * Parse window.location.hash for the pattern #pod/<encoded-podId>.
- * Returns the decoded podId string, or null if absent / malformed.
- */
-function parsePodHash() {
-    const hash = window.location.hash;
-    if (!hash || !hash.startsWith('#pod/')) return null;
-    const raw = hash.slice('#pod/'.length);
-    if (!raw) return null;
-    try {
-        return decodeURIComponent(raw);
-    } catch (_) {
-        return null;
-    }
-}
-
-/**
  * After tiles are rendered, find the tile matching podId and open its panel.
  * Safe to call with a null/unknown podId — does nothing in that case.
  */
@@ -524,21 +524,17 @@ function applyInitialSelection(podId) {
     }
 }
 
-/* Determine initial pod to select (hash takes priority over localStorage) */
-const _hashPod = parsePodHash();
-const _storedPod = !_hashPod ? readStoredPod() : null;
-const _initPodId = _hashPod || _storedPod || null;
-
 /* First poll: run, then apply initial selection if we have one */
 poll().then(() => {
-    if (_initPodId && !selectedPodId) {
-        applyInitialSelection(_initPodId);
+    const initialPodId = podContext.selectInitialPod(allTiles.map(t => ({ podId: t.podId })), { hash: true });
+    if (initialPodId && !selectedPodId) {
+        applyInitialSelection(initialPodId);
     }
 }).finally(schedulePoll);
 
 /* Cross-tab sync: when console.html writes argus.console.pod, reflect it here */
 window.addEventListener('storage', (e) => {
-    if (e.key !== POD_STORAGE_KEY || !e.newValue) return;
+    if (e.key !== podContext.storageKey || !e.newValue) return;
     const podId = e.newValue;
     if (podId === selectedPodId) return;
     applyInitialSelection(podId);

--- a/argus-frontend/src/main/resources/public/js/pod-context.js
+++ b/argus-frontend/src/main/resources/public/js/pod-context.js
@@ -1,0 +1,98 @@
+// Shared selected-pod context for the static dashboard surfaces.
+(function () {
+    'use strict';
+
+    if (window.ArgusPodContext) return;
+
+    var STORAGE_KEY = 'argus.console.pod';
+
+    function readStoredPod() {
+        try { return window.localStorage.getItem(STORAGE_KEY); }
+        catch (e) { return null; }
+    }
+
+    function writeStoredPod(podId) {
+        if (!podId) return;
+        try { window.localStorage.setItem(STORAGE_KEY, podId); }
+        catch (e) { /* URL context still preserves the active selection. */ }
+    }
+
+    function readQueryParam(name) {
+        return new URLSearchParams(window.location.search).get(name);
+    }
+
+    function writeParams(params) {
+        var url = new URL(window.location.href);
+        Object.keys(params).forEach(function (key) {
+            var value = params[key];
+            if (value === null || value === undefined || value === '') {
+                url.searchParams.delete(key);
+            } else {
+                url.searchParams.set(key, value);
+            }
+        });
+        window.history.replaceState({}, '', url.toString());
+    }
+
+    function readHashPod() {
+        var hash = window.location.hash;
+        if (!hash || hash.indexOf('#pod/') !== 0) return null;
+        var raw = hash.slice('#pod/'.length);
+        if (!raw) return null;
+        try { return decodeURIComponent(raw); }
+        catch (e) { return null; }
+    }
+
+    function selectInitialPod(pods, options) {
+        if (!Array.isArray(pods) || pods.length === 0) return null;
+        var known = new Set(pods.map(function (p) { return p.podId; }));
+        var opts = options || {};
+        var hashPod = opts.hash ? readHashPod() : null;
+        var urlPod = readQueryParam('pod');
+        var stored = readStoredPod();
+        return (hashPod && known.has(hashPod)) ? hashPod
+            : (urlPod && known.has(urlPod)) ? urlPod
+            : (stored && known.has(stored)) ? stored
+            : pods[0].podId;
+    }
+
+    function groupPods(pods) {
+        var grouped = {};
+        (pods || []).forEach(function (p) {
+            var key = p.deployment || p.namespace || 'other';
+            (grouped[key] = grouped[key] || []).push(p);
+        });
+        return grouped;
+    }
+
+    function podLabel(podId, pod) {
+        if (!pod) return podId || '';
+        return pod.podName || pod.podId || podId || '';
+    }
+
+    function contextUrls(podId, options) {
+        var encoded = encodeURIComponent(podId || '');
+        var opts = options || {};
+        return {
+            dashboard: opts.dashboard || '/?pod=' + encoded,
+            fleet: '/fleet.html#pod/' + encoded,
+            profilesCpu: '/profiles.html?pod=' + encoded + '&event=cpu&range=3600',
+            profilesAlloc: '/profiles.html?pod=' + encoded + '&event=alloc&range=3600',
+            console: '/console.html?pod=' + encoded
+        };
+    }
+
+    window.ArgusPodContext = Object.freeze({
+        storageKey: STORAGE_KEY,
+        readStoredPod: readStoredPod,
+        writeStoredPod: writeStoredPod,
+        readQueryParam: readQueryParam,
+        writeParams: writeParams,
+        writePodParam: function (podId) { writeParams({ pod: podId }); },
+        readHashPod: readHashPod,
+        selectInitialPod: selectInitialPod,
+        groupPods: groupPods,
+        podLabel: podLabel,
+        contextUrls: contextUrls
+    });
+})();

--- a/argus-frontend/src/main/resources/public/js/profiles.js
+++ b/argus-frontend/src/main/resources/public/js/profiles.js
@@ -12,7 +12,7 @@
 (function () {
     'use strict';
 
-    var POD_STORAGE_KEY = 'argus.console.pod';
+    var podContext = window.ArgusPodContext;
     var AGGREGATOR_BASE = ''; // same origin
 
     var els = {};
@@ -20,13 +20,23 @@
 
     function $(id) { return document.getElementById(id); }
 
-    function readStoredPod() {
-        try { return window.localStorage.getItem(POD_STORAGE_KEY); }
-        catch (e) { return null; }
+    function applyQueryStateToControls() {
+        var event = podContext.readQueryParam('event');
+        var range = podContext.readQueryParam('range');
+        if (event && Array.from(els.event.options).some(function (opt) { return opt.value === event; })) {
+            els.event.value = event;
+        }
+        if (range && Array.from(els.range.options).some(function (opt) { return opt.value === range; })) {
+            els.range.value = range;
+        }
     }
-    function writeStoredPod(podId) {
-        try { window.localStorage.setItem(POD_STORAGE_KEY, podId); }
-        catch (e) { /* ignore */ }
+
+    function syncUrlState() {
+        podContext.writeParams({
+            pod: els.pod.value,
+            event: els.event.value,
+            range: els.range.value
+        });
     }
 
     function setStatus(msg, kind) {
@@ -47,14 +57,8 @@
             els.pod.appendChild(opt);
             return;
         }
-        var grouped = {};
-        pods.forEach(function (p) {
-            var k = p.deployment || p.namespace || 'other';
-            (grouped[k] = grouped[k] || []).push(p);
-        });
-        var stored = readStoredPod();
-        var knownIds = new Set(pods.map(function (p) { return p.podId; }));
-        var initial = (stored && knownIds.has(stored)) ? stored : pods[0].podId;
+        var grouped = podContext.groupPods(pods);
+        var initial = podContext.selectInitialPod(pods);
         Object.keys(grouped).sort().forEach(function (group) {
             var og = document.createElement('optgroup');
             og.label = group;
@@ -98,7 +102,8 @@
         var pod = els.pod.value;
         var event = els.event.value;
         if (!pod) { setStatus('Select a pod first.', 'warn'); return; }
-        writeStoredPod(pod);
+        podContext.writeStoredPod(pod);
+        syncUrlState();
         var w = trailingWindowMillis();
         var url = AGGREGATOR_BASE + '/profile/query?pod=' + encodeURIComponent(pod) +
             '&event=' + encodeURIComponent(event) +
@@ -121,7 +126,8 @@
         var pod = els.pod.value;
         var event = els.event.value;
         if (!pod) { setStatus('Select a pod first.', 'warn'); return; }
-        writeStoredPod(pod);
+        podContext.writeStoredPod(pod);
+        syncUrlState();
         var now = Date.now();
         var sec = parseInt(els.range.value, 10) || 3600;
         // base = the window before head; head = the trailing window.
@@ -169,13 +175,23 @@
 
         els.queryBtn.addEventListener('click', runQuery);
         els.diffBtn.addEventListener('click', runDiff);
+        els.pod.addEventListener('change', function () {
+            podContext.writeStoredPod(els.pod.value);
+            syncUrlState();
+        });
+        els.event.addEventListener('change', syncUrlState);
+        els.range.addEventListener('change', syncUrlState);
         // Re-resolve to current pod selection on cross-tab change.
         window.addEventListener('storage', function (e) {
-            if (e.key !== POD_STORAGE_KEY || !e.newValue) return;
+            if (e.key !== podContext.storageKey || !e.newValue) return;
             var known = new Set(pods.map(function (p) { return p.podId; }));
-            if (known.has(e.newValue)) els.pod.value = e.newValue;
+            if (known.has(e.newValue)) {
+                els.pod.value = e.newValue;
+                syncUrlState();
+            }
         });
 
+        applyQueryStateToControls();
         loadPods().then(function () {
             if (els.pod.value) runQuery();
         });

--- a/argus-frontend/src/main/resources/public/js/websocket.js
+++ b/argus-frontend/src/main/resources/public/js/websocket.js
@@ -82,6 +82,7 @@ function setClusterMode() {
     if (statusTextElement) {
         statusTextElement.textContent = 'Cluster mode (no live stream)';
     }
+    updateModeStrip('Snapshot polling', 'Selected-pod REST snapshots active; WebSocket stream unavailable in cluster mode');
 }
 
 function setConnected(connected) {
@@ -89,11 +90,20 @@ function setConnected(connected) {
         statusElement.classList.remove('disconnected');
         statusElement.classList.add('connected');
         statusTextElement.textContent = 'Connected';
+        updateModeStrip('Live stream', 'WebSocket connected');
     } else {
         statusElement.classList.remove('connected');
         statusElement.classList.add('disconnected');
         statusTextElement.textContent = 'Disconnected';
+        updateModeStrip('Live stream', 'WebSocket disconnected');
     }
+}
+
+function updateModeStrip(titleText, detailText) {
+    const title = document.getElementById('dashboard-mode-title');
+    const detail = document.getElementById('dashboard-mode-detail');
+    if (title) title.textContent = titleText;
+    if (detail) detail.textContent = detailText;
 }
 
 function scheduleReconnect() {

--- a/argus-frontend/src/main/resources/public/profiles.html
+++ b/argus-frontend/src/main/resources/public/profiles.html
@@ -100,6 +100,7 @@
     </style>
     <script src="/js/theme-preboot.js"></script>
     <script src="/js/theme.js"></script>
+    <script src="/js/pod-context.js"></script>
 </head>
 <body>
 

--- a/argus-server/src/test/java/io/argus/server/metrics/DashboardStaticAssetsSmokeTest.java
+++ b/argus-server/src/test/java/io/argus/server/metrics/DashboardStaticAssetsSmokeTest.java
@@ -1,0 +1,65 @@
+package io.argus.server.metrics;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class DashboardStaticAssetsSmokeTest {
+
+    @Test
+    void mainDashboardKeepsModeStripAndIncidentSynopsisHooks() throws Exception {
+        String html = readRepoFile("argus-frontend/src/main/resources/public/index.html");
+        String app = readRepoFile("argus-frontend/src/main/resources/public/js/app.js");
+        String cluster = readRepoFile("argus-frontend/src/main/resources/public/js/dashboard-cluster.js");
+        String podContext = readRepoFile("argus-frontend/src/main/resources/public/js/pod-context.js");
+        String websocket = readRepoFile("argus-frontend/src/main/resources/public/js/websocket.js");
+
+        assertContains(html, "/js/pod-context.js");
+        assertContains(html, "id=\"dashboard-mode-strip\"");
+        assertContains(html, "id=\"incident-synopsis-list\"");
+        assertContains(podContext, "window.ArgusPodContext");
+        assertContains(podContext, "opts.hash ? readHashPod() : null");
+        assertContains(cluster, "ArgusPodContext");
+        assertContains(app, "function updateIncidentSynopsis()");
+        assertContains(cluster, "Selected-pod REST snapshots are active");
+        assertContains(websocket, "WebSocket connected");
+    }
+
+    @Test
+    void fleetProfilesAndConsolePreservePodContext() throws Exception {
+        String fleetHtml = readRepoFile("argus-frontend/src/main/resources/public/fleet.html");
+        String fleetJs = readRepoFile("argus-frontend/src/main/resources/public/js/fleet.js");
+        String profilesJs = readRepoFile("argus-frontend/src/main/resources/public/js/profiles.js");
+        String consoleHtml = readRepoFile("argus-frontend/src/main/resources/public/console.html");
+
+        assertContains(fleetHtml, "/js/pod-context.js");
+        assertContains(consoleHtml, "/js/pod-context.js");
+        assertContains(fleetHtml, "id=\"panel-reasons\"");
+        assertContains(fleetHtml, "id=\"panel-profiles-cpu-link\"");
+        assertContains(fleetJs, "buildTopReasons");
+        assertContains(fleetJs, "podContext.contextUrls");
+        assertContains(fleetJs, "podContext.selectInitialPod");
+        assertContains(profilesJs, "podContext.readQueryParam('event')");
+        assertContains(profilesJs, "podContext.readQueryParam('range')");
+        assertContains(consoleHtml, "podContext.selectInitialPod");
+    }
+
+    private static void assertContains(String text, String needle) {
+        assertTrue(text.contains(needle), "missing expected dashboard smoke hook: " + needle);
+    }
+
+    private static String readRepoFile(String relative) throws IOException {
+        Path userDir = Path.of(System.getProperty("user.dir")).toAbsolutePath();
+        for (Path root = userDir; root != null; root = root.getParent()) {
+            Path candidate = root.resolve(relative);
+            if (Files.exists(candidate)) {
+                return Files.readString(candidate);
+            }
+        }
+        throw new IOException("Unable to find repo file: " + relative + " from " + userDir);
+    }
+}

--- a/argus-server/src/test/java/io/argus/server/metrics/GrafanaDashboardMetricReferencesTest.java
+++ b/argus-server/src/test/java/io/argus/server/metrics/GrafanaDashboardMetricReferencesTest.java
@@ -1,0 +1,211 @@
+package io.argus.server.metrics;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.LinkedHashSet;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class GrafanaDashboardMetricReferencesTest {
+
+    private static final Pattern EXPR = Pattern.compile("\"expr\"\\s*:\\s*\"((?:\\\\.|[^\"\\\\])*)\"");
+    private static final Pattern METRIC_TOKEN = Pattern.compile("\\b(?:argus|jvm)_[A-Za-z0-9_:]+\\b");
+    private static final Pattern APPEND_METRIC_LITERAL =
+            Pattern.compile("append(?:Gauge|Counter)\\(sb,\\s*\"([a-zA-Z_:][a-zA-Z0-9_:]*)\"");
+    private static final Pattern HELP_METRIC_LITERAL =
+            Pattern.compile("# HELP ([a-zA-Z_:][a-zA-Z0-9_:]*)\\b");
+    private static final Pattern SEMCONV_PROMETHEUS_NAME =
+            Pattern.compile("new Metric\\(\\s*\"[^\"]+\",\\s*\"([a-zA-Z_:][a-zA-Z0-9_:]*)\"");
+    private static final Pattern DOC_METRIC = Pattern.compile("`((?:argus|jvm)_[A-Za-z0-9_:]+)`");
+    private static final Pattern VARIABLE_NAME = Pattern.compile("\"name\"\\s*:\\s*\"([A-Za-z0-9_]+)\"");
+    private static final Pattern NUMERIC_PANEL_ID = Pattern.compile("\"id\"\\s*:\\s*(\\d+)");
+    private static final List<String> FLEET_LABEL_MATCHERS = List.of(
+            "namespace=~\"$namespace\"",
+            "deployment=~\"$deployment\"",
+            "pod=~\"$pod\"",
+            "instance=~\"$instance\""
+    );
+    private static final Set<String> HISTOGRAM_FAMILIES = Set.of(
+            "argus_gc_pause_seconds",
+            "jvm_gc_duration_seconds"
+    );
+
+    @Test
+    void dashboardPromqlReferencesOnlyExportedAndDocumentedMetrics() throws Exception {
+        String dashboard = readRepoFile("docs/grafana-dashboard.json");
+        Set<String> referenced = extractReferencedMetrics(dashboard);
+        Set<String> exported = exportedMetricNames();
+        Set<String> documented = documentedMetricNames();
+
+        assertFalse(referenced.isEmpty(), "Grafana dashboard should contain PromQL metric references");
+        for (String metric : referenced) {
+            assertTrue(containsMetric(exported, metric),
+                    () -> "Grafana references metric not emitted by PrometheusMetricsCollector: " + metric);
+            assertTrue(containsMetric(documented, metric),
+                    () -> "Grafana references metric missing from docs/dashboard-contract.md: " + metric);
+        }
+    }
+
+    @Test
+    void dashboardPromqlAppliesFleetVariablesToMetricSelectors() throws Exception {
+        String dashboard = readRepoFile("docs/grafana-dashboard.json");
+        for (String expr : extractExpressions(dashboard)) {
+            Matcher tokens = METRIC_TOKEN.matcher(expr);
+            while (tokens.find()) {
+                int selectorStart = tokens.end();
+                assertTrue(selectorStart < expr.length() && expr.charAt(selectorStart) == '{',
+                        () -> "metric selector missing fleet label matchers for " + tokens.group() + " in " + expr);
+                int selectorEnd = expr.indexOf('}', selectorStart);
+                assertTrue(selectorEnd > selectorStart,
+                        () -> "metric selector is not closed for " + tokens.group() + " in " + expr);
+                String selector = expr.substring(selectorStart + 1, selectorEnd);
+                for (String matcher : FLEET_LABEL_MATCHERS) {
+                    assertTrue(selector.contains(matcher),
+                            () -> "metric selector missing " + matcher + " for " + tokens.group() + " in " + expr);
+                }
+            }
+        }
+    }
+
+    @Test
+    void dashboardHasFleetVariablesAndLocalDrilldownLinks() throws Exception {
+        String dashboard = readRepoFile("docs/grafana-dashboard.json");
+        Set<String> variables = extract(VARIABLE_NAME, dashboard);
+
+        for (String expected : Set.of("datasource", "namespace", "deployment", "pod", "instance")) {
+            assertTrue(variables.contains(expected), "missing Grafana variable: " + expected);
+        }
+
+        assertTrue(dashboard.contains("/fleet.html"), "dashboard should link to Fleet");
+        assertTrue(dashboard.contains("/profiles.html?"), "dashboard should link to Profiles with query state");
+        assertTrue(dashboard.contains("/console.html?"), "dashboard should link to Console with pod context");
+        assertTrue(dashboard.contains("/prometheus"), "dashboard should link to the Prometheus scrape endpoint");
+        assertTrue(dashboard.contains("docs/kubernetes.md"), "dashboard should link to Kubernetes setup docs");
+    }
+
+    @Test
+    void dashboardPanelsKeepRequiredShapeAndUniqueIds() throws Exception {
+        String dashboard = readRepoFile("docs/grafana-dashboard.json");
+        Set<String> ids = new HashSet<>();
+        Matcher matcher = NUMERIC_PANEL_ID.matcher(dashboard);
+        int panelIdCount = 0;
+        while (matcher.find()) {
+            panelIdCount++;
+            assertTrue(ids.add(matcher.group(1)), "duplicate Grafana panel id: " + matcher.group(1));
+        }
+
+        assertTrue(panelIdCount >= 50, "expected the dashboard to keep the existing panel coverage");
+        assertTrue(countOccurrences(dashboard, "\"gridPos\"") >= panelIdCount,
+                "every panel should carry a gridPos block");
+        assertTrue(countOccurrences(dashboard, "\"title\"") >= panelIdCount,
+                "every panel should carry a title");
+        assertTrue(countOccurrences(dashboard, "\"type\"") >= panelIdCount,
+                "every panel should carry a type");
+    }
+
+    @Test
+    void helmPackagedDashboardMatchesPrimaryGrafanaDashboard() throws Exception {
+        assertEquals(
+                readRepoFile("docs/grafana-dashboard.json"),
+                readRepoFile("charts/argus/dashboards/argus-jvm-observability.json"),
+                "Helm-packaged Grafana dashboard must stay in sync with docs/grafana-dashboard.json");
+    }
+
+    private static Set<String> extractReferencedMetrics(String dashboard) {
+        Set<String> metrics = new LinkedHashSet<>();
+        for (String expr : extractExpressions(dashboard)) {
+            Matcher tokens = METRIC_TOKEN.matcher(expr);
+            while (tokens.find()) {
+                metrics.add(tokens.group());
+            }
+        }
+        return metrics;
+    }
+
+    private static List<String> extractExpressions(String dashboard) {
+        List<String> expressions = new ArrayList<>();
+        Matcher exprs = EXPR.matcher(dashboard);
+        while (exprs.find()) {
+            expressions.add(unescapeJsonString(exprs.group(1)));
+        }
+        return expressions;
+    }
+
+    private static Set<String> exportedMetricNames() throws IOException {
+        Set<String> names = new HashSet<>();
+        String collector = readRepoFile("argus-server/src/main/java/io/argus/server/metrics/PrometheusMetricsCollector.java");
+        names.addAll(extract(APPEND_METRIC_LITERAL, collector));
+        names.addAll(extract(HELP_METRIC_LITERAL, collector));
+
+        String semconv = readRepoFile("argus-server/src/main/java/io/argus/server/metrics/SemconvMetrics.java");
+        names.addAll(extract(SEMCONV_PROMETHEUS_NAME, semconv));
+        return names;
+    }
+
+    private static Set<String> documentedMetricNames() throws IOException {
+        String contract = readRepoFile("docs/dashboard-contract.md");
+        return extract(DOC_METRIC, contract);
+    }
+
+    private static boolean containsMetric(Set<String> names, String metric) {
+        if (names.contains(metric)) {
+            return true;
+        }
+        String family = histogramFamily(metric);
+        return family != null && names.contains(family);
+    }
+
+    private static String histogramFamily(String name) {
+        String family = name.replaceFirst("_(bucket|sum|count)$", "");
+        return !family.equals(name) && HISTOGRAM_FAMILIES.contains(family) ? family : null;
+    }
+
+    private static Set<String> extract(Pattern pattern, String text) {
+        Set<String> values = new LinkedHashSet<>();
+        Matcher matcher = pattern.matcher(text);
+        while (matcher.find()) {
+            values.add(matcher.group(1));
+        }
+        return values;
+    }
+
+    private static int countOccurrences(String text, String needle) {
+        int count = 0;
+        int index = 0;
+        while ((index = text.indexOf(needle, index)) >= 0) {
+            count++;
+            index += needle.length();
+        }
+        return count;
+    }
+
+    private static String unescapeJsonString(String value) {
+        return value
+                .replace("\\\"", "\"")
+                .replace("\\\\", "\\")
+                .replace("\\n", "\n")
+                .replace("\\t", "\t");
+    }
+
+    private static String readRepoFile(String relative) throws IOException {
+        Path userDir = Path.of(System.getProperty("user.dir")).toAbsolutePath();
+        for (Path root = userDir; root != null; root = root.getParent()) {
+            Path candidate = root.resolve(relative);
+            if (Files.exists(candidate)) {
+                return Files.readString(candidate);
+            }
+        }
+        throw new IOException("Unable to find repo file: " + relative + " from " + userDir);
+    }
+}

--- a/charts/argus/dashboards/argus-jvm-observability.json
+++ b/charts/argus/dashboards/argus-jvm-observability.json
@@ -15,12 +15,97 @@
       }
     ]
   },
-  "description": "Argus JVM Observability Platform \u2014 Production-grade monitoring for Virtual Threads, GC, Memory, CPU, and Application Health",
+  "description": "Argus JVM Observability Platform — Production-grade monitoring for Virtual Threads, GC, Memory, CPU, and Application Health",
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 2,
   "id": null,
-  "links": [],
+  "links": [
+    {
+      "asDropdown": false,
+      "icon": "external link",
+      "includeVars": true,
+      "keepTime": true,
+      "tags": [],
+      "targetBlank": true,
+      "title": "Fleet",
+      "tooltip": "Open Argus Fleet view",
+      "type": "link",
+      "url": "/fleet.html"
+    },
+    {
+      "asDropdown": false,
+      "icon": "external link",
+      "includeVars": true,
+      "keepTime": true,
+      "tags": [],
+      "targetBlank": true,
+      "title": "Selected Pod Dashboard",
+      "tooltip": "Open selected pod in the local dashboard snapshot view",
+      "type": "link",
+      "url": "/?pod=${pod}"
+    },
+    {
+      "asDropdown": false,
+      "icon": "external link",
+      "includeVars": true,
+      "keepTime": true,
+      "tags": [],
+      "targetBlank": true,
+      "title": "Profiles CPU",
+      "tooltip": "Open CPU profiles for selected pod",
+      "type": "link",
+      "url": "/profiles.html?pod=${pod}&event=cpu&range=3600"
+    },
+    {
+      "asDropdown": false,
+      "icon": "external link",
+      "includeVars": true,
+      "keepTime": true,
+      "tags": [],
+      "targetBlank": true,
+      "title": "Profiles Allocation",
+      "tooltip": "Open allocation profiles for selected pod",
+      "type": "link",
+      "url": "/profiles.html?pod=${pod}&event=alloc&range=3600"
+    },
+    {
+      "asDropdown": false,
+      "icon": "external link",
+      "includeVars": true,
+      "keepTime": false,
+      "tags": [],
+      "targetBlank": true,
+      "title": "Console",
+      "tooltip": "Run commands against selected pod",
+      "type": "link",
+      "url": "/console.html?pod=${pod}"
+    },
+    {
+      "asDropdown": false,
+      "icon": "external link",
+      "includeVars": false,
+      "keepTime": false,
+      "tags": [],
+      "targetBlank": true,
+      "title": "Prometheus Scrape",
+      "tooltip": "Open raw scrape endpoint",
+      "type": "link",
+      "url": "/prometheus"
+    },
+    {
+      "asDropdown": false,
+      "icon": "doc",
+      "includeVars": false,
+      "keepTime": false,
+      "tags": [],
+      "targetBlank": true,
+      "title": "Kubernetes Setup",
+      "tooltip": "Open setup documentation",
+      "type": "link",
+      "url": "docs/kubernetes.md"
+    }
+  ],
   "liveNow": true,
   "panels": [
     {
@@ -32,7 +117,7 @@
         "y": 0
       },
       "id": 200,
-      "title": "\ud83d\udd34 Health Overview",
+      "title": "🔴 Health Overview",
       "type": "row"
     },
     {
@@ -51,7 +136,7 @@
                 },
                 "1": {
                   "color": "red",
-                  "text": "\u26a0 LEAK"
+                  "text": "⚠ LEAK"
                 }
               },
               "type": "value"
@@ -92,8 +177,40 @@
       "type": "stat",
       "targets": [
         {
-          "expr": "argus_gc_leak_suspected",
+          "expr": "argus_gc_leak_suspected{namespace=~\"$namespace\",deployment=~\"$deployment\",pod=~\"$pod\",instance=~\"$instance\"}",
           "legendFormat": ""
+        }
+      ],
+      "links": [
+        {
+          "title": "Fleet",
+          "url": "/fleet.html",
+          "targetBlank": true
+        },
+        {
+          "title": "Selected pod dashboard",
+          "url": "/?pod=${__field.labels.pod}",
+          "targetBlank": true
+        },
+        {
+          "title": "Profiles CPU",
+          "url": "/profiles.html?pod=${__field.labels.pod}&event=cpu&range=3600",
+          "targetBlank": true
+        },
+        {
+          "title": "Profiles allocation",
+          "url": "/profiles.html?pod=${__field.labels.pod}&event=alloc&range=3600",
+          "targetBlank": true
+        },
+        {
+          "title": "Console",
+          "url": "/console.html?pod=${__field.labels.pod}",
+          "targetBlank": true
+        },
+        {
+          "title": "Prometheus scrape",
+          "url": "/prometheus",
+          "targetBlank": true
         }
       ]
     },
@@ -113,7 +230,7 @@
                 },
                 "1": {
                   "color": "orange",
-                  "text": "\u26a0 HIGH"
+                  "text": "⚠ HIGH"
                 }
               },
               "type": "value"
@@ -154,8 +271,40 @@
       "type": "stat",
       "targets": [
         {
-          "expr": "argus_gc_overhead_warning",
+          "expr": "argus_gc_overhead_warning{namespace=~\"$namespace\",deployment=~\"$deployment\",pod=~\"$pod\",instance=~\"$instance\"}",
           "legendFormat": ""
+        }
+      ],
+      "links": [
+        {
+          "title": "Fleet",
+          "url": "/fleet.html",
+          "targetBlank": true
+        },
+        {
+          "title": "Selected pod dashboard",
+          "url": "/?pod=${__field.labels.pod}",
+          "targetBlank": true
+        },
+        {
+          "title": "Profiles CPU",
+          "url": "/profiles.html?pod=${__field.labels.pod}&event=cpu&range=3600",
+          "targetBlank": true
+        },
+        {
+          "title": "Profiles allocation",
+          "url": "/profiles.html?pod=${__field.labels.pod}&event=alloc&range=3600",
+          "targetBlank": true
+        },
+        {
+          "title": "Console",
+          "url": "/console.html?pod=${__field.labels.pod}",
+          "targetBlank": true
+        },
+        {
+          "title": "Prometheus scrape",
+          "url": "/prometheus",
+          "targetBlank": true
         }
       ]
     },
@@ -208,7 +357,7 @@
       "type": "stat",
       "targets": [
         {
-          "expr": "argus_gc_overhead_ratio",
+          "expr": "argus_gc_overhead_ratio{namespace=~\"$namespace\",deployment=~\"$deployment\",pod=~\"$pod\",instance=~\"$instance\"}",
           "legendFormat": ""
         }
       ]
@@ -260,8 +409,40 @@
       "type": "stat",
       "targets": [
         {
-          "expr": "argus_gc_pause_time_seconds_max",
+          "expr": "argus_gc_pause_time_seconds_max{namespace=~\"$namespace\",deployment=~\"$deployment\",pod=~\"$pod\",instance=~\"$instance\"}",
           "legendFormat": ""
+        }
+      ],
+      "links": [
+        {
+          "title": "Fleet",
+          "url": "/fleet.html",
+          "targetBlank": true
+        },
+        {
+          "title": "Selected pod dashboard",
+          "url": "/?pod=${__field.labels.pod}",
+          "targetBlank": true
+        },
+        {
+          "title": "Profiles CPU",
+          "url": "/profiles.html?pod=${__field.labels.pod}&event=cpu&range=3600",
+          "targetBlank": true
+        },
+        {
+          "title": "Profiles allocation",
+          "url": "/profiles.html?pod=${__field.labels.pod}&event=alloc&range=3600",
+          "targetBlank": true
+        },
+        {
+          "title": "Console",
+          "url": "/console.html?pod=${__field.labels.pod}",
+          "targetBlank": true
+        },
+        {
+          "title": "Prometheus scrape",
+          "url": "/prometheus",
+          "targetBlank": true
         }
       ]
     },
@@ -312,8 +493,40 @@
       "type": "stat",
       "targets": [
         {
-          "expr": "argus_heap_used_bytes",
+          "expr": "argus_heap_used_bytes{namespace=~\"$namespace\",deployment=~\"$deployment\",pod=~\"$pod\",instance=~\"$instance\"}",
           "legendFormat": ""
+        }
+      ],
+      "links": [
+        {
+          "title": "Fleet",
+          "url": "/fleet.html",
+          "targetBlank": true
+        },
+        {
+          "title": "Selected pod dashboard",
+          "url": "/?pod=${__field.labels.pod}",
+          "targetBlank": true
+        },
+        {
+          "title": "Profiles CPU",
+          "url": "/profiles.html?pod=${__field.labels.pod}&event=cpu&range=3600",
+          "targetBlank": true
+        },
+        {
+          "title": "Profiles allocation",
+          "url": "/profiles.html?pod=${__field.labels.pod}&event=alloc&range=3600",
+          "targetBlank": true
+        },
+        {
+          "title": "Console",
+          "url": "/console.html?pod=${__field.labels.pod}",
+          "targetBlank": true
+        },
+        {
+          "title": "Prometheus scrape",
+          "url": "/prometheus",
+          "targetBlank": true
         }
       ]
     },
@@ -366,8 +579,40 @@
       "type": "stat",
       "targets": [
         {
-          "expr": "argus_cpu_jvm_user_ratio + argus_cpu_jvm_system_ratio",
+          "expr": "argus_cpu_jvm_user_ratio{namespace=~\"$namespace\",deployment=~\"$deployment\",pod=~\"$pod\",instance=~\"$instance\"} + argus_cpu_jvm_system_ratio{namespace=~\"$namespace\",deployment=~\"$deployment\",pod=~\"$pod\",instance=~\"$instance\"}",
           "legendFormat": ""
+        }
+      ],
+      "links": [
+        {
+          "title": "Fleet",
+          "url": "/fleet.html",
+          "targetBlank": true
+        },
+        {
+          "title": "Selected pod dashboard",
+          "url": "/?pod=${__field.labels.pod}",
+          "targetBlank": true
+        },
+        {
+          "title": "Profiles CPU",
+          "url": "/profiles.html?pod=${__field.labels.pod}&event=cpu&range=3600",
+          "targetBlank": true
+        },
+        {
+          "title": "Profiles allocation",
+          "url": "/profiles.html?pod=${__field.labels.pod}&event=alloc&range=3600",
+          "targetBlank": true
+        },
+        {
+          "title": "Console",
+          "url": "/console.html?pod=${__field.labels.pod}",
+          "targetBlank": true
+        },
+        {
+          "title": "Prometheus scrape",
+          "url": "/prometheus",
+          "targetBlank": true
         }
       ]
     },
@@ -409,7 +654,7 @@
       "type": "stat",
       "targets": [
         {
-          "expr": "argus_virtual_threads_active",
+          "expr": "argus_virtual_threads_active{namespace=~\"$namespace\",deployment=~\"$deployment\",pod=~\"$pod\",instance=~\"$instance\"}",
           "legendFormat": ""
         }
       ]
@@ -456,8 +701,597 @@
       "type": "stat",
       "targets": [
         {
-          "expr": "argus_virtual_threads_pinned_unique_stacks",
+          "expr": "argus_virtual_threads_pinned_unique_stacks{namespace=~\"$namespace\",deployment=~\"$deployment\",pod=~\"$pod\",instance=~\"$instance\"}",
           "legendFormat": ""
+        }
+      ],
+      "links": [
+        {
+          "title": "Fleet",
+          "url": "/fleet.html",
+          "targetBlank": true
+        },
+        {
+          "title": "Selected pod dashboard",
+          "url": "/?pod=${__field.labels.pod}",
+          "targetBlank": true
+        },
+        {
+          "title": "Profiles CPU",
+          "url": "/profiles.html?pod=${__field.labels.pod}&event=cpu&range=3600",
+          "targetBlank": true
+        },
+        {
+          "title": "Profiles allocation",
+          "url": "/profiles.html?pod=${__field.labels.pod}&event=alloc&range=3600",
+          "targetBlank": true
+        },
+        {
+          "title": "Console",
+          "url": "/console.html?pod=${__field.labels.pod}",
+          "targetBlank": true
+        },
+        {
+          "title": "Prometheus scrape",
+          "url": "/prometheus",
+          "targetBlank": true
+        }
+      ]
+    },
+    {
+      "collapsed": false,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 4
+      },
+      "id": 222,
+      "panels": [],
+      "title": "Incident Triage",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 1
+              },
+              {
+                "color": "red",
+                "value": 3
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 0,
+        "y": 5
+      },
+      "id": 223,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "title": "Pods With GC Warning",
+      "type": "stat",
+      "targets": [
+        {
+          "expr": "sum(argus_gc_overhead_warning{namespace=~\"$namespace\",deployment=~\"$deployment\",pod=~\"$pod\",instance=~\"$instance\"})",
+          "legendFormat": ""
+        }
+      ],
+      "links": [
+        {
+          "title": "Fleet",
+          "url": "/fleet.html",
+          "targetBlank": true
+        },
+        {
+          "title": "Selected pod dashboard",
+          "url": "/?pod=${__field.labels.pod}",
+          "targetBlank": true
+        },
+        {
+          "title": "Profiles CPU",
+          "url": "/profiles.html?pod=${__field.labels.pod}&event=cpu&range=3600",
+          "targetBlank": true
+        },
+        {
+          "title": "Profiles allocation",
+          "url": "/profiles.html?pod=${__field.labels.pod}&event=alloc&range=3600",
+          "targetBlank": true
+        },
+        {
+          "title": "Console",
+          "url": "/console.html?pod=${__field.labels.pod}",
+          "targetBlank": true
+        },
+        {
+          "title": "Prometheus scrape",
+          "url": "/prometheus",
+          "targetBlank": true
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 80
+              },
+              {
+                "color": "red",
+                "value": 90
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 4,
+        "y": 5
+      },
+      "id": 224,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "title": "Max Heap Usage",
+      "type": "stat",
+      "targets": [
+        {
+          "expr": "max(argus_heap_usage_ratio{namespace=~\"$namespace\",deployment=~\"$deployment\",pod=~\"$pod\",instance=~\"$instance\"}) * 100",
+          "legendFormat": ""
+        }
+      ],
+      "links": [
+        {
+          "title": "Fleet",
+          "url": "/fleet.html",
+          "targetBlank": true
+        },
+        {
+          "title": "Selected pod dashboard",
+          "url": "/?pod=${__field.labels.pod}",
+          "targetBlank": true
+        },
+        {
+          "title": "Profiles CPU",
+          "url": "/profiles.html?pod=${__field.labels.pod}&event=cpu&range=3600",
+          "targetBlank": true
+        },
+        {
+          "title": "Profiles allocation",
+          "url": "/profiles.html?pod=${__field.labels.pod}&event=alloc&range=3600",
+          "targetBlank": true
+        },
+        {
+          "title": "Console",
+          "url": "/console.html?pod=${__field.labels.pod}",
+          "targetBlank": true
+        },
+        {
+          "title": "Prometheus scrape",
+          "url": "/prometheus",
+          "targetBlank": true
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 1
+              },
+              {
+                "color": "red",
+                "value": 10
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 8,
+        "y": 5
+      },
+      "id": 225,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "title": "Pinning Rate",
+      "type": "stat",
+      "targets": [
+        {
+          "expr": "sum(rate(argus_virtual_threads_pinned_total{namespace=~\"$namespace\",deployment=~\"$deployment\",pod=~\"$pod\",instance=~\"$instance\"}[5m])) * 60",
+          "legendFormat": ""
+        }
+      ],
+      "links": [
+        {
+          "title": "Fleet",
+          "url": "/fleet.html",
+          "targetBlank": true
+        },
+        {
+          "title": "Selected pod dashboard",
+          "url": "/?pod=${__field.labels.pod}",
+          "targetBlank": true
+        },
+        {
+          "title": "Profiles CPU",
+          "url": "/profiles.html?pod=${__field.labels.pod}&event=cpu&range=3600",
+          "targetBlank": true
+        },
+        {
+          "title": "Profiles allocation",
+          "url": "/profiles.html?pod=${__field.labels.pod}&event=alloc&range=3600",
+          "targetBlank": true
+        },
+        {
+          "title": "Console",
+          "url": "/console.html?pod=${__field.labels.pod}",
+          "targetBlank": true
+        },
+        {
+          "title": "Prometheus scrape",
+          "url": "/prometheus",
+          "targetBlank": true
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "Bps",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 26214400
+              },
+              {
+                "color": "red",
+                "value": 104857600
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 12,
+        "y": 5
+      },
+      "id": 226,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "title": "Allocation Rate",
+      "type": "stat",
+      "targets": [
+        {
+          "expr": "sum(argus_allocation_rate_bytes_per_second{namespace=~\"$namespace\",deployment=~\"$deployment\",pod=~\"$pod\",instance=~\"$instance\"})",
+          "legendFormat": ""
+        }
+      ],
+      "links": [
+        {
+          "title": "Fleet",
+          "url": "/fleet.html",
+          "targetBlank": true
+        },
+        {
+          "title": "Selected pod dashboard",
+          "url": "/?pod=${__field.labels.pod}",
+          "targetBlank": true
+        },
+        {
+          "title": "Profiles CPU",
+          "url": "/profiles.html?pod=${__field.labels.pod}&event=cpu&range=3600",
+          "targetBlank": true
+        },
+        {
+          "title": "Profiles allocation",
+          "url": "/profiles.html?pod=${__field.labels.pod}&event=alloc&range=3600",
+          "targetBlank": true
+        },
+        {
+          "title": "Console",
+          "url": "/console.html?pod=${__field.labels.pod}",
+          "targetBlank": true
+        },
+        {
+          "title": "Prometheus scrape",
+          "url": "/prometheus",
+          "targetBlank": true
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 0.1
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 16,
+        "y": 5
+      },
+      "id": 227,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "title": "Contention Time Rate",
+      "type": "stat",
+      "targets": [
+        {
+          "expr": "sum(rate(argus_contention_time_seconds_total{namespace=~\"$namespace\",deployment=~\"$deployment\",pod=~\"$pod\",instance=~\"$instance\"}[5m]))",
+          "legendFormat": ""
+        }
+      ],
+      "links": [
+        {
+          "title": "Fleet",
+          "url": "/fleet.html",
+          "targetBlank": true
+        },
+        {
+          "title": "Selected pod dashboard",
+          "url": "/?pod=${__field.labels.pod}",
+          "targetBlank": true
+        },
+        {
+          "title": "Profiles CPU",
+          "url": "/profiles.html?pod=${__field.labels.pod}&event=cpu&range=3600",
+          "targetBlank": true
+        },
+        {
+          "title": "Profiles allocation",
+          "url": "/profiles.html?pod=${__field.labels.pod}&event=alloc&range=3600",
+          "targetBlank": true
+        },
+        {
+          "title": "Console",
+          "url": "/console.html?pod=${__field.labels.pod}",
+          "targetBlank": true
+        },
+        {
+          "title": "Prometheus scrape",
+          "url": "/prometheus",
+          "targetBlank": true
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 0.5
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 20,
+        "y": 5
+      },
+      "id": 228,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "title": "Worst Scrape Duration",
+      "type": "stat",
+      "targets": [
+        {
+          "expr": "max(argus_scrape_duration_seconds{namespace=~\"$namespace\",deployment=~\"$deployment\",pod=~\"$pod\",instance=~\"$instance\"})",
+          "legendFormat": ""
+        }
+      ],
+      "links": [
+        {
+          "title": "Fleet",
+          "url": "/fleet.html",
+          "targetBlank": true
+        },
+        {
+          "title": "Selected pod dashboard",
+          "url": "/?pod=${__field.labels.pod}",
+          "targetBlank": true
+        },
+        {
+          "title": "Profiles CPU",
+          "url": "/profiles.html?pod=${__field.labels.pod}&event=cpu&range=3600",
+          "targetBlank": true
+        },
+        {
+          "title": "Profiles allocation",
+          "url": "/profiles.html?pod=${__field.labels.pod}&event=alloc&range=3600",
+          "targetBlank": true
+        },
+        {
+          "title": "Console",
+          "url": "/console.html?pod=${__field.labels.pod}",
+          "targetBlank": true
+        },
+        {
+          "title": "Prometheus scrape",
+          "url": "/prometheus",
+          "targetBlank": true
         }
       ]
     },
@@ -467,10 +1301,10 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 4
+        "y": 9
       },
       "id": 201,
-      "title": "\ud83d\udcca Heap & GC",
+      "title": "📊 Heap & GC",
       "type": "row"
     },
     {
@@ -539,7 +1373,7 @@
         "h": 8,
         "w": 8,
         "x": 0,
-        "y": 5
+        "y": 10
       },
       "id": 10,
       "options": {
@@ -556,11 +1390,11 @@
       "type": "timeseries",
       "targets": [
         {
-          "expr": "argus_heap_used_bytes",
+          "expr": "argus_heap_used_bytes{namespace=~\"$namespace\",deployment=~\"$deployment\",pod=~\"$pod\",instance=~\"$instance\"}",
           "legendFormat": "Used"
         },
         {
-          "expr": "argus_heap_committed_bytes",
+          "expr": "argus_heap_committed_bytes{namespace=~\"$namespace\",deployment=~\"$deployment\",pod=~\"$pod\",instance=~\"$instance\"}",
           "legendFormat": "Committed"
         }
       ]
@@ -618,14 +1452,14 @@
         "h": 8,
         "w": 4,
         "x": 8,
-        "y": 5
+        "y": 10
       },
       "id": 11,
       "title": "Heap Usage %",
       "type": "timeseries",
       "targets": [
         {
-          "expr": "argus_heap_usage_ratio",
+          "expr": "argus_heap_usage_ratio{namespace=~\"$namespace\",deployment=~\"$deployment\",pod=~\"$pod\",instance=~\"$instance\"}",
           "legendFormat": "Heap Usage"
         }
       ]
@@ -681,7 +1515,7 @@
         "h": 8,
         "w": 6,
         "x": 12,
-        "y": 5
+        "y": 10
       },
       "id": 12,
       "options": {
@@ -697,12 +1531,44 @@
       "type": "timeseries",
       "targets": [
         {
-          "expr": "argus_gc_pause_time_seconds_max",
+          "expr": "argus_gc_pause_time_seconds_max{namespace=~\"$namespace\",deployment=~\"$deployment\",pod=~\"$pod\",instance=~\"$instance\"}",
           "legendFormat": "Max Pause"
         },
         {
-          "expr": "argus_gc_pause_time_seconds_avg",
+          "expr": "argus_gc_pause_time_seconds_avg{namespace=~\"$namespace\",deployment=~\"$deployment\",pod=~\"$pod\",instance=~\"$instance\"}",
           "legendFormat": "Avg Pause"
+        }
+      ],
+      "links": [
+        {
+          "title": "Fleet",
+          "url": "/fleet.html",
+          "targetBlank": true
+        },
+        {
+          "title": "Selected pod dashboard",
+          "url": "/?pod=${__field.labels.pod}",
+          "targetBlank": true
+        },
+        {
+          "title": "Profiles CPU",
+          "url": "/profiles.html?pod=${__field.labels.pod}&event=cpu&range=3600",
+          "targetBlank": true
+        },
+        {
+          "title": "Profiles allocation",
+          "url": "/profiles.html?pod=${__field.labels.pod}&event=alloc&range=3600",
+          "targetBlank": true
+        },
+        {
+          "title": "Console",
+          "url": "/console.html?pod=${__field.labels.pod}",
+          "targetBlank": true
+        },
+        {
+          "title": "Prometheus scrape",
+          "url": "/prometheus",
+          "targetBlank": true
         }
       ]
     },
@@ -750,15 +1616,47 @@
         "h": 8,
         "w": 6,
         "x": 18,
-        "y": 5
+        "y": 10
       },
       "id": 13,
       "title": "GC Overhead",
       "type": "timeseries",
       "targets": [
         {
-          "expr": "argus_gc_overhead_ratio",
+          "expr": "argus_gc_overhead_ratio{namespace=~\"$namespace\",deployment=~\"$deployment\",pod=~\"$pod\",instance=~\"$instance\"}",
           "legendFormat": "Overhead"
+        }
+      ],
+      "links": [
+        {
+          "title": "Fleet",
+          "url": "/fleet.html",
+          "targetBlank": true
+        },
+        {
+          "title": "Selected pod dashboard",
+          "url": "/?pod=${__field.labels.pod}",
+          "targetBlank": true
+        },
+        {
+          "title": "Profiles CPU",
+          "url": "/profiles.html?pod=${__field.labels.pod}&event=cpu&range=3600",
+          "targetBlank": true
+        },
+        {
+          "title": "Profiles allocation",
+          "url": "/profiles.html?pod=${__field.labels.pod}&event=alloc&range=3600",
+          "targetBlank": true
+        },
+        {
+          "title": "Console",
+          "url": "/console.html?pod=${__field.labels.pod}",
+          "targetBlank": true
+        },
+        {
+          "title": "Prometheus scrape",
+          "url": "/prometheus",
+          "targetBlank": true
         }
       ]
     },
@@ -768,10 +1666,10 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 13
+        "y": 18
       },
       "id": 202,
-      "title": "\ud83d\udd0d Memory Leak Detection & Allocation",
+      "title": "🔍 Memory Leak Detection & Allocation",
       "type": "row"
     },
     {
@@ -806,7 +1704,7 @@
         "h": 7,
         "w": 4,
         "x": 0,
-        "y": 14
+        "y": 19
       },
       "id": 20,
       "options": {
@@ -819,12 +1717,44 @@
           ]
         }
       },
-      "title": "Leak Confidence (R\u00b2)",
+      "title": "Leak Confidence (R²)",
       "type": "gauge",
       "targets": [
         {
-          "expr": "argus_gc_leak_confidence",
+          "expr": "argus_gc_leak_confidence{namespace=~\"$namespace\",deployment=~\"$deployment\",pod=~\"$pod\",instance=~\"$instance\"}",
           "legendFormat": ""
+        }
+      ],
+      "links": [
+        {
+          "title": "Fleet",
+          "url": "/fleet.html",
+          "targetBlank": true
+        },
+        {
+          "title": "Selected pod dashboard",
+          "url": "/?pod=${__field.labels.pod}",
+          "targetBlank": true
+        },
+        {
+          "title": "Profiles CPU",
+          "url": "/profiles.html?pod=${__field.labels.pod}&event=cpu&range=3600",
+          "targetBlank": true
+        },
+        {
+          "title": "Profiles allocation",
+          "url": "/profiles.html?pod=${__field.labels.pod}&event=alloc&range=3600",
+          "targetBlank": true
+        },
+        {
+          "title": "Console",
+          "url": "/console.html?pod=${__field.labels.pod}",
+          "targetBlank": true
+        },
+        {
+          "title": "Prometheus scrape",
+          "url": "/prometheus",
+          "targetBlank": true
         }
       ]
     },
@@ -866,15 +1796,15 @@
         "h": 7,
         "w": 8,
         "x": 4,
-        "y": 14
+        "y": 19
       },
       "id": 21,
       "title": "Leak Confidence Over Time",
       "type": "timeseries",
       "targets": [
         {
-          "expr": "argus_gc_leak_confidence",
-          "legendFormat": "R\u00b2"
+          "expr": "argus_gc_leak_confidence{namespace=~\"$namespace\",deployment=~\"$deployment\",pod=~\"$pod\",instance=~\"$instance\"}",
+          "legendFormat": "R²"
         }
       ]
     },
@@ -901,7 +1831,7 @@
         "h": 7,
         "w": 6,
         "x": 12,
-        "y": 14
+        "y": 19
       },
       "id": 22,
       "options": {
@@ -917,12 +1847,44 @@
       "type": "timeseries",
       "targets": [
         {
-          "expr": "argus_gc_allocation_rate_kbps",
+          "expr": "argus_gc_allocation_rate_kbps{namespace=~\"$namespace\",deployment=~\"$deployment\",pod=~\"$pod\",instance=~\"$instance\"}",
           "legendFormat": "Allocation"
         },
         {
-          "expr": "argus_gc_promotion_rate_kbps",
+          "expr": "argus_gc_promotion_rate_kbps{namespace=~\"$namespace\",deployment=~\"$deployment\",pod=~\"$pod\",instance=~\"$instance\"}",
           "legendFormat": "Promotion"
+        }
+      ],
+      "links": [
+        {
+          "title": "Fleet",
+          "url": "/fleet.html",
+          "targetBlank": true
+        },
+        {
+          "title": "Selected pod dashboard",
+          "url": "/?pod=${__field.labels.pod}",
+          "targetBlank": true
+        },
+        {
+          "title": "Profiles CPU",
+          "url": "/profiles.html?pod=${__field.labels.pod}&event=cpu&range=3600",
+          "targetBlank": true
+        },
+        {
+          "title": "Profiles allocation",
+          "url": "/profiles.html?pod=${__field.labels.pod}&event=alloc&range=3600",
+          "targetBlank": true
+        },
+        {
+          "title": "Console",
+          "url": "/console.html?pod=${__field.labels.pod}",
+          "targetBlank": true
+        },
+        {
+          "title": "Prometheus scrape",
+          "url": "/prometheus",
+          "targetBlank": true
         }
       ]
     },
@@ -948,14 +1910,14 @@
         "h": 7,
         "w": 6,
         "x": 18,
-        "y": 14
+        "y": 19
       },
       "id": 23,
       "title": "GC Events (rate)",
       "type": "timeseries",
       "targets": [
         {
-          "expr": "rate(argus_gc_events_total[1m])*60",
+          "expr": "rate(argus_gc_events_total{namespace=~\"$namespace\",deployment=~\"$deployment\",pod=~\"$pod\",instance=~\"$instance\"}[1m])*60",
           "legendFormat": "GC Events/min"
         }
       ]
@@ -966,10 +1928,10 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 21
+        "y": 26
       },
       "id": 203,
-      "title": "\ud83e\uddf5 Virtual Threads",
+      "title": "🧵 Virtual Threads",
       "type": "row"
     },
     {
@@ -995,14 +1957,14 @@
         "h": 7,
         "w": 6,
         "x": 0,
-        "y": 22
+        "y": 27
       },
       "id": 30,
       "title": "Active Virtual Threads",
       "type": "timeseries",
       "targets": [
         {
-          "expr": "argus_virtual_threads_active",
+          "expr": "argus_virtual_threads_active{namespace=~\"$namespace\",deployment=~\"$deployment\",pod=~\"$pod\",instance=~\"$instance\"}",
           "legendFormat": "Active"
         }
       ]
@@ -1028,7 +1990,7 @@
         "h": 7,
         "w": 6,
         "x": 6,
-        "y": 22
+        "y": 27
       },
       "id": 31,
       "options": {
@@ -1044,11 +2006,11 @@
       "type": "timeseries",
       "targets": [
         {
-          "expr": "rate(argus_virtual_threads_started_total[1m])*60",
+          "expr": "rate(argus_virtual_threads_started_total{namespace=~\"$namespace\",deployment=~\"$deployment\",pod=~\"$pod\",instance=~\"$instance\"}[1m])*60",
           "legendFormat": "Started/min"
         },
         {
-          "expr": "rate(argus_virtual_threads_ended_total[1m])*60",
+          "expr": "rate(argus_virtual_threads_ended_total{namespace=~\"$namespace\",deployment=~\"$deployment\",pod=~\"$pod\",instance=~\"$instance\"}[1m])*60",
           "legendFormat": "Ended/min"
         }
       ]
@@ -1091,7 +2053,7 @@
         "h": 7,
         "w": 6,
         "x": 12,
-        "y": 22
+        "y": 27
       },
       "id": 32,
       "options": {
@@ -1107,12 +2069,44 @@
       "type": "timeseries",
       "targets": [
         {
-          "expr": "rate(argus_virtual_threads_pinned_total[1m])*60",
+          "expr": "rate(argus_virtual_threads_pinned_total{namespace=~\"$namespace\",deployment=~\"$deployment\",pod=~\"$pod\",instance=~\"$instance\"}[1m])*60",
           "legendFormat": "Pinning Events/min"
         },
         {
-          "expr": "argus_virtual_threads_pinned_unique_stacks",
+          "expr": "argus_virtual_threads_pinned_unique_stacks{namespace=~\"$namespace\",deployment=~\"$deployment\",pod=~\"$pod\",instance=~\"$instance\"}",
           "legendFormat": "Unique Stacks"
+        }
+      ],
+      "links": [
+        {
+          "title": "Fleet",
+          "url": "/fleet.html",
+          "targetBlank": true
+        },
+        {
+          "title": "Selected pod dashboard",
+          "url": "/?pod=${__field.labels.pod}",
+          "targetBlank": true
+        },
+        {
+          "title": "Profiles CPU",
+          "url": "/profiles.html?pod=${__field.labels.pod}&event=cpu&range=3600",
+          "targetBlank": true
+        },
+        {
+          "title": "Profiles allocation",
+          "url": "/profiles.html?pod=${__field.labels.pod}&event=alloc&range=3600",
+          "targetBlank": true
+        },
+        {
+          "title": "Console",
+          "url": "/console.html?pod=${__field.labels.pod}",
+          "targetBlank": true
+        },
+        {
+          "title": "Prometheus scrape",
+          "url": "/prometheus",
+          "targetBlank": true
         }
       ]
     },
@@ -1137,7 +2131,7 @@
         "h": 7,
         "w": 6,
         "x": 18,
-        "y": 22
+        "y": 27
       },
       "id": 33,
       "options": {
@@ -1153,11 +2147,11 @@
       "type": "timeseries",
       "targets": [
         {
-          "expr": "argus_carrier_threads",
+          "expr": "argus_carrier_threads{namespace=~\"$namespace\",deployment=~\"$deployment\",pod=~\"$pod\",instance=~\"$instance\"}",
           "legendFormat": "Carrier Count"
         },
         {
-          "expr": "argus_carrier_threads_avg_per_carrier",
+          "expr": "argus_carrier_threads_avg_per_carrier{namespace=~\"$namespace\",deployment=~\"$deployment\",pod=~\"$pod\",instance=~\"$instance\"}",
           "legendFormat": "Avg VT/Carrier"
         }
       ]
@@ -1168,10 +2162,10 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 29
+        "y": 34
       },
       "id": 204,
-      "title": "\u26a1 CPU & Metaspace",
+      "title": "⚡ CPU & Metaspace",
       "type": "row"
     },
     {
@@ -1202,7 +2196,7 @@
         "h": 7,
         "w": 7,
         "x": 0,
-        "y": 30
+        "y": 35
       },
       "id": 40,
       "options": {
@@ -1218,11 +2212,11 @@
       "type": "timeseries",
       "targets": [
         {
-          "expr": "argus_cpu_jvm_user_ratio",
+          "expr": "argus_cpu_jvm_user_ratio{namespace=~\"$namespace\",deployment=~\"$deployment\",pod=~\"$pod\",instance=~\"$instance\"}",
           "legendFormat": "User"
         },
         {
-          "expr": "argus_cpu_jvm_system_ratio",
+          "expr": "argus_cpu_jvm_system_ratio{namespace=~\"$namespace\",deployment=~\"$deployment\",pod=~\"$pod\",instance=~\"$instance\"}",
           "legendFormat": "System"
         }
       ]
@@ -1252,14 +2246,14 @@
         "h": 7,
         "w": 5,
         "x": 7,
-        "y": 30
+        "y": 35
       },
       "id": 41,
       "title": "Machine CPU",
       "type": "timeseries",
       "targets": [
         {
-          "expr": "argus_cpu_machine_total_ratio",
+          "expr": "argus_cpu_machine_total_ratio{namespace=~\"$namespace\",deployment=~\"$deployment\",pod=~\"$pod\",instance=~\"$instance\"}",
           "legendFormat": "Total"
         }
       ]
@@ -1310,7 +2304,7 @@
         "h": 7,
         "w": 8,
         "x": 12,
-        "y": 30
+        "y": 35
       },
       "id": 50,
       "options": {
@@ -1326,15 +2320,15 @@
       "type": "timeseries",
       "targets": [
         {
-          "expr": "argus_metaspace_used_bytes",
+          "expr": "argus_metaspace_used_bytes{namespace=~\"$namespace\",deployment=~\"$deployment\",pod=~\"$pod\",instance=~\"$instance\"}",
           "legendFormat": "Used"
         },
         {
-          "expr": "argus_metaspace_committed_bytes",
+          "expr": "argus_metaspace_committed_bytes{namespace=~\"$namespace\",deployment=~\"$deployment\",pod=~\"$pod\",instance=~\"$instance\"}",
           "legendFormat": "Committed"
         },
         {
-          "expr": "argus_metaspace_reserved_bytes",
+          "expr": "argus_metaspace_reserved_bytes{namespace=~\"$namespace\",deployment=~\"$deployment\",pod=~\"$pod\",instance=~\"$instance\"}",
           "legendFormat": "Reserved"
         }
       ]
@@ -1361,14 +2355,14 @@
         "h": 7,
         "w": 4,
         "x": 20,
-        "y": 30
+        "y": 35
       },
       "id": 51,
       "title": "Loaded Classes",
       "type": "timeseries",
       "targets": [
         {
-          "expr": "argus_metaspace_classes_loaded",
+          "expr": "argus_metaspace_classes_loaded{namespace=~\"$namespace\",deployment=~\"$deployment\",pod=~\"$pod\",instance=~\"$instance\"}",
           "legendFormat": "Classes"
         }
       ]
@@ -1379,10 +2373,10 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 37
+        "y": 42
       },
       "id": 206,
-      "title": "\ud83d\udcc8 Counters & Totals",
+      "title": "📈 Counters & Totals",
       "type": "row"
     },
     {
@@ -1406,7 +2400,7 @@
         "h": 4,
         "w": 4,
         "x": 0,
-        "y": 38
+        "y": 43
       },
       "id": 60,
       "options": {
@@ -1423,7 +2417,7 @@
       "type": "stat",
       "targets": [
         {
-          "expr": "argus_gc_events_total",
+          "expr": "argus_gc_events_total{namespace=~\"$namespace\",deployment=~\"$deployment\",pod=~\"$pod\",instance=~\"$instance\"}",
           "legendFormat": ""
         }
       ]
@@ -1450,7 +2444,7 @@
         "h": 4,
         "w": 4,
         "x": 4,
-        "y": 38
+        "y": 43
       },
       "id": 61,
       "options": {
@@ -1467,7 +2461,7 @@
       "type": "stat",
       "targets": [
         {
-          "expr": "argus_gc_pause_time_seconds_total",
+          "expr": "argus_gc_pause_time_seconds_total{namespace=~\"$namespace\",deployment=~\"$deployment\",pod=~\"$pod\",instance=~\"$instance\"}",
           "legendFormat": ""
         }
       ]
@@ -1493,7 +2487,7 @@
         "h": 4,
         "w": 4,
         "x": 8,
-        "y": 38
+        "y": 43
       },
       "id": 62,
       "options": {
@@ -1510,7 +2504,7 @@
       "type": "stat",
       "targets": [
         {
-          "expr": "argus_virtual_threads_started_total",
+          "expr": "argus_virtual_threads_started_total{namespace=~\"$namespace\",deployment=~\"$deployment\",pod=~\"$pod\",instance=~\"$instance\"}",
           "legendFormat": ""
         }
       ]
@@ -1536,7 +2530,7 @@
         "h": 4,
         "w": 4,
         "x": 12,
-        "y": 38
+        "y": 43
       },
       "id": 63,
       "options": {
@@ -1553,7 +2547,7 @@
       "type": "stat",
       "targets": [
         {
-          "expr": "argus_virtual_threads_ended_total",
+          "expr": "argus_virtual_threads_ended_total{namespace=~\"$namespace\",deployment=~\"$deployment\",pod=~\"$pod\",instance=~\"$instance\"}",
           "legendFormat": ""
         }
       ]
@@ -1583,7 +2577,7 @@
         "h": 4,
         "w": 4,
         "x": 16,
-        "y": 38
+        "y": 43
       },
       "id": 64,
       "options": {
@@ -1600,7 +2594,7 @@
       "type": "stat",
       "targets": [
         {
-          "expr": "argus_virtual_threads_submit_failed_total",
+          "expr": "argus_virtual_threads_submit_failed_total{namespace=~\"$namespace\",deployment=~\"$deployment\",pod=~\"$pod\",instance=~\"$instance\"}",
           "legendFormat": ""
         }
       ]
@@ -1626,7 +2620,7 @@
         "h": 4,
         "w": 4,
         "x": 20,
-        "y": 38
+        "y": 43
       },
       "id": 65,
       "options": {
@@ -1643,7 +2637,7 @@
       "type": "stat",
       "targets": [
         {
-          "expr": "argus_virtual_threads_pinned_total",
+          "expr": "argus_virtual_threads_pinned_total{namespace=~\"$namespace\",deployment=~\"$deployment\",pod=~\"$pod\",instance=~\"$instance\"}",
           "legendFormat": ""
         }
       ]
@@ -1654,10 +2648,10 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 43
+        "y": 48
       },
       "id": 207,
-      "title": "\ud83e\udde0 Derived Insights",
+      "title": "🧠 Derived Insights",
       "type": "row"
     },
     {
@@ -1683,7 +2677,7 @@
         "h": 7,
         "w": 8,
         "x": 0,
-        "y": 44
+        "y": 49
       },
       "id": 208,
       "options": {
@@ -1699,11 +2693,11 @@
       "type": "timeseries",
       "targets": [
         {
-          "expr": "argus_virtual_threads_started_total - argus_virtual_threads_ended_total",
+          "expr": "argus_virtual_threads_started_total{namespace=~\"$namespace\",deployment=~\"$deployment\",pod=~\"$pod\",instance=~\"$instance\"} - argus_virtual_threads_ended_total{namespace=~\"$namespace\",deployment=~\"$deployment\",pod=~\"$pod\",instance=~\"$instance\"}",
           "legendFormat": "Backlog"
         },
         {
-          "expr": "argus_virtual_threads_active",
+          "expr": "argus_virtual_threads_active{namespace=~\"$namespace\",deployment=~\"$deployment\",pod=~\"$pod\",instance=~\"$instance\"}",
           "legendFormat": "Active"
         }
       ]
@@ -1748,14 +2742,14 @@
         "h": 7,
         "w": 8,
         "x": 8,
-        "y": 44
+        "y": 49
       },
       "id": 209,
       "title": "Promotion / Allocation Ratio",
       "type": "timeseries",
       "targets": [
         {
-          "expr": "argus_gc_promotion_rate_kbps / (argus_gc_allocation_rate_kbps > 0 or 1)",
+          "expr": "argus_gc_promotion_rate_kbps{namespace=~\"$namespace\",deployment=~\"$deployment\",pod=~\"$pod\",instance=~\"$instance\"} / (argus_gc_allocation_rate_kbps{namespace=~\"$namespace\",deployment=~\"$deployment\",pod=~\"$pod\",instance=~\"$instance\"} > 0 or 1)",
           "legendFormat": "Promo/Alloc"
         }
       ]
@@ -1784,14 +2778,14 @@
         "h": 7,
         "w": 8,
         "x": 16,
-        "y": 44
+        "y": 49
       },
       "id": 210,
       "title": "Heap Headroom (Free)",
       "type": "timeseries",
       "targets": [
         {
-          "expr": "argus_heap_committed_bytes - argus_heap_used_bytes",
+          "expr": "argus_heap_committed_bytes{namespace=~\"$namespace\",deployment=~\"$deployment\",pod=~\"$pod\",instance=~\"$instance\"} - argus_heap_used_bytes{namespace=~\"$namespace\",deployment=~\"$deployment\",pod=~\"$pod\",instance=~\"$instance\"}",
           "legendFormat": "Free Heap"
         }
       ]
@@ -1802,10 +2796,10 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 51
+        "y": 56
       },
       "id": 211,
-      "title": "\ud83d\ude80 Rates & Throughput",
+      "title": "🚀 Rates & Throughput",
       "type": "row"
     },
     {
@@ -1830,7 +2824,7 @@
         "h": 7,
         "w": 6,
         "x": 0,
-        "y": 52
+        "y": 57
       },
       "id": 212,
       "options": {
@@ -1846,11 +2840,11 @@
       "type": "timeseries",
       "targets": [
         {
-          "expr": "rate(argus_virtual_threads_started_total[30s])",
+          "expr": "rate(argus_virtual_threads_started_total{namespace=~\"$namespace\",deployment=~\"$deployment\",pod=~\"$pod\",instance=~\"$instance\"}[30s])",
           "legendFormat": "Created/s"
         },
         {
-          "expr": "rate(argus_virtual_threads_ended_total[30s])",
+          "expr": "rate(argus_virtual_threads_ended_total{namespace=~\"$namespace\",deployment=~\"$deployment\",pod=~\"$pod\",instance=~\"$instance\"}[30s])",
           "legendFormat": "Ended/s"
         }
       ]
@@ -1878,14 +2872,14 @@
         "h": 7,
         "w": 6,
         "x": 6,
-        "y": 52
+        "y": 57
       },
       "id": 213,
       "title": "Pinning Rate (/s)",
       "type": "timeseries",
       "targets": [
         {
-          "expr": "rate(argus_virtual_threads_pinned_total[30s])",
+          "expr": "rate(argus_virtual_threads_pinned_total{namespace=~\"$namespace\",deployment=~\"$deployment\",pod=~\"$pod\",instance=~\"$instance\"}[30s])",
           "legendFormat": "Pinning/s"
         }
       ]
@@ -1913,14 +2907,14 @@
         "h": 7,
         "w": 6,
         "x": 12,
-        "y": 52
+        "y": 57
       },
       "id": 214,
       "title": "GC Pauses / min",
       "type": "timeseries",
       "targets": [
         {
-          "expr": "rate(argus_gc_events_total[1m]) * 60",
+          "expr": "rate(argus_gc_events_total{namespace=~\"$namespace\",deployment=~\"$deployment\",pod=~\"$pod\",instance=~\"$instance\"}[1m]) * 60",
           "legendFormat": "GC/min"
         }
       ]
@@ -1965,14 +2959,14 @@
         "h": 7,
         "w": 6,
         "x": 18,
-        "y": 52
+        "y": 57
       },
       "id": 215,
       "title": "Metaspace Usage %",
       "type": "timeseries",
       "targets": [
         {
-          "expr": "argus_metaspace_used_bytes / (argus_metaspace_committed_bytes > 0 or 1)",
+          "expr": "argus_metaspace_used_bytes{namespace=~\"$namespace\",deployment=~\"$deployment\",pod=~\"$pod\",instance=~\"$instance\"} / (argus_metaspace_committed_bytes{namespace=~\"$namespace\",deployment=~\"$deployment\",pod=~\"$pod\",instance=~\"$instance\"} > 0 or 1)",
           "legendFormat": "Metaspace %"
         }
       ]
@@ -1983,10 +2977,10 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 59
+        "y": 64
       },
       "id": 216,
-      "title": "\ud83d\udcca Comparison & Capacity",
+      "title": "📊 Comparison & Capacity",
       "type": "row"
     },
     {
@@ -2006,7 +3000,7 @@
         "h": 8,
         "w": 6,
         "x": 0,
-        "y": 60
+        "y": 65
       },
       "id": 217,
       "options": {
@@ -2028,15 +3022,15 @@
       "type": "piechart",
       "targets": [
         {
-          "expr": "argus_heap_used_bytes",
+          "expr": "argus_heap_used_bytes{namespace=~\"$namespace\",deployment=~\"$deployment\",pod=~\"$pod\",instance=~\"$instance\"}",
           "legendFormat": "Heap Used"
         },
         {
-          "expr": "argus_heap_committed_bytes - argus_heap_used_bytes",
+          "expr": "argus_heap_committed_bytes{namespace=~\"$namespace\",deployment=~\"$deployment\",pod=~\"$pod\",instance=~\"$instance\"} - argus_heap_used_bytes{namespace=~\"$namespace\",deployment=~\"$deployment\",pod=~\"$pod\",instance=~\"$instance\"}",
           "legendFormat": "Heap Free"
         },
         {
-          "expr": "argus_metaspace_used_bytes",
+          "expr": "argus_metaspace_used_bytes{namespace=~\"$namespace\",deployment=~\"$deployment\",pod=~\"$pod\",instance=~\"$instance\"}",
           "legendFormat": "Metaspace"
         }
       ]
@@ -2073,7 +3067,7 @@
         "h": 8,
         "w": 6,
         "x": 6,
-        "y": 60
+        "y": 65
       },
       "id": 218,
       "options": {
@@ -2090,7 +3084,7 @@
       "type": "gauge",
       "targets": [
         {
-          "expr": "argus_gc_overhead_ratio",
+          "expr": "argus_gc_overhead_ratio{namespace=~\"$namespace\",deployment=~\"$deployment\",pod=~\"$pod\",instance=~\"$instance\"}",
           "legendFormat": "GC Budget"
         }
       ]
@@ -2120,7 +3114,7 @@
         "h": 8,
         "w": 6,
         "x": 12,
-        "y": 60
+        "y": 65
       },
       "id": 219,
       "options": {
@@ -2136,11 +3130,11 @@
       "type": "timeseries",
       "targets": [
         {
-          "expr": "argus_gc_allocation_rate_kbps",
+          "expr": "argus_gc_allocation_rate_kbps{namespace=~\"$namespace\",deployment=~\"$deployment\",pod=~\"$pod\",instance=~\"$instance\"}",
           "legendFormat": "Allocation KB/s"
         },
         {
-          "expr": "argus_gc_promotion_rate_kbps",
+          "expr": "argus_gc_promotion_rate_kbps{namespace=~\"$namespace\",deployment=~\"$deployment\",pod=~\"$pod\",instance=~\"$instance\"}",
           "legendFormat": "Promotion KB/s"
         }
       ]
@@ -2175,7 +3169,7 @@
         "h": 4,
         "w": 6,
         "x": 18,
-        "y": 60
+        "y": 65
       },
       "id": 220,
       "options": {
@@ -2192,8 +3186,40 @@
       "type": "stat",
       "targets": [
         {
-          "expr": "argus_scrape_duration_seconds",
+          "expr": "argus_scrape_duration_seconds{namespace=~\"$namespace\",deployment=~\"$deployment\",pod=~\"$pod\",instance=~\"$instance\"}",
           "legendFormat": ""
+        }
+      ],
+      "links": [
+        {
+          "title": "Fleet",
+          "url": "/fleet.html",
+          "targetBlank": true
+        },
+        {
+          "title": "Selected pod dashboard",
+          "url": "/?pod=${__field.labels.pod}",
+          "targetBlank": true
+        },
+        {
+          "title": "Profiles CPU",
+          "url": "/profiles.html?pod=${__field.labels.pod}&event=cpu&range=3600",
+          "targetBlank": true
+        },
+        {
+          "title": "Profiles allocation",
+          "url": "/profiles.html?pod=${__field.labels.pod}&event=alloc&range=3600",
+          "targetBlank": true
+        },
+        {
+          "title": "Console",
+          "url": "/console.html?pod=${__field.labels.pod}",
+          "targetBlank": true
+        },
+        {
+          "title": "Prometheus scrape",
+          "url": "/prometheus",
+          "targetBlank": true
         }
       ]
     },
@@ -2209,7 +3235,7 @@
         "h": 4,
         "w": 6,
         "x": 18,
-        "y": 64
+        "y": 69
       },
       "id": 221,
       "options": {
@@ -2222,7 +3248,7 @@
       "type": "table",
       "targets": [
         {
-          "expr": "argus_build_info",
+          "expr": "argus_build_info{namespace=~\"$namespace\",deployment=~\"$deployment\",pod=~\"$pod\",instance=~\"$instance\"}",
           "legendFormat": "",
           "format": "table",
           "instant": true
@@ -2242,6 +3268,662 @@
               "jdk_version": "JDK"
             }
           }
+        }
+      ],
+      "links": [
+        {
+          "title": "Fleet",
+          "url": "/fleet.html",
+          "targetBlank": true
+        },
+        {
+          "title": "Selected pod dashboard",
+          "url": "/?pod=${__field.labels.pod}",
+          "targetBlank": true
+        },
+        {
+          "title": "Profiles CPU",
+          "url": "/profiles.html?pod=${__field.labels.pod}&event=cpu&range=3600",
+          "targetBlank": true
+        },
+        {
+          "title": "Profiles allocation",
+          "url": "/profiles.html?pod=${__field.labels.pod}&event=alloc&range=3600",
+          "targetBlank": true
+        },
+        {
+          "title": "Console",
+          "url": "/console.html?pod=${__field.labels.pod}",
+          "targetBlank": true
+        },
+        {
+          "title": "Prometheus scrape",
+          "url": "/prometheus",
+          "targetBlank": true
+        }
+      ]
+    },
+    {
+      "collapsed": false,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 74
+      },
+      "id": 229,
+      "panels": [],
+      "title": "GC Pause Percentiles",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "custom": {
+            "fillOpacity": 10,
+            "lineWidth": 2,
+            "showPoints": "never"
+          },
+          "color": {
+            "mode": "palette-classic"
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 0,
+        "y": 75
+      },
+      "id": 230,
+      "options": {
+        "tooltip": {
+          "mode": "multi"
+        },
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        }
+      },
+      "title": "GC Pause p50/p95/p99",
+      "type": "timeseries",
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.50, sum(rate(argus_gc_pause_seconds_bucket{namespace=~\"$namespace\",deployment=~\"$deployment\",pod=~\"$pod\",instance=~\"$instance\"}[5m])) by (le)) or histogram_quantile(0.50, sum(rate(jvm_gc_duration_seconds_bucket{namespace=~\"$namespace\",deployment=~\"$deployment\",pod=~\"$pod\",instance=~\"$instance\"}[5m])) by (le))",
+          "legendFormat": "p50"
+        },
+        {
+          "expr": "histogram_quantile(0.95, sum(rate(argus_gc_pause_seconds_bucket{namespace=~\"$namespace\",deployment=~\"$deployment\",pod=~\"$pod\",instance=~\"$instance\"}[5m])) by (le)) or histogram_quantile(0.95, sum(rate(jvm_gc_duration_seconds_bucket{namespace=~\"$namespace\",deployment=~\"$deployment\",pod=~\"$pod\",instance=~\"$instance\"}[5m])) by (le))",
+          "legendFormat": "p95"
+        },
+        {
+          "expr": "histogram_quantile(0.99, sum(rate(argus_gc_pause_seconds_bucket{namespace=~\"$namespace\",deployment=~\"$deployment\",pod=~\"$pod\",instance=~\"$instance\"}[5m])) by (le)) or histogram_quantile(0.99, sum(rate(jvm_gc_duration_seconds_bucket{namespace=~\"$namespace\",deployment=~\"$deployment\",pod=~\"$pod\",instance=~\"$instance\"}[5m])) by (le))",
+          "legendFormat": "p99"
+        }
+      ],
+      "links": [
+        {
+          "title": "Fleet",
+          "url": "/fleet.html",
+          "targetBlank": true
+        },
+        {
+          "title": "Selected pod dashboard",
+          "url": "/?pod=${__field.labels.pod}",
+          "targetBlank": true
+        },
+        {
+          "title": "Profiles CPU",
+          "url": "/profiles.html?pod=${__field.labels.pod}&event=cpu&range=3600",
+          "targetBlank": true
+        },
+        {
+          "title": "Profiles allocation",
+          "url": "/profiles.html?pod=${__field.labels.pod}&event=alloc&range=3600",
+          "targetBlank": true
+        },
+        {
+          "title": "Console",
+          "url": "/console.html?pod=${__field.labels.pod}",
+          "targetBlank": true
+        },
+        {
+          "title": "Prometheus scrape",
+          "url": "/prometheus",
+          "targetBlank": true
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "custom": {
+            "fillOpacity": 10,
+            "lineWidth": 2,
+            "showPoints": "never"
+          },
+          "color": {
+            "mode": "palette-classic"
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 12,
+        "y": 75
+      },
+      "id": 231,
+      "options": {
+        "tooltip": {
+          "mode": "multi"
+        },
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        }
+      },
+      "title": "GC Pause By Collector/Cause",
+      "type": "timeseries",
+      "targets": [
+        {
+          "expr": "topk(10, rate(argus_gc_pause_breakdown_seconds_total{namespace=~\"$namespace\",deployment=~\"$deployment\",pod=~\"$pod\",instance=~\"$instance\"}[5m]))",
+          "legendFormat": "{{gc_name}} / {{gc_cause}}"
+        }
+      ],
+      "links": [
+        {
+          "title": "Fleet",
+          "url": "/fleet.html",
+          "targetBlank": true
+        },
+        {
+          "title": "Selected pod dashboard",
+          "url": "/?pod=${__field.labels.pod}",
+          "targetBlank": true
+        },
+        {
+          "title": "Profiles CPU",
+          "url": "/profiles.html?pod=${__field.labels.pod}&event=cpu&range=3600",
+          "targetBlank": true
+        },
+        {
+          "title": "Profiles allocation",
+          "url": "/profiles.html?pod=${__field.labels.pod}&event=alloc&range=3600",
+          "targetBlank": true
+        },
+        {
+          "title": "Console",
+          "url": "/console.html?pod=${__field.labels.pod}",
+          "targetBlank": true
+        },
+        {
+          "title": "Prometheus scrape",
+          "url": "/prometheus",
+          "targetBlank": true
+        }
+      ]
+    },
+    {
+      "collapsed": false,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 82
+      },
+      "id": 232,
+      "panels": [],
+      "title": "Allocation, Contention & Profiling",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "Bps",
+          "custom": {
+            "fillOpacity": 10,
+            "lineWidth": 2,
+            "showPoints": "never"
+          },
+          "color": {
+            "mode": "palette-classic"
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 0,
+        "y": 83
+      },
+      "id": 233,
+      "options": {
+        "tooltip": {
+          "mode": "multi"
+        },
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        }
+      },
+      "title": "Allocation Throughput",
+      "type": "timeseries",
+      "targets": [
+        {
+          "expr": "sum(argus_allocation_rate_bytes_per_second{namespace=~\"$namespace\",deployment=~\"$deployment\",pod=~\"$pod\",instance=~\"$instance\"})",
+          "legendFormat": "Allocation rate"
+        },
+        {
+          "expr": "rate(argus_allocation_bytes_total{namespace=~\"$namespace\",deployment=~\"$deployment\",pod=~\"$pod\",instance=~\"$instance\"}[5m])",
+          "legendFormat": "Bytes allocated rate"
+        }
+      ],
+      "links": [
+        {
+          "title": "Fleet",
+          "url": "/fleet.html",
+          "targetBlank": true
+        },
+        {
+          "title": "Selected pod dashboard",
+          "url": "/?pod=${__field.labels.pod}",
+          "targetBlank": true
+        },
+        {
+          "title": "Profiles CPU",
+          "url": "/profiles.html?pod=${__field.labels.pod}&event=cpu&range=3600",
+          "targetBlank": true
+        },
+        {
+          "title": "Profiles allocation",
+          "url": "/profiles.html?pod=${__field.labels.pod}&event=alloc&range=3600",
+          "targetBlank": true
+        },
+        {
+          "title": "Console",
+          "url": "/console.html?pod=${__field.labels.pod}",
+          "targetBlank": true
+        },
+        {
+          "title": "Prometheus scrape",
+          "url": "/prometheus",
+          "targetBlank": true
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 8,
+        "y": 83
+      },
+      "id": 234,
+      "options": {
+        "showHeader": true,
+        "footer": {
+          "show": false
+        }
+      },
+      "title": "Top Allocating Classes",
+      "type": "table",
+      "targets": [
+        {
+          "expr": "topk(10, argus_allocation_class_bytes{namespace=~\"$namespace\",deployment=~\"$deployment\",pod=~\"$pod\",instance=~\"$instance\"})",
+          "format": "table",
+          "instant": true,
+          "legendFormat": ""
+        }
+      ],
+      "links": [
+        {
+          "title": "Fleet",
+          "url": "/fleet.html",
+          "targetBlank": true
+        },
+        {
+          "title": "Selected pod dashboard",
+          "url": "/?pod=${__field.labels.pod}",
+          "targetBlank": true
+        },
+        {
+          "title": "Profiles CPU",
+          "url": "/profiles.html?pod=${__field.labels.pod}&event=cpu&range=3600",
+          "targetBlank": true
+        },
+        {
+          "title": "Profiles allocation",
+          "url": "/profiles.html?pod=${__field.labels.pod}&event=alloc&range=3600",
+          "targetBlank": true
+        },
+        {
+          "title": "Console",
+          "url": "/console.html?pod=${__field.labels.pod}",
+          "targetBlank": true
+        },
+        {
+          "title": "Prometheus scrape",
+          "url": "/prometheus",
+          "targetBlank": true
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "custom": {
+            "fillOpacity": 10,
+            "lineWidth": 2,
+            "showPoints": "never"
+          },
+          "color": {
+            "mode": "palette-classic"
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 16,
+        "y": 83
+      },
+      "id": 235,
+      "options": {
+        "tooltip": {
+          "mode": "multi"
+        },
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        }
+      },
+      "title": "Contention Events & Time",
+      "type": "timeseries",
+      "targets": [
+        {
+          "expr": "sum(rate(argus_contention_events_total{namespace=~\"$namespace\",deployment=~\"$deployment\",pod=~\"$pod\",instance=~\"$instance\"}[5m]))",
+          "legendFormat": "events/s"
+        },
+        {
+          "expr": "sum(rate(argus_contention_time_seconds_total{namespace=~\"$namespace\",deployment=~\"$deployment\",pod=~\"$pod\",instance=~\"$instance\"}[5m]))",
+          "legendFormat": "seconds/s"
+        }
+      ],
+      "links": [
+        {
+          "title": "Fleet",
+          "url": "/fleet.html",
+          "targetBlank": true
+        },
+        {
+          "title": "Selected pod dashboard",
+          "url": "/?pod=${__field.labels.pod}",
+          "targetBlank": true
+        },
+        {
+          "title": "Profiles CPU",
+          "url": "/profiles.html?pod=${__field.labels.pod}&event=cpu&range=3600",
+          "targetBlank": true
+        },
+        {
+          "title": "Profiles allocation",
+          "url": "/profiles.html?pod=${__field.labels.pod}&event=alloc&range=3600",
+          "targetBlank": true
+        },
+        {
+          "title": "Console",
+          "url": "/console.html?pod=${__field.labels.pod}",
+          "targetBlank": true
+        },
+        {
+          "title": "Prometheus scrape",
+          "url": "/prometheus",
+          "targetBlank": true
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 0,
+        "y": 90
+      },
+      "id": 236,
+      "options": {
+        "showHeader": true,
+        "footer": {
+          "show": false
+        }
+      },
+      "title": "Top Contention Hotspots",
+      "type": "table",
+      "targets": [
+        {
+          "expr": "topk(10, argus_contention_hotspot_events{namespace=~\"$namespace\",deployment=~\"$deployment\",pod=~\"$pod\",instance=~\"$instance\"})",
+          "format": "table",
+          "instant": true,
+          "legendFormat": ""
+        }
+      ],
+      "links": [
+        {
+          "title": "Fleet",
+          "url": "/fleet.html",
+          "targetBlank": true
+        },
+        {
+          "title": "Selected pod dashboard",
+          "url": "/?pod=${__field.labels.pod}",
+          "targetBlank": true
+        },
+        {
+          "title": "Profiles CPU",
+          "url": "/profiles.html?pod=${__field.labels.pod}&event=cpu&range=3600",
+          "targetBlank": true
+        },
+        {
+          "title": "Profiles allocation",
+          "url": "/profiles.html?pod=${__field.labels.pod}&event=alloc&range=3600",
+          "targetBlank": true
+        },
+        {
+          "title": "Console",
+          "url": "/console.html?pod=${__field.labels.pod}",
+          "targetBlank": true
+        },
+        {
+          "title": "Prometheus scrape",
+          "url": "/prometheus",
+          "targetBlank": true
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "fillOpacity": 10,
+            "lineWidth": 2,
+            "showPoints": "never"
+          },
+          "color": {
+            "mode": "palette-classic"
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 8,
+        "y": 90
+      },
+      "id": 237,
+      "options": {
+        "tooltip": {
+          "mode": "multi"
+        },
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        }
+      },
+      "title": "Profiling Sample Rate",
+      "type": "timeseries",
+      "targets": [
+        {
+          "expr": "sum(rate(argus_profiling_samples_total{namespace=~\"$namespace\",deployment=~\"$deployment\",pod=~\"$pod\",instance=~\"$instance\"}[5m]))",
+          "legendFormat": "samples/s"
+        }
+      ],
+      "links": [
+        {
+          "title": "Fleet",
+          "url": "/fleet.html",
+          "targetBlank": true
+        },
+        {
+          "title": "Selected pod dashboard",
+          "url": "/?pod=${__field.labels.pod}",
+          "targetBlank": true
+        },
+        {
+          "title": "Profiles CPU",
+          "url": "/profiles.html?pod=${__field.labels.pod}&event=cpu&range=3600",
+          "targetBlank": true
+        },
+        {
+          "title": "Profiles allocation",
+          "url": "/profiles.html?pod=${__field.labels.pod}&event=alloc&range=3600",
+          "targetBlank": true
+        },
+        {
+          "title": "Console",
+          "url": "/console.html?pod=${__field.labels.pod}",
+          "targetBlank": true
+        },
+        {
+          "title": "Prometheus scrape",
+          "url": "/prometheus",
+          "targetBlank": true
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 16,
+        "y": 90
+      },
+      "id": 238,
+      "options": {
+        "showHeader": true,
+        "footer": {
+          "show": false
+        }
+      },
+      "title": "Top Profiled Methods",
+      "type": "table",
+      "targets": [
+        {
+          "expr": "topk(10, argus_profiling_method_samples{namespace=~\"$namespace\",deployment=~\"$deployment\",pod=~\"$pod\",instance=~\"$instance\"})",
+          "format": "table",
+          "instant": true,
+          "legendFormat": ""
+        }
+      ],
+      "links": [
+        {
+          "title": "Fleet",
+          "url": "/fleet.html",
+          "targetBlank": true
+        },
+        {
+          "title": "Selected pod dashboard",
+          "url": "/?pod=${__field.labels.pod}",
+          "targetBlank": true
+        },
+        {
+          "title": "Profiles CPU",
+          "url": "/profiles.html?pod=${__field.labels.pod}&event=cpu&range=3600",
+          "targetBlank": true
+        },
+        {
+          "title": "Profiles allocation",
+          "url": "/profiles.html?pod=${__field.labels.pod}&event=alloc&range=3600",
+          "targetBlank": true
+        },
+        {
+          "title": "Console",
+          "url": "/console.html?pod=${__field.labels.pod}",
+          "targetBlank": true
+        },
+        {
+          "title": "Prometheus scrape",
+          "url": "/prometheus",
+          "targetBlank": true
         }
       ]
     }
@@ -2274,6 +3956,106 @@
         "regex": "",
         "skipUrlSync": false,
         "type": "datasource"
+      },
+      {
+        "allValue": ".*",
+        "current": {
+          "selected": false,
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${datasource}"
+        },
+        "definition": "label_values(argus_build_info, namespace)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Namespace",
+        "multi": true,
+        "name": "namespace",
+        "options": [],
+        "query": "label_values(argus_build_info, namespace)",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "allValue": ".*",
+        "current": {
+          "selected": false,
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${datasource}"
+        },
+        "definition": "label_values(argus_build_info{namespace=~\"$namespace\"}, deployment)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Deployment",
+        "multi": true,
+        "name": "deployment",
+        "options": [],
+        "query": "label_values(argus_build_info{namespace=~\"$namespace\"}, deployment)",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "allValue": ".*",
+        "current": {
+          "selected": false,
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${datasource}"
+        },
+        "definition": "label_values(argus_build_info{namespace=~\"$namespace\",deployment=~\"$deployment\"}, pod)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Pod",
+        "multi": true,
+        "name": "pod",
+        "options": [],
+        "query": "label_values(argus_build_info{namespace=~\"$namespace\",deployment=~\"$deployment\"}, pod)",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "allValue": ".*",
+        "current": {
+          "selected": false,
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${datasource}"
+        },
+        "definition": "label_values(argus_build_info{namespace=~\"$namespace\",deployment=~\"$deployment\",pod=~\"$pod\"}, instance)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Instance",
+        "multi": true,
+        "name": "instance",
+        "options": [],
+        "query": "label_values(argus_build_info{namespace=~\"$namespace\",deployment=~\"$deployment\",pod=~\"$pod\"}, instance)",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "type": "query"
       }
     ]
   },

--- a/docs/dashboard-contract.md
+++ b/docs/dashboard-contract.md
@@ -1,0 +1,97 @@
+# Dashboard Metric Contract
+
+This file is the shared contract for the Grafana dashboard and the local Argus
+dashboard. Keep it in sync with `PrometheusMetricsCollector`, the local REST
+handlers, and `docs/grafana-dashboard.json`.
+
+## Surfaces
+
+| Surface | Window | Source | Primary use |
+|---|---:|---|---|
+| Grafana | minutes to days | `/prometheus` or OpenMetrics scrape | Fleet-wide trends, alerting, and capacity review |
+| Local dashboard | seconds to minutes | Netty REST endpoints plus WebSocket events | Live JVM triage and selected-pod drilldown |
+| Fleet | latest scrape | Aggregator scrape cache | Find unhealthy pods and route to drilldowns |
+| Profiles | selected window | `/profile/query` and `/profile/diff` | Explain CPU, allocation, lock, and wall-time hotspots |
+| Console | point-in-time | `/api/commands` and `/api/exec` | Run JVM diagnostics against the selected process or pod |
+
+## Labels
+
+Argus metrics can carry Kubernetes identity labels when the process has the
+corresponding environment variables. Grafana variables must keep an `All`
+option so the same dashboard works for local scrapes with no Kubernetes labels.
+
+| Label | Source | Notes |
+|---|---|---|
+| `namespace` | Kubernetes metadata | Optional; empty in local mode |
+| `deployment` | Kubernetes metadata | Optional; may be absent for naked pods |
+| `pod` | Kubernetes metadata | Optional; used for local drilldown links |
+| `instance` | Prometheus scrape target | Available from Prometheus, not emitted by Argus itself |
+| `version` | `argus_build_info` | Argus implementation version or `dev` |
+| `jdk_version` | `argus_build_info` | Runtime JVM version |
+
+## Metrics
+
+| Domain | Prometheus metric | Labels | Local API equivalent | Owner |
+|---|---|---|---|---|
+| Build | `argus_build_info` | `version`, `jdk_version`, optional K8s labels | `/config` runtime block | `argus-server` |
+| Scrape health | `argus_scrape_duration_seconds` | optional K8s labels | aggregator scrape status in `/fleet/list` | `argus-server` |
+| JVM memory | `jvm_memory_used_bytes` | `jvm_memory_pool_name`, optional K8s labels | `/gc-analysis`, `/metaspace-metrics` | `argus-server` |
+| JVM memory | `jvm_memory_committed_bytes` | `jvm_memory_pool_name`, optional K8s labels | `/gc-analysis`, `/metaspace-metrics` | `argus-server` |
+| JVM memory | `jvm_memory_used_after_last_gc_bytes` | `jvm_memory_pool_name`, optional K8s labels | `/gc-analysis` | `argus-server` |
+| JVM GC | `jvm_gc_duration_seconds` | histogram `le`, optional K8s labels | `/gc-analysis` pause histogram | `argus-server` |
+| JVM CPU | `jvm_cpu_recent_utilization_ratio` | optional K8s labels | `/cpu-metrics` | `argus-server` |
+| JVM threads | `jvm_thread_count` | optional K8s labels | `/metrics`, `/active-threads` | `argus-server` |
+| JVM classes | `jvm_class_count` | optional K8s labels | `/metaspace-metrics` | `argus-server` |
+| Legacy heap | `argus_heap_used_bytes` | optional K8s labels | `/gc-analysis` | `argus-server` |
+| Legacy heap | `argus_heap_committed_bytes` | optional K8s labels | `/gc-analysis` | `argus-server` |
+| Heap pressure | `argus_heap_usage_ratio` | optional K8s labels | `/gc-analysis` | `argus-server` |
+| GC events | `argus_gc_events_total` | optional K8s labels | `/gc-analysis` | `argus-server` |
+| GC pause | `argus_gc_pause_time_seconds_total` | optional K8s labels | `/gc-analysis` | `argus-server` |
+| GC pause | `argus_gc_pause_time_seconds_max` | optional K8s labels | `/gc-analysis` | `argus-server` |
+| GC pause | `argus_gc_pause_time_seconds_avg` | optional K8s labels | `/gc-analysis` | `argus-server` |
+| GC pause histogram | `argus_gc_pause_seconds` | histogram `le`, optional K8s labels | `/gc-analysis` pause histogram | `argus-server` |
+| GC pressure | `argus_gc_overhead_ratio` | optional K8s labels | `/gc-analysis` | `argus-server` |
+| GC pressure | `argus_gc_overhead_warning` | optional K8s labels | `/gc-analysis` | `argus-server` |
+| GC allocation | `argus_gc_allocation_rate_kbps` | optional K8s labels | `/gc-analysis` | `argus-server` |
+| GC promotion | `argus_gc_promotion_rate_kbps` | optional K8s labels | `/gc-analysis` | `argus-server` |
+| Leak detection | `argus_gc_leak_suspected` | optional K8s labels | `/gc-analysis` | `argus-server` |
+| Leak detection | `argus_gc_leak_confidence` | optional K8s labels | `/gc-analysis` | `argus-server` |
+| GC breakdown | `argus_gc_pause_breakdown_seconds_total` | `gc_name`, `gc_cause`, optional K8s labels | `/gc-analysis` collector breakdown | `argus-server` |
+| GC breakdown | `argus_gc_events_breakdown_total` | `gc_name`, `gc_cause`, optional K8s labels | `/gc-analysis` collector breakdown | `argus-server` |
+| Virtual threads | `argus_virtual_threads_started_total` | optional K8s labels | `/metrics`, WebSocket events | `argus-server` |
+| Virtual threads | `argus_virtual_threads_ended_total` | optional K8s labels | `/metrics`, WebSocket events | `argus-server` |
+| Virtual threads | `argus_virtual_threads_submit_failed_total` | optional K8s labels | `/metrics`, WebSocket events | `argus-server` |
+| Virtual threads | `argus_virtual_threads_active` | optional K8s labels | `/metrics`, `/active-threads` | `argus-server` |
+| Pinning | `argus_virtual_threads_pinned_total` | optional K8s labels | `/pinning-analysis` | `argus-server` |
+| Pinning | `argus_virtual_threads_pinned_unique_stacks` | optional K8s labels | `/pinning-analysis` | `argus-server` |
+| Carriers | `argus_carrier_threads` | optional K8s labels | `/carrier-threads` | `argus-server` |
+| Carriers | `argus_carrier_threads_virtual_handled_total` | optional K8s labels | `/carrier-threads` | `argus-server` |
+| Carriers | `argus_carrier_threads_avg_per_carrier` | optional K8s labels | `/carrier-threads` | `argus-server` |
+| Legacy CPU | `argus_cpu_jvm_user_ratio` | optional K8s labels | `/cpu-metrics` | `argus-server` |
+| Legacy CPU | `argus_cpu_jvm_system_ratio` | optional K8s labels | `/cpu-metrics` | `argus-server` |
+| Legacy CPU | `argus_cpu_machine_total_ratio` | optional K8s labels | `/cpu-metrics` | `argus-server` |
+| Metaspace | `argus_metaspace_reserved_bytes` | optional K8s labels | `/metaspace-metrics` | `argus-server` |
+| Legacy metaspace | `argus_metaspace_used_bytes` | optional K8s labels | `/metaspace-metrics` | `argus-server` |
+| Legacy metaspace | `argus_metaspace_committed_bytes` | optional K8s labels | `/metaspace-metrics` | `argus-server` |
+| Legacy metaspace | `argus_metaspace_classes_loaded` | optional K8s labels | `/metaspace-metrics` | `argus-server` |
+| Allocation | `argus_allocation_total` | optional K8s labels | `/allocation-analysis` | `argus-server` |
+| Allocation | `argus_allocation_bytes_total` | optional K8s labels | `/allocation-analysis` | `argus-server` |
+| Allocation | `argus_allocation_rate_bytes_per_second` | optional K8s labels | `/allocation-analysis` | `argus-server` |
+| Allocation | `argus_allocation_class_bytes` | `class`, optional K8s labels | `/allocation-analysis` top classes | `argus-server` |
+| Contention | `argus_contention_events_total` | optional K8s labels | `/contention-analysis` | `argus-server` |
+| Contention | `argus_contention_time_seconds_total` | optional K8s labels | `/contention-analysis` | `argus-server` |
+| Contention | `argus_contention_hotspot_events` | `monitor`, optional K8s labels | `/contention-analysis` hotspots | `argus-server` |
+| Profiling | `argus_profiling_samples_total` | optional K8s labels | `/method-profiling`, `/flame-graph` | `argus-server` |
+| Profiling | `argus_profiling_method_samples` | `class`, `method`, optional K8s labels | `/method-profiling` top methods | `argus-server` |
+
+## Maintenance Rules
+
+- Add a row here before adding a Grafana panel that references a new metric.
+- Keep Grafana variables optional and `includeAll=true` for fleet labels.
+- Apply `namespace`, `deployment`, `pod`, and `instance` variable matchers to
+  every Grafana metric selector so fleet filters affect panel data and local
+  unlabeled scrapes still match the `All` regex.
+- Prefer semconv `jvm_*` names for standard JVM signals; keep `argus_*` for
+  Argus-specific diagnostics and legacy compatibility.
+- Drilldown links should preserve pod context with `pod`, `event`, and `range`
+  query parameters where applicable.

--- a/docs/grafana-dashboard.json
+++ b/docs/grafana-dashboard.json
@@ -15,12 +15,97 @@
       }
     ]
   },
-  "description": "Argus JVM Observability Platform \u2014 Production-grade monitoring for Virtual Threads, GC, Memory, CPU, and Application Health",
+  "description": "Argus JVM Observability Platform — Production-grade monitoring for Virtual Threads, GC, Memory, CPU, and Application Health",
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 2,
   "id": null,
-  "links": [],
+  "links": [
+    {
+      "asDropdown": false,
+      "icon": "external link",
+      "includeVars": true,
+      "keepTime": true,
+      "tags": [],
+      "targetBlank": true,
+      "title": "Fleet",
+      "tooltip": "Open Argus Fleet view",
+      "type": "link",
+      "url": "/fleet.html"
+    },
+    {
+      "asDropdown": false,
+      "icon": "external link",
+      "includeVars": true,
+      "keepTime": true,
+      "tags": [],
+      "targetBlank": true,
+      "title": "Selected Pod Dashboard",
+      "tooltip": "Open selected pod in the local dashboard snapshot view",
+      "type": "link",
+      "url": "/?pod=${pod}"
+    },
+    {
+      "asDropdown": false,
+      "icon": "external link",
+      "includeVars": true,
+      "keepTime": true,
+      "tags": [],
+      "targetBlank": true,
+      "title": "Profiles CPU",
+      "tooltip": "Open CPU profiles for selected pod",
+      "type": "link",
+      "url": "/profiles.html?pod=${pod}&event=cpu&range=3600"
+    },
+    {
+      "asDropdown": false,
+      "icon": "external link",
+      "includeVars": true,
+      "keepTime": true,
+      "tags": [],
+      "targetBlank": true,
+      "title": "Profiles Allocation",
+      "tooltip": "Open allocation profiles for selected pod",
+      "type": "link",
+      "url": "/profiles.html?pod=${pod}&event=alloc&range=3600"
+    },
+    {
+      "asDropdown": false,
+      "icon": "external link",
+      "includeVars": true,
+      "keepTime": false,
+      "tags": [],
+      "targetBlank": true,
+      "title": "Console",
+      "tooltip": "Run commands against selected pod",
+      "type": "link",
+      "url": "/console.html?pod=${pod}"
+    },
+    {
+      "asDropdown": false,
+      "icon": "external link",
+      "includeVars": false,
+      "keepTime": false,
+      "tags": [],
+      "targetBlank": true,
+      "title": "Prometheus Scrape",
+      "tooltip": "Open raw scrape endpoint",
+      "type": "link",
+      "url": "/prometheus"
+    },
+    {
+      "asDropdown": false,
+      "icon": "doc",
+      "includeVars": false,
+      "keepTime": false,
+      "tags": [],
+      "targetBlank": true,
+      "title": "Kubernetes Setup",
+      "tooltip": "Open setup documentation",
+      "type": "link",
+      "url": "docs/kubernetes.md"
+    }
+  ],
   "liveNow": true,
   "panels": [
     {
@@ -32,7 +117,7 @@
         "y": 0
       },
       "id": 200,
-      "title": "\ud83d\udd34 Health Overview",
+      "title": "🔴 Health Overview",
       "type": "row"
     },
     {
@@ -51,7 +136,7 @@
                 },
                 "1": {
                   "color": "red",
-                  "text": "\u26a0 LEAK"
+                  "text": "⚠ LEAK"
                 }
               },
               "type": "value"
@@ -92,8 +177,40 @@
       "type": "stat",
       "targets": [
         {
-          "expr": "argus_gc_leak_suspected",
+          "expr": "argus_gc_leak_suspected{namespace=~\"$namespace\",deployment=~\"$deployment\",pod=~\"$pod\",instance=~\"$instance\"}",
           "legendFormat": ""
+        }
+      ],
+      "links": [
+        {
+          "title": "Fleet",
+          "url": "/fleet.html",
+          "targetBlank": true
+        },
+        {
+          "title": "Selected pod dashboard",
+          "url": "/?pod=${__field.labels.pod}",
+          "targetBlank": true
+        },
+        {
+          "title": "Profiles CPU",
+          "url": "/profiles.html?pod=${__field.labels.pod}&event=cpu&range=3600",
+          "targetBlank": true
+        },
+        {
+          "title": "Profiles allocation",
+          "url": "/profiles.html?pod=${__field.labels.pod}&event=alloc&range=3600",
+          "targetBlank": true
+        },
+        {
+          "title": "Console",
+          "url": "/console.html?pod=${__field.labels.pod}",
+          "targetBlank": true
+        },
+        {
+          "title": "Prometheus scrape",
+          "url": "/prometheus",
+          "targetBlank": true
         }
       ]
     },
@@ -113,7 +230,7 @@
                 },
                 "1": {
                   "color": "orange",
-                  "text": "\u26a0 HIGH"
+                  "text": "⚠ HIGH"
                 }
               },
               "type": "value"
@@ -154,8 +271,40 @@
       "type": "stat",
       "targets": [
         {
-          "expr": "argus_gc_overhead_warning",
+          "expr": "argus_gc_overhead_warning{namespace=~\"$namespace\",deployment=~\"$deployment\",pod=~\"$pod\",instance=~\"$instance\"}",
           "legendFormat": ""
+        }
+      ],
+      "links": [
+        {
+          "title": "Fleet",
+          "url": "/fleet.html",
+          "targetBlank": true
+        },
+        {
+          "title": "Selected pod dashboard",
+          "url": "/?pod=${__field.labels.pod}",
+          "targetBlank": true
+        },
+        {
+          "title": "Profiles CPU",
+          "url": "/profiles.html?pod=${__field.labels.pod}&event=cpu&range=3600",
+          "targetBlank": true
+        },
+        {
+          "title": "Profiles allocation",
+          "url": "/profiles.html?pod=${__field.labels.pod}&event=alloc&range=3600",
+          "targetBlank": true
+        },
+        {
+          "title": "Console",
+          "url": "/console.html?pod=${__field.labels.pod}",
+          "targetBlank": true
+        },
+        {
+          "title": "Prometheus scrape",
+          "url": "/prometheus",
+          "targetBlank": true
         }
       ]
     },
@@ -208,7 +357,7 @@
       "type": "stat",
       "targets": [
         {
-          "expr": "argus_gc_overhead_ratio",
+          "expr": "argus_gc_overhead_ratio{namespace=~\"$namespace\",deployment=~\"$deployment\",pod=~\"$pod\",instance=~\"$instance\"}",
           "legendFormat": ""
         }
       ]
@@ -260,8 +409,40 @@
       "type": "stat",
       "targets": [
         {
-          "expr": "argus_gc_pause_time_seconds_max",
+          "expr": "argus_gc_pause_time_seconds_max{namespace=~\"$namespace\",deployment=~\"$deployment\",pod=~\"$pod\",instance=~\"$instance\"}",
           "legendFormat": ""
+        }
+      ],
+      "links": [
+        {
+          "title": "Fleet",
+          "url": "/fleet.html",
+          "targetBlank": true
+        },
+        {
+          "title": "Selected pod dashboard",
+          "url": "/?pod=${__field.labels.pod}",
+          "targetBlank": true
+        },
+        {
+          "title": "Profiles CPU",
+          "url": "/profiles.html?pod=${__field.labels.pod}&event=cpu&range=3600",
+          "targetBlank": true
+        },
+        {
+          "title": "Profiles allocation",
+          "url": "/profiles.html?pod=${__field.labels.pod}&event=alloc&range=3600",
+          "targetBlank": true
+        },
+        {
+          "title": "Console",
+          "url": "/console.html?pod=${__field.labels.pod}",
+          "targetBlank": true
+        },
+        {
+          "title": "Prometheus scrape",
+          "url": "/prometheus",
+          "targetBlank": true
         }
       ]
     },
@@ -312,8 +493,40 @@
       "type": "stat",
       "targets": [
         {
-          "expr": "argus_heap_used_bytes",
+          "expr": "argus_heap_used_bytes{namespace=~\"$namespace\",deployment=~\"$deployment\",pod=~\"$pod\",instance=~\"$instance\"}",
           "legendFormat": ""
+        }
+      ],
+      "links": [
+        {
+          "title": "Fleet",
+          "url": "/fleet.html",
+          "targetBlank": true
+        },
+        {
+          "title": "Selected pod dashboard",
+          "url": "/?pod=${__field.labels.pod}",
+          "targetBlank": true
+        },
+        {
+          "title": "Profiles CPU",
+          "url": "/profiles.html?pod=${__field.labels.pod}&event=cpu&range=3600",
+          "targetBlank": true
+        },
+        {
+          "title": "Profiles allocation",
+          "url": "/profiles.html?pod=${__field.labels.pod}&event=alloc&range=3600",
+          "targetBlank": true
+        },
+        {
+          "title": "Console",
+          "url": "/console.html?pod=${__field.labels.pod}",
+          "targetBlank": true
+        },
+        {
+          "title": "Prometheus scrape",
+          "url": "/prometheus",
+          "targetBlank": true
         }
       ]
     },
@@ -366,8 +579,40 @@
       "type": "stat",
       "targets": [
         {
-          "expr": "argus_cpu_jvm_user_ratio + argus_cpu_jvm_system_ratio",
+          "expr": "argus_cpu_jvm_user_ratio{namespace=~\"$namespace\",deployment=~\"$deployment\",pod=~\"$pod\",instance=~\"$instance\"} + argus_cpu_jvm_system_ratio{namespace=~\"$namespace\",deployment=~\"$deployment\",pod=~\"$pod\",instance=~\"$instance\"}",
           "legendFormat": ""
+        }
+      ],
+      "links": [
+        {
+          "title": "Fleet",
+          "url": "/fleet.html",
+          "targetBlank": true
+        },
+        {
+          "title": "Selected pod dashboard",
+          "url": "/?pod=${__field.labels.pod}",
+          "targetBlank": true
+        },
+        {
+          "title": "Profiles CPU",
+          "url": "/profiles.html?pod=${__field.labels.pod}&event=cpu&range=3600",
+          "targetBlank": true
+        },
+        {
+          "title": "Profiles allocation",
+          "url": "/profiles.html?pod=${__field.labels.pod}&event=alloc&range=3600",
+          "targetBlank": true
+        },
+        {
+          "title": "Console",
+          "url": "/console.html?pod=${__field.labels.pod}",
+          "targetBlank": true
+        },
+        {
+          "title": "Prometheus scrape",
+          "url": "/prometheus",
+          "targetBlank": true
         }
       ]
     },
@@ -409,7 +654,7 @@
       "type": "stat",
       "targets": [
         {
-          "expr": "argus_virtual_threads_active",
+          "expr": "argus_virtual_threads_active{namespace=~\"$namespace\",deployment=~\"$deployment\",pod=~\"$pod\",instance=~\"$instance\"}",
           "legendFormat": ""
         }
       ]
@@ -456,8 +701,597 @@
       "type": "stat",
       "targets": [
         {
-          "expr": "argus_virtual_threads_pinned_unique_stacks",
+          "expr": "argus_virtual_threads_pinned_unique_stacks{namespace=~\"$namespace\",deployment=~\"$deployment\",pod=~\"$pod\",instance=~\"$instance\"}",
           "legendFormat": ""
+        }
+      ],
+      "links": [
+        {
+          "title": "Fleet",
+          "url": "/fleet.html",
+          "targetBlank": true
+        },
+        {
+          "title": "Selected pod dashboard",
+          "url": "/?pod=${__field.labels.pod}",
+          "targetBlank": true
+        },
+        {
+          "title": "Profiles CPU",
+          "url": "/profiles.html?pod=${__field.labels.pod}&event=cpu&range=3600",
+          "targetBlank": true
+        },
+        {
+          "title": "Profiles allocation",
+          "url": "/profiles.html?pod=${__field.labels.pod}&event=alloc&range=3600",
+          "targetBlank": true
+        },
+        {
+          "title": "Console",
+          "url": "/console.html?pod=${__field.labels.pod}",
+          "targetBlank": true
+        },
+        {
+          "title": "Prometheus scrape",
+          "url": "/prometheus",
+          "targetBlank": true
+        }
+      ]
+    },
+    {
+      "collapsed": false,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 4
+      },
+      "id": 222,
+      "panels": [],
+      "title": "Incident Triage",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 1
+              },
+              {
+                "color": "red",
+                "value": 3
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 0,
+        "y": 5
+      },
+      "id": 223,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "title": "Pods With GC Warning",
+      "type": "stat",
+      "targets": [
+        {
+          "expr": "sum(argus_gc_overhead_warning{namespace=~\"$namespace\",deployment=~\"$deployment\",pod=~\"$pod\",instance=~\"$instance\"})",
+          "legendFormat": ""
+        }
+      ],
+      "links": [
+        {
+          "title": "Fleet",
+          "url": "/fleet.html",
+          "targetBlank": true
+        },
+        {
+          "title": "Selected pod dashboard",
+          "url": "/?pod=${__field.labels.pod}",
+          "targetBlank": true
+        },
+        {
+          "title": "Profiles CPU",
+          "url": "/profiles.html?pod=${__field.labels.pod}&event=cpu&range=3600",
+          "targetBlank": true
+        },
+        {
+          "title": "Profiles allocation",
+          "url": "/profiles.html?pod=${__field.labels.pod}&event=alloc&range=3600",
+          "targetBlank": true
+        },
+        {
+          "title": "Console",
+          "url": "/console.html?pod=${__field.labels.pod}",
+          "targetBlank": true
+        },
+        {
+          "title": "Prometheus scrape",
+          "url": "/prometheus",
+          "targetBlank": true
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 80
+              },
+              {
+                "color": "red",
+                "value": 90
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 4,
+        "y": 5
+      },
+      "id": 224,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "title": "Max Heap Usage",
+      "type": "stat",
+      "targets": [
+        {
+          "expr": "max(argus_heap_usage_ratio{namespace=~\"$namespace\",deployment=~\"$deployment\",pod=~\"$pod\",instance=~\"$instance\"}) * 100",
+          "legendFormat": ""
+        }
+      ],
+      "links": [
+        {
+          "title": "Fleet",
+          "url": "/fleet.html",
+          "targetBlank": true
+        },
+        {
+          "title": "Selected pod dashboard",
+          "url": "/?pod=${__field.labels.pod}",
+          "targetBlank": true
+        },
+        {
+          "title": "Profiles CPU",
+          "url": "/profiles.html?pod=${__field.labels.pod}&event=cpu&range=3600",
+          "targetBlank": true
+        },
+        {
+          "title": "Profiles allocation",
+          "url": "/profiles.html?pod=${__field.labels.pod}&event=alloc&range=3600",
+          "targetBlank": true
+        },
+        {
+          "title": "Console",
+          "url": "/console.html?pod=${__field.labels.pod}",
+          "targetBlank": true
+        },
+        {
+          "title": "Prometheus scrape",
+          "url": "/prometheus",
+          "targetBlank": true
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 1
+              },
+              {
+                "color": "red",
+                "value": 10
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 8,
+        "y": 5
+      },
+      "id": 225,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "title": "Pinning Rate",
+      "type": "stat",
+      "targets": [
+        {
+          "expr": "sum(rate(argus_virtual_threads_pinned_total{namespace=~\"$namespace\",deployment=~\"$deployment\",pod=~\"$pod\",instance=~\"$instance\"}[5m])) * 60",
+          "legendFormat": ""
+        }
+      ],
+      "links": [
+        {
+          "title": "Fleet",
+          "url": "/fleet.html",
+          "targetBlank": true
+        },
+        {
+          "title": "Selected pod dashboard",
+          "url": "/?pod=${__field.labels.pod}",
+          "targetBlank": true
+        },
+        {
+          "title": "Profiles CPU",
+          "url": "/profiles.html?pod=${__field.labels.pod}&event=cpu&range=3600",
+          "targetBlank": true
+        },
+        {
+          "title": "Profiles allocation",
+          "url": "/profiles.html?pod=${__field.labels.pod}&event=alloc&range=3600",
+          "targetBlank": true
+        },
+        {
+          "title": "Console",
+          "url": "/console.html?pod=${__field.labels.pod}",
+          "targetBlank": true
+        },
+        {
+          "title": "Prometheus scrape",
+          "url": "/prometheus",
+          "targetBlank": true
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "Bps",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 26214400
+              },
+              {
+                "color": "red",
+                "value": 104857600
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 12,
+        "y": 5
+      },
+      "id": 226,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "title": "Allocation Rate",
+      "type": "stat",
+      "targets": [
+        {
+          "expr": "sum(argus_allocation_rate_bytes_per_second{namespace=~\"$namespace\",deployment=~\"$deployment\",pod=~\"$pod\",instance=~\"$instance\"})",
+          "legendFormat": ""
+        }
+      ],
+      "links": [
+        {
+          "title": "Fleet",
+          "url": "/fleet.html",
+          "targetBlank": true
+        },
+        {
+          "title": "Selected pod dashboard",
+          "url": "/?pod=${__field.labels.pod}",
+          "targetBlank": true
+        },
+        {
+          "title": "Profiles CPU",
+          "url": "/profiles.html?pod=${__field.labels.pod}&event=cpu&range=3600",
+          "targetBlank": true
+        },
+        {
+          "title": "Profiles allocation",
+          "url": "/profiles.html?pod=${__field.labels.pod}&event=alloc&range=3600",
+          "targetBlank": true
+        },
+        {
+          "title": "Console",
+          "url": "/console.html?pod=${__field.labels.pod}",
+          "targetBlank": true
+        },
+        {
+          "title": "Prometheus scrape",
+          "url": "/prometheus",
+          "targetBlank": true
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 0.1
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 16,
+        "y": 5
+      },
+      "id": 227,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "title": "Contention Time Rate",
+      "type": "stat",
+      "targets": [
+        {
+          "expr": "sum(rate(argus_contention_time_seconds_total{namespace=~\"$namespace\",deployment=~\"$deployment\",pod=~\"$pod\",instance=~\"$instance\"}[5m]))",
+          "legendFormat": ""
+        }
+      ],
+      "links": [
+        {
+          "title": "Fleet",
+          "url": "/fleet.html",
+          "targetBlank": true
+        },
+        {
+          "title": "Selected pod dashboard",
+          "url": "/?pod=${__field.labels.pod}",
+          "targetBlank": true
+        },
+        {
+          "title": "Profiles CPU",
+          "url": "/profiles.html?pod=${__field.labels.pod}&event=cpu&range=3600",
+          "targetBlank": true
+        },
+        {
+          "title": "Profiles allocation",
+          "url": "/profiles.html?pod=${__field.labels.pod}&event=alloc&range=3600",
+          "targetBlank": true
+        },
+        {
+          "title": "Console",
+          "url": "/console.html?pod=${__field.labels.pod}",
+          "targetBlank": true
+        },
+        {
+          "title": "Prometheus scrape",
+          "url": "/prometheus",
+          "targetBlank": true
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 0.5
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 20,
+        "y": 5
+      },
+      "id": 228,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "title": "Worst Scrape Duration",
+      "type": "stat",
+      "targets": [
+        {
+          "expr": "max(argus_scrape_duration_seconds{namespace=~\"$namespace\",deployment=~\"$deployment\",pod=~\"$pod\",instance=~\"$instance\"})",
+          "legendFormat": ""
+        }
+      ],
+      "links": [
+        {
+          "title": "Fleet",
+          "url": "/fleet.html",
+          "targetBlank": true
+        },
+        {
+          "title": "Selected pod dashboard",
+          "url": "/?pod=${__field.labels.pod}",
+          "targetBlank": true
+        },
+        {
+          "title": "Profiles CPU",
+          "url": "/profiles.html?pod=${__field.labels.pod}&event=cpu&range=3600",
+          "targetBlank": true
+        },
+        {
+          "title": "Profiles allocation",
+          "url": "/profiles.html?pod=${__field.labels.pod}&event=alloc&range=3600",
+          "targetBlank": true
+        },
+        {
+          "title": "Console",
+          "url": "/console.html?pod=${__field.labels.pod}",
+          "targetBlank": true
+        },
+        {
+          "title": "Prometheus scrape",
+          "url": "/prometheus",
+          "targetBlank": true
         }
       ]
     },
@@ -467,10 +1301,10 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 4
+        "y": 9
       },
       "id": 201,
-      "title": "\ud83d\udcca Heap & GC",
+      "title": "📊 Heap & GC",
       "type": "row"
     },
     {
@@ -539,7 +1373,7 @@
         "h": 8,
         "w": 8,
         "x": 0,
-        "y": 5
+        "y": 10
       },
       "id": 10,
       "options": {
@@ -556,11 +1390,11 @@
       "type": "timeseries",
       "targets": [
         {
-          "expr": "argus_heap_used_bytes",
+          "expr": "argus_heap_used_bytes{namespace=~\"$namespace\",deployment=~\"$deployment\",pod=~\"$pod\",instance=~\"$instance\"}",
           "legendFormat": "Used"
         },
         {
-          "expr": "argus_heap_committed_bytes",
+          "expr": "argus_heap_committed_bytes{namespace=~\"$namespace\",deployment=~\"$deployment\",pod=~\"$pod\",instance=~\"$instance\"}",
           "legendFormat": "Committed"
         }
       ]
@@ -618,14 +1452,14 @@
         "h": 8,
         "w": 4,
         "x": 8,
-        "y": 5
+        "y": 10
       },
       "id": 11,
       "title": "Heap Usage %",
       "type": "timeseries",
       "targets": [
         {
-          "expr": "argus_heap_usage_ratio",
+          "expr": "argus_heap_usage_ratio{namespace=~\"$namespace\",deployment=~\"$deployment\",pod=~\"$pod\",instance=~\"$instance\"}",
           "legendFormat": "Heap Usage"
         }
       ]
@@ -681,7 +1515,7 @@
         "h": 8,
         "w": 6,
         "x": 12,
-        "y": 5
+        "y": 10
       },
       "id": 12,
       "options": {
@@ -697,12 +1531,44 @@
       "type": "timeseries",
       "targets": [
         {
-          "expr": "argus_gc_pause_time_seconds_max",
+          "expr": "argus_gc_pause_time_seconds_max{namespace=~\"$namespace\",deployment=~\"$deployment\",pod=~\"$pod\",instance=~\"$instance\"}",
           "legendFormat": "Max Pause"
         },
         {
-          "expr": "argus_gc_pause_time_seconds_avg",
+          "expr": "argus_gc_pause_time_seconds_avg{namespace=~\"$namespace\",deployment=~\"$deployment\",pod=~\"$pod\",instance=~\"$instance\"}",
           "legendFormat": "Avg Pause"
+        }
+      ],
+      "links": [
+        {
+          "title": "Fleet",
+          "url": "/fleet.html",
+          "targetBlank": true
+        },
+        {
+          "title": "Selected pod dashboard",
+          "url": "/?pod=${__field.labels.pod}",
+          "targetBlank": true
+        },
+        {
+          "title": "Profiles CPU",
+          "url": "/profiles.html?pod=${__field.labels.pod}&event=cpu&range=3600",
+          "targetBlank": true
+        },
+        {
+          "title": "Profiles allocation",
+          "url": "/profiles.html?pod=${__field.labels.pod}&event=alloc&range=3600",
+          "targetBlank": true
+        },
+        {
+          "title": "Console",
+          "url": "/console.html?pod=${__field.labels.pod}",
+          "targetBlank": true
+        },
+        {
+          "title": "Prometheus scrape",
+          "url": "/prometheus",
+          "targetBlank": true
         }
       ]
     },
@@ -750,15 +1616,47 @@
         "h": 8,
         "w": 6,
         "x": 18,
-        "y": 5
+        "y": 10
       },
       "id": 13,
       "title": "GC Overhead",
       "type": "timeseries",
       "targets": [
         {
-          "expr": "argus_gc_overhead_ratio",
+          "expr": "argus_gc_overhead_ratio{namespace=~\"$namespace\",deployment=~\"$deployment\",pod=~\"$pod\",instance=~\"$instance\"}",
           "legendFormat": "Overhead"
+        }
+      ],
+      "links": [
+        {
+          "title": "Fleet",
+          "url": "/fleet.html",
+          "targetBlank": true
+        },
+        {
+          "title": "Selected pod dashboard",
+          "url": "/?pod=${__field.labels.pod}",
+          "targetBlank": true
+        },
+        {
+          "title": "Profiles CPU",
+          "url": "/profiles.html?pod=${__field.labels.pod}&event=cpu&range=3600",
+          "targetBlank": true
+        },
+        {
+          "title": "Profiles allocation",
+          "url": "/profiles.html?pod=${__field.labels.pod}&event=alloc&range=3600",
+          "targetBlank": true
+        },
+        {
+          "title": "Console",
+          "url": "/console.html?pod=${__field.labels.pod}",
+          "targetBlank": true
+        },
+        {
+          "title": "Prometheus scrape",
+          "url": "/prometheus",
+          "targetBlank": true
         }
       ]
     },
@@ -768,10 +1666,10 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 13
+        "y": 18
       },
       "id": 202,
-      "title": "\ud83d\udd0d Memory Leak Detection & Allocation",
+      "title": "🔍 Memory Leak Detection & Allocation",
       "type": "row"
     },
     {
@@ -806,7 +1704,7 @@
         "h": 7,
         "w": 4,
         "x": 0,
-        "y": 14
+        "y": 19
       },
       "id": 20,
       "options": {
@@ -819,12 +1717,44 @@
           ]
         }
       },
-      "title": "Leak Confidence (R\u00b2)",
+      "title": "Leak Confidence (R²)",
       "type": "gauge",
       "targets": [
         {
-          "expr": "argus_gc_leak_confidence",
+          "expr": "argus_gc_leak_confidence{namespace=~\"$namespace\",deployment=~\"$deployment\",pod=~\"$pod\",instance=~\"$instance\"}",
           "legendFormat": ""
+        }
+      ],
+      "links": [
+        {
+          "title": "Fleet",
+          "url": "/fleet.html",
+          "targetBlank": true
+        },
+        {
+          "title": "Selected pod dashboard",
+          "url": "/?pod=${__field.labels.pod}",
+          "targetBlank": true
+        },
+        {
+          "title": "Profiles CPU",
+          "url": "/profiles.html?pod=${__field.labels.pod}&event=cpu&range=3600",
+          "targetBlank": true
+        },
+        {
+          "title": "Profiles allocation",
+          "url": "/profiles.html?pod=${__field.labels.pod}&event=alloc&range=3600",
+          "targetBlank": true
+        },
+        {
+          "title": "Console",
+          "url": "/console.html?pod=${__field.labels.pod}",
+          "targetBlank": true
+        },
+        {
+          "title": "Prometheus scrape",
+          "url": "/prometheus",
+          "targetBlank": true
         }
       ]
     },
@@ -866,15 +1796,15 @@
         "h": 7,
         "w": 8,
         "x": 4,
-        "y": 14
+        "y": 19
       },
       "id": 21,
       "title": "Leak Confidence Over Time",
       "type": "timeseries",
       "targets": [
         {
-          "expr": "argus_gc_leak_confidence",
-          "legendFormat": "R\u00b2"
+          "expr": "argus_gc_leak_confidence{namespace=~\"$namespace\",deployment=~\"$deployment\",pod=~\"$pod\",instance=~\"$instance\"}",
+          "legendFormat": "R²"
         }
       ]
     },
@@ -901,7 +1831,7 @@
         "h": 7,
         "w": 6,
         "x": 12,
-        "y": 14
+        "y": 19
       },
       "id": 22,
       "options": {
@@ -917,12 +1847,44 @@
       "type": "timeseries",
       "targets": [
         {
-          "expr": "argus_gc_allocation_rate_kbps",
+          "expr": "argus_gc_allocation_rate_kbps{namespace=~\"$namespace\",deployment=~\"$deployment\",pod=~\"$pod\",instance=~\"$instance\"}",
           "legendFormat": "Allocation"
         },
         {
-          "expr": "argus_gc_promotion_rate_kbps",
+          "expr": "argus_gc_promotion_rate_kbps{namespace=~\"$namespace\",deployment=~\"$deployment\",pod=~\"$pod\",instance=~\"$instance\"}",
           "legendFormat": "Promotion"
+        }
+      ],
+      "links": [
+        {
+          "title": "Fleet",
+          "url": "/fleet.html",
+          "targetBlank": true
+        },
+        {
+          "title": "Selected pod dashboard",
+          "url": "/?pod=${__field.labels.pod}",
+          "targetBlank": true
+        },
+        {
+          "title": "Profiles CPU",
+          "url": "/profiles.html?pod=${__field.labels.pod}&event=cpu&range=3600",
+          "targetBlank": true
+        },
+        {
+          "title": "Profiles allocation",
+          "url": "/profiles.html?pod=${__field.labels.pod}&event=alloc&range=3600",
+          "targetBlank": true
+        },
+        {
+          "title": "Console",
+          "url": "/console.html?pod=${__field.labels.pod}",
+          "targetBlank": true
+        },
+        {
+          "title": "Prometheus scrape",
+          "url": "/prometheus",
+          "targetBlank": true
         }
       ]
     },
@@ -948,14 +1910,14 @@
         "h": 7,
         "w": 6,
         "x": 18,
-        "y": 14
+        "y": 19
       },
       "id": 23,
       "title": "GC Events (rate)",
       "type": "timeseries",
       "targets": [
         {
-          "expr": "rate(argus_gc_events_total[1m])*60",
+          "expr": "rate(argus_gc_events_total{namespace=~\"$namespace\",deployment=~\"$deployment\",pod=~\"$pod\",instance=~\"$instance\"}[1m])*60",
           "legendFormat": "GC Events/min"
         }
       ]
@@ -966,10 +1928,10 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 21
+        "y": 26
       },
       "id": 203,
-      "title": "\ud83e\uddf5 Virtual Threads",
+      "title": "🧵 Virtual Threads",
       "type": "row"
     },
     {
@@ -995,14 +1957,14 @@
         "h": 7,
         "w": 6,
         "x": 0,
-        "y": 22
+        "y": 27
       },
       "id": 30,
       "title": "Active Virtual Threads",
       "type": "timeseries",
       "targets": [
         {
-          "expr": "argus_virtual_threads_active",
+          "expr": "argus_virtual_threads_active{namespace=~\"$namespace\",deployment=~\"$deployment\",pod=~\"$pod\",instance=~\"$instance\"}",
           "legendFormat": "Active"
         }
       ]
@@ -1028,7 +1990,7 @@
         "h": 7,
         "w": 6,
         "x": 6,
-        "y": 22
+        "y": 27
       },
       "id": 31,
       "options": {
@@ -1044,11 +2006,11 @@
       "type": "timeseries",
       "targets": [
         {
-          "expr": "rate(argus_virtual_threads_started_total[1m])*60",
+          "expr": "rate(argus_virtual_threads_started_total{namespace=~\"$namespace\",deployment=~\"$deployment\",pod=~\"$pod\",instance=~\"$instance\"}[1m])*60",
           "legendFormat": "Started/min"
         },
         {
-          "expr": "rate(argus_virtual_threads_ended_total[1m])*60",
+          "expr": "rate(argus_virtual_threads_ended_total{namespace=~\"$namespace\",deployment=~\"$deployment\",pod=~\"$pod\",instance=~\"$instance\"}[1m])*60",
           "legendFormat": "Ended/min"
         }
       ]
@@ -1091,7 +2053,7 @@
         "h": 7,
         "w": 6,
         "x": 12,
-        "y": 22
+        "y": 27
       },
       "id": 32,
       "options": {
@@ -1107,12 +2069,44 @@
       "type": "timeseries",
       "targets": [
         {
-          "expr": "rate(argus_virtual_threads_pinned_total[1m])*60",
+          "expr": "rate(argus_virtual_threads_pinned_total{namespace=~\"$namespace\",deployment=~\"$deployment\",pod=~\"$pod\",instance=~\"$instance\"}[1m])*60",
           "legendFormat": "Pinning Events/min"
         },
         {
-          "expr": "argus_virtual_threads_pinned_unique_stacks",
+          "expr": "argus_virtual_threads_pinned_unique_stacks{namespace=~\"$namespace\",deployment=~\"$deployment\",pod=~\"$pod\",instance=~\"$instance\"}",
           "legendFormat": "Unique Stacks"
+        }
+      ],
+      "links": [
+        {
+          "title": "Fleet",
+          "url": "/fleet.html",
+          "targetBlank": true
+        },
+        {
+          "title": "Selected pod dashboard",
+          "url": "/?pod=${__field.labels.pod}",
+          "targetBlank": true
+        },
+        {
+          "title": "Profiles CPU",
+          "url": "/profiles.html?pod=${__field.labels.pod}&event=cpu&range=3600",
+          "targetBlank": true
+        },
+        {
+          "title": "Profiles allocation",
+          "url": "/profiles.html?pod=${__field.labels.pod}&event=alloc&range=3600",
+          "targetBlank": true
+        },
+        {
+          "title": "Console",
+          "url": "/console.html?pod=${__field.labels.pod}",
+          "targetBlank": true
+        },
+        {
+          "title": "Prometheus scrape",
+          "url": "/prometheus",
+          "targetBlank": true
         }
       ]
     },
@@ -1137,7 +2131,7 @@
         "h": 7,
         "w": 6,
         "x": 18,
-        "y": 22
+        "y": 27
       },
       "id": 33,
       "options": {
@@ -1153,11 +2147,11 @@
       "type": "timeseries",
       "targets": [
         {
-          "expr": "argus_carrier_threads",
+          "expr": "argus_carrier_threads{namespace=~\"$namespace\",deployment=~\"$deployment\",pod=~\"$pod\",instance=~\"$instance\"}",
           "legendFormat": "Carrier Count"
         },
         {
-          "expr": "argus_carrier_threads_avg_per_carrier",
+          "expr": "argus_carrier_threads_avg_per_carrier{namespace=~\"$namespace\",deployment=~\"$deployment\",pod=~\"$pod\",instance=~\"$instance\"}",
           "legendFormat": "Avg VT/Carrier"
         }
       ]
@@ -1168,10 +2162,10 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 29
+        "y": 34
       },
       "id": 204,
-      "title": "\u26a1 CPU & Metaspace",
+      "title": "⚡ CPU & Metaspace",
       "type": "row"
     },
     {
@@ -1202,7 +2196,7 @@
         "h": 7,
         "w": 7,
         "x": 0,
-        "y": 30
+        "y": 35
       },
       "id": 40,
       "options": {
@@ -1218,11 +2212,11 @@
       "type": "timeseries",
       "targets": [
         {
-          "expr": "argus_cpu_jvm_user_ratio",
+          "expr": "argus_cpu_jvm_user_ratio{namespace=~\"$namespace\",deployment=~\"$deployment\",pod=~\"$pod\",instance=~\"$instance\"}",
           "legendFormat": "User"
         },
         {
-          "expr": "argus_cpu_jvm_system_ratio",
+          "expr": "argus_cpu_jvm_system_ratio{namespace=~\"$namespace\",deployment=~\"$deployment\",pod=~\"$pod\",instance=~\"$instance\"}",
           "legendFormat": "System"
         }
       ]
@@ -1252,14 +2246,14 @@
         "h": 7,
         "w": 5,
         "x": 7,
-        "y": 30
+        "y": 35
       },
       "id": 41,
       "title": "Machine CPU",
       "type": "timeseries",
       "targets": [
         {
-          "expr": "argus_cpu_machine_total_ratio",
+          "expr": "argus_cpu_machine_total_ratio{namespace=~\"$namespace\",deployment=~\"$deployment\",pod=~\"$pod\",instance=~\"$instance\"}",
           "legendFormat": "Total"
         }
       ]
@@ -1310,7 +2304,7 @@
         "h": 7,
         "w": 8,
         "x": 12,
-        "y": 30
+        "y": 35
       },
       "id": 50,
       "options": {
@@ -1326,15 +2320,15 @@
       "type": "timeseries",
       "targets": [
         {
-          "expr": "argus_metaspace_used_bytes",
+          "expr": "argus_metaspace_used_bytes{namespace=~\"$namespace\",deployment=~\"$deployment\",pod=~\"$pod\",instance=~\"$instance\"}",
           "legendFormat": "Used"
         },
         {
-          "expr": "argus_metaspace_committed_bytes",
+          "expr": "argus_metaspace_committed_bytes{namespace=~\"$namespace\",deployment=~\"$deployment\",pod=~\"$pod\",instance=~\"$instance\"}",
           "legendFormat": "Committed"
         },
         {
-          "expr": "argus_metaspace_reserved_bytes",
+          "expr": "argus_metaspace_reserved_bytes{namespace=~\"$namespace\",deployment=~\"$deployment\",pod=~\"$pod\",instance=~\"$instance\"}",
           "legendFormat": "Reserved"
         }
       ]
@@ -1361,14 +2355,14 @@
         "h": 7,
         "w": 4,
         "x": 20,
-        "y": 30
+        "y": 35
       },
       "id": 51,
       "title": "Loaded Classes",
       "type": "timeseries",
       "targets": [
         {
-          "expr": "argus_metaspace_classes_loaded",
+          "expr": "argus_metaspace_classes_loaded{namespace=~\"$namespace\",deployment=~\"$deployment\",pod=~\"$pod\",instance=~\"$instance\"}",
           "legendFormat": "Classes"
         }
       ]
@@ -1379,10 +2373,10 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 37
+        "y": 42
       },
       "id": 206,
-      "title": "\ud83d\udcc8 Counters & Totals",
+      "title": "📈 Counters & Totals",
       "type": "row"
     },
     {
@@ -1406,7 +2400,7 @@
         "h": 4,
         "w": 4,
         "x": 0,
-        "y": 38
+        "y": 43
       },
       "id": 60,
       "options": {
@@ -1423,7 +2417,7 @@
       "type": "stat",
       "targets": [
         {
-          "expr": "argus_gc_events_total",
+          "expr": "argus_gc_events_total{namespace=~\"$namespace\",deployment=~\"$deployment\",pod=~\"$pod\",instance=~\"$instance\"}",
           "legendFormat": ""
         }
       ]
@@ -1450,7 +2444,7 @@
         "h": 4,
         "w": 4,
         "x": 4,
-        "y": 38
+        "y": 43
       },
       "id": 61,
       "options": {
@@ -1467,7 +2461,7 @@
       "type": "stat",
       "targets": [
         {
-          "expr": "argus_gc_pause_time_seconds_total",
+          "expr": "argus_gc_pause_time_seconds_total{namespace=~\"$namespace\",deployment=~\"$deployment\",pod=~\"$pod\",instance=~\"$instance\"}",
           "legendFormat": ""
         }
       ]
@@ -1493,7 +2487,7 @@
         "h": 4,
         "w": 4,
         "x": 8,
-        "y": 38
+        "y": 43
       },
       "id": 62,
       "options": {
@@ -1510,7 +2504,7 @@
       "type": "stat",
       "targets": [
         {
-          "expr": "argus_virtual_threads_started_total",
+          "expr": "argus_virtual_threads_started_total{namespace=~\"$namespace\",deployment=~\"$deployment\",pod=~\"$pod\",instance=~\"$instance\"}",
           "legendFormat": ""
         }
       ]
@@ -1536,7 +2530,7 @@
         "h": 4,
         "w": 4,
         "x": 12,
-        "y": 38
+        "y": 43
       },
       "id": 63,
       "options": {
@@ -1553,7 +2547,7 @@
       "type": "stat",
       "targets": [
         {
-          "expr": "argus_virtual_threads_ended_total",
+          "expr": "argus_virtual_threads_ended_total{namespace=~\"$namespace\",deployment=~\"$deployment\",pod=~\"$pod\",instance=~\"$instance\"}",
           "legendFormat": ""
         }
       ]
@@ -1583,7 +2577,7 @@
         "h": 4,
         "w": 4,
         "x": 16,
-        "y": 38
+        "y": 43
       },
       "id": 64,
       "options": {
@@ -1600,7 +2594,7 @@
       "type": "stat",
       "targets": [
         {
-          "expr": "argus_virtual_threads_submit_failed_total",
+          "expr": "argus_virtual_threads_submit_failed_total{namespace=~\"$namespace\",deployment=~\"$deployment\",pod=~\"$pod\",instance=~\"$instance\"}",
           "legendFormat": ""
         }
       ]
@@ -1626,7 +2620,7 @@
         "h": 4,
         "w": 4,
         "x": 20,
-        "y": 38
+        "y": 43
       },
       "id": 65,
       "options": {
@@ -1643,7 +2637,7 @@
       "type": "stat",
       "targets": [
         {
-          "expr": "argus_virtual_threads_pinned_total",
+          "expr": "argus_virtual_threads_pinned_total{namespace=~\"$namespace\",deployment=~\"$deployment\",pod=~\"$pod\",instance=~\"$instance\"}",
           "legendFormat": ""
         }
       ]
@@ -1654,10 +2648,10 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 43
+        "y": 48
       },
       "id": 207,
-      "title": "\ud83e\udde0 Derived Insights",
+      "title": "🧠 Derived Insights",
       "type": "row"
     },
     {
@@ -1683,7 +2677,7 @@
         "h": 7,
         "w": 8,
         "x": 0,
-        "y": 44
+        "y": 49
       },
       "id": 208,
       "options": {
@@ -1699,11 +2693,11 @@
       "type": "timeseries",
       "targets": [
         {
-          "expr": "argus_virtual_threads_started_total - argus_virtual_threads_ended_total",
+          "expr": "argus_virtual_threads_started_total{namespace=~\"$namespace\",deployment=~\"$deployment\",pod=~\"$pod\",instance=~\"$instance\"} - argus_virtual_threads_ended_total{namespace=~\"$namespace\",deployment=~\"$deployment\",pod=~\"$pod\",instance=~\"$instance\"}",
           "legendFormat": "Backlog"
         },
         {
-          "expr": "argus_virtual_threads_active",
+          "expr": "argus_virtual_threads_active{namespace=~\"$namespace\",deployment=~\"$deployment\",pod=~\"$pod\",instance=~\"$instance\"}",
           "legendFormat": "Active"
         }
       ]
@@ -1748,14 +2742,14 @@
         "h": 7,
         "w": 8,
         "x": 8,
-        "y": 44
+        "y": 49
       },
       "id": 209,
       "title": "Promotion / Allocation Ratio",
       "type": "timeseries",
       "targets": [
         {
-          "expr": "argus_gc_promotion_rate_kbps / (argus_gc_allocation_rate_kbps > 0 or 1)",
+          "expr": "argus_gc_promotion_rate_kbps{namespace=~\"$namespace\",deployment=~\"$deployment\",pod=~\"$pod\",instance=~\"$instance\"} / (argus_gc_allocation_rate_kbps{namespace=~\"$namespace\",deployment=~\"$deployment\",pod=~\"$pod\",instance=~\"$instance\"} > 0 or 1)",
           "legendFormat": "Promo/Alloc"
         }
       ]
@@ -1784,14 +2778,14 @@
         "h": 7,
         "w": 8,
         "x": 16,
-        "y": 44
+        "y": 49
       },
       "id": 210,
       "title": "Heap Headroom (Free)",
       "type": "timeseries",
       "targets": [
         {
-          "expr": "argus_heap_committed_bytes - argus_heap_used_bytes",
+          "expr": "argus_heap_committed_bytes{namespace=~\"$namespace\",deployment=~\"$deployment\",pod=~\"$pod\",instance=~\"$instance\"} - argus_heap_used_bytes{namespace=~\"$namespace\",deployment=~\"$deployment\",pod=~\"$pod\",instance=~\"$instance\"}",
           "legendFormat": "Free Heap"
         }
       ]
@@ -1802,10 +2796,10 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 51
+        "y": 56
       },
       "id": 211,
-      "title": "\ud83d\ude80 Rates & Throughput",
+      "title": "🚀 Rates & Throughput",
       "type": "row"
     },
     {
@@ -1830,7 +2824,7 @@
         "h": 7,
         "w": 6,
         "x": 0,
-        "y": 52
+        "y": 57
       },
       "id": 212,
       "options": {
@@ -1846,11 +2840,11 @@
       "type": "timeseries",
       "targets": [
         {
-          "expr": "rate(argus_virtual_threads_started_total[30s])",
+          "expr": "rate(argus_virtual_threads_started_total{namespace=~\"$namespace\",deployment=~\"$deployment\",pod=~\"$pod\",instance=~\"$instance\"}[30s])",
           "legendFormat": "Created/s"
         },
         {
-          "expr": "rate(argus_virtual_threads_ended_total[30s])",
+          "expr": "rate(argus_virtual_threads_ended_total{namespace=~\"$namespace\",deployment=~\"$deployment\",pod=~\"$pod\",instance=~\"$instance\"}[30s])",
           "legendFormat": "Ended/s"
         }
       ]
@@ -1878,14 +2872,14 @@
         "h": 7,
         "w": 6,
         "x": 6,
-        "y": 52
+        "y": 57
       },
       "id": 213,
       "title": "Pinning Rate (/s)",
       "type": "timeseries",
       "targets": [
         {
-          "expr": "rate(argus_virtual_threads_pinned_total[30s])",
+          "expr": "rate(argus_virtual_threads_pinned_total{namespace=~\"$namespace\",deployment=~\"$deployment\",pod=~\"$pod\",instance=~\"$instance\"}[30s])",
           "legendFormat": "Pinning/s"
         }
       ]
@@ -1913,14 +2907,14 @@
         "h": 7,
         "w": 6,
         "x": 12,
-        "y": 52
+        "y": 57
       },
       "id": 214,
       "title": "GC Pauses / min",
       "type": "timeseries",
       "targets": [
         {
-          "expr": "rate(argus_gc_events_total[1m]) * 60",
+          "expr": "rate(argus_gc_events_total{namespace=~\"$namespace\",deployment=~\"$deployment\",pod=~\"$pod\",instance=~\"$instance\"}[1m]) * 60",
           "legendFormat": "GC/min"
         }
       ]
@@ -1965,14 +2959,14 @@
         "h": 7,
         "w": 6,
         "x": 18,
-        "y": 52
+        "y": 57
       },
       "id": 215,
       "title": "Metaspace Usage %",
       "type": "timeseries",
       "targets": [
         {
-          "expr": "argus_metaspace_used_bytes / (argus_metaspace_committed_bytes > 0 or 1)",
+          "expr": "argus_metaspace_used_bytes{namespace=~\"$namespace\",deployment=~\"$deployment\",pod=~\"$pod\",instance=~\"$instance\"} / (argus_metaspace_committed_bytes{namespace=~\"$namespace\",deployment=~\"$deployment\",pod=~\"$pod\",instance=~\"$instance\"} > 0 or 1)",
           "legendFormat": "Metaspace %"
         }
       ]
@@ -1983,10 +2977,10 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 59
+        "y": 64
       },
       "id": 216,
-      "title": "\ud83d\udcca Comparison & Capacity",
+      "title": "📊 Comparison & Capacity",
       "type": "row"
     },
     {
@@ -2006,7 +3000,7 @@
         "h": 8,
         "w": 6,
         "x": 0,
-        "y": 60
+        "y": 65
       },
       "id": 217,
       "options": {
@@ -2028,15 +3022,15 @@
       "type": "piechart",
       "targets": [
         {
-          "expr": "argus_heap_used_bytes",
+          "expr": "argus_heap_used_bytes{namespace=~\"$namespace\",deployment=~\"$deployment\",pod=~\"$pod\",instance=~\"$instance\"}",
           "legendFormat": "Heap Used"
         },
         {
-          "expr": "argus_heap_committed_bytes - argus_heap_used_bytes",
+          "expr": "argus_heap_committed_bytes{namespace=~\"$namespace\",deployment=~\"$deployment\",pod=~\"$pod\",instance=~\"$instance\"} - argus_heap_used_bytes{namespace=~\"$namespace\",deployment=~\"$deployment\",pod=~\"$pod\",instance=~\"$instance\"}",
           "legendFormat": "Heap Free"
         },
         {
-          "expr": "argus_metaspace_used_bytes",
+          "expr": "argus_metaspace_used_bytes{namespace=~\"$namespace\",deployment=~\"$deployment\",pod=~\"$pod\",instance=~\"$instance\"}",
           "legendFormat": "Metaspace"
         }
       ]
@@ -2073,7 +3067,7 @@
         "h": 8,
         "w": 6,
         "x": 6,
-        "y": 60
+        "y": 65
       },
       "id": 218,
       "options": {
@@ -2090,7 +3084,7 @@
       "type": "gauge",
       "targets": [
         {
-          "expr": "argus_gc_overhead_ratio",
+          "expr": "argus_gc_overhead_ratio{namespace=~\"$namespace\",deployment=~\"$deployment\",pod=~\"$pod\",instance=~\"$instance\"}",
           "legendFormat": "GC Budget"
         }
       ]
@@ -2120,7 +3114,7 @@
         "h": 8,
         "w": 6,
         "x": 12,
-        "y": 60
+        "y": 65
       },
       "id": 219,
       "options": {
@@ -2136,11 +3130,11 @@
       "type": "timeseries",
       "targets": [
         {
-          "expr": "argus_gc_allocation_rate_kbps",
+          "expr": "argus_gc_allocation_rate_kbps{namespace=~\"$namespace\",deployment=~\"$deployment\",pod=~\"$pod\",instance=~\"$instance\"}",
           "legendFormat": "Allocation KB/s"
         },
         {
-          "expr": "argus_gc_promotion_rate_kbps",
+          "expr": "argus_gc_promotion_rate_kbps{namespace=~\"$namespace\",deployment=~\"$deployment\",pod=~\"$pod\",instance=~\"$instance\"}",
           "legendFormat": "Promotion KB/s"
         }
       ]
@@ -2175,7 +3169,7 @@
         "h": 4,
         "w": 6,
         "x": 18,
-        "y": 60
+        "y": 65
       },
       "id": 220,
       "options": {
@@ -2192,8 +3186,40 @@
       "type": "stat",
       "targets": [
         {
-          "expr": "argus_scrape_duration_seconds",
+          "expr": "argus_scrape_duration_seconds{namespace=~\"$namespace\",deployment=~\"$deployment\",pod=~\"$pod\",instance=~\"$instance\"}",
           "legendFormat": ""
+        }
+      ],
+      "links": [
+        {
+          "title": "Fleet",
+          "url": "/fleet.html",
+          "targetBlank": true
+        },
+        {
+          "title": "Selected pod dashboard",
+          "url": "/?pod=${__field.labels.pod}",
+          "targetBlank": true
+        },
+        {
+          "title": "Profiles CPU",
+          "url": "/profiles.html?pod=${__field.labels.pod}&event=cpu&range=3600",
+          "targetBlank": true
+        },
+        {
+          "title": "Profiles allocation",
+          "url": "/profiles.html?pod=${__field.labels.pod}&event=alloc&range=3600",
+          "targetBlank": true
+        },
+        {
+          "title": "Console",
+          "url": "/console.html?pod=${__field.labels.pod}",
+          "targetBlank": true
+        },
+        {
+          "title": "Prometheus scrape",
+          "url": "/prometheus",
+          "targetBlank": true
         }
       ]
     },
@@ -2209,7 +3235,7 @@
         "h": 4,
         "w": 6,
         "x": 18,
-        "y": 64
+        "y": 69
       },
       "id": 221,
       "options": {
@@ -2222,7 +3248,7 @@
       "type": "table",
       "targets": [
         {
-          "expr": "argus_build_info",
+          "expr": "argus_build_info{namespace=~\"$namespace\",deployment=~\"$deployment\",pod=~\"$pod\",instance=~\"$instance\"}",
           "legendFormat": "",
           "format": "table",
           "instant": true
@@ -2242,6 +3268,662 @@
               "jdk_version": "JDK"
             }
           }
+        }
+      ],
+      "links": [
+        {
+          "title": "Fleet",
+          "url": "/fleet.html",
+          "targetBlank": true
+        },
+        {
+          "title": "Selected pod dashboard",
+          "url": "/?pod=${__field.labels.pod}",
+          "targetBlank": true
+        },
+        {
+          "title": "Profiles CPU",
+          "url": "/profiles.html?pod=${__field.labels.pod}&event=cpu&range=3600",
+          "targetBlank": true
+        },
+        {
+          "title": "Profiles allocation",
+          "url": "/profiles.html?pod=${__field.labels.pod}&event=alloc&range=3600",
+          "targetBlank": true
+        },
+        {
+          "title": "Console",
+          "url": "/console.html?pod=${__field.labels.pod}",
+          "targetBlank": true
+        },
+        {
+          "title": "Prometheus scrape",
+          "url": "/prometheus",
+          "targetBlank": true
+        }
+      ]
+    },
+    {
+      "collapsed": false,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 74
+      },
+      "id": 229,
+      "panels": [],
+      "title": "GC Pause Percentiles",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "custom": {
+            "fillOpacity": 10,
+            "lineWidth": 2,
+            "showPoints": "never"
+          },
+          "color": {
+            "mode": "palette-classic"
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 0,
+        "y": 75
+      },
+      "id": 230,
+      "options": {
+        "tooltip": {
+          "mode": "multi"
+        },
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        }
+      },
+      "title": "GC Pause p50/p95/p99",
+      "type": "timeseries",
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.50, sum(rate(argus_gc_pause_seconds_bucket{namespace=~\"$namespace\",deployment=~\"$deployment\",pod=~\"$pod\",instance=~\"$instance\"}[5m])) by (le)) or histogram_quantile(0.50, sum(rate(jvm_gc_duration_seconds_bucket{namespace=~\"$namespace\",deployment=~\"$deployment\",pod=~\"$pod\",instance=~\"$instance\"}[5m])) by (le))",
+          "legendFormat": "p50"
+        },
+        {
+          "expr": "histogram_quantile(0.95, sum(rate(argus_gc_pause_seconds_bucket{namespace=~\"$namespace\",deployment=~\"$deployment\",pod=~\"$pod\",instance=~\"$instance\"}[5m])) by (le)) or histogram_quantile(0.95, sum(rate(jvm_gc_duration_seconds_bucket{namespace=~\"$namespace\",deployment=~\"$deployment\",pod=~\"$pod\",instance=~\"$instance\"}[5m])) by (le))",
+          "legendFormat": "p95"
+        },
+        {
+          "expr": "histogram_quantile(0.99, sum(rate(argus_gc_pause_seconds_bucket{namespace=~\"$namespace\",deployment=~\"$deployment\",pod=~\"$pod\",instance=~\"$instance\"}[5m])) by (le)) or histogram_quantile(0.99, sum(rate(jvm_gc_duration_seconds_bucket{namespace=~\"$namespace\",deployment=~\"$deployment\",pod=~\"$pod\",instance=~\"$instance\"}[5m])) by (le))",
+          "legendFormat": "p99"
+        }
+      ],
+      "links": [
+        {
+          "title": "Fleet",
+          "url": "/fleet.html",
+          "targetBlank": true
+        },
+        {
+          "title": "Selected pod dashboard",
+          "url": "/?pod=${__field.labels.pod}",
+          "targetBlank": true
+        },
+        {
+          "title": "Profiles CPU",
+          "url": "/profiles.html?pod=${__field.labels.pod}&event=cpu&range=3600",
+          "targetBlank": true
+        },
+        {
+          "title": "Profiles allocation",
+          "url": "/profiles.html?pod=${__field.labels.pod}&event=alloc&range=3600",
+          "targetBlank": true
+        },
+        {
+          "title": "Console",
+          "url": "/console.html?pod=${__field.labels.pod}",
+          "targetBlank": true
+        },
+        {
+          "title": "Prometheus scrape",
+          "url": "/prometheus",
+          "targetBlank": true
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "custom": {
+            "fillOpacity": 10,
+            "lineWidth": 2,
+            "showPoints": "never"
+          },
+          "color": {
+            "mode": "palette-classic"
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 12,
+        "y": 75
+      },
+      "id": 231,
+      "options": {
+        "tooltip": {
+          "mode": "multi"
+        },
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        }
+      },
+      "title": "GC Pause By Collector/Cause",
+      "type": "timeseries",
+      "targets": [
+        {
+          "expr": "topk(10, rate(argus_gc_pause_breakdown_seconds_total{namespace=~\"$namespace\",deployment=~\"$deployment\",pod=~\"$pod\",instance=~\"$instance\"}[5m]))",
+          "legendFormat": "{{gc_name}} / {{gc_cause}}"
+        }
+      ],
+      "links": [
+        {
+          "title": "Fleet",
+          "url": "/fleet.html",
+          "targetBlank": true
+        },
+        {
+          "title": "Selected pod dashboard",
+          "url": "/?pod=${__field.labels.pod}",
+          "targetBlank": true
+        },
+        {
+          "title": "Profiles CPU",
+          "url": "/profiles.html?pod=${__field.labels.pod}&event=cpu&range=3600",
+          "targetBlank": true
+        },
+        {
+          "title": "Profiles allocation",
+          "url": "/profiles.html?pod=${__field.labels.pod}&event=alloc&range=3600",
+          "targetBlank": true
+        },
+        {
+          "title": "Console",
+          "url": "/console.html?pod=${__field.labels.pod}",
+          "targetBlank": true
+        },
+        {
+          "title": "Prometheus scrape",
+          "url": "/prometheus",
+          "targetBlank": true
+        }
+      ]
+    },
+    {
+      "collapsed": false,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 82
+      },
+      "id": 232,
+      "panels": [],
+      "title": "Allocation, Contention & Profiling",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "Bps",
+          "custom": {
+            "fillOpacity": 10,
+            "lineWidth": 2,
+            "showPoints": "never"
+          },
+          "color": {
+            "mode": "palette-classic"
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 0,
+        "y": 83
+      },
+      "id": 233,
+      "options": {
+        "tooltip": {
+          "mode": "multi"
+        },
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        }
+      },
+      "title": "Allocation Throughput",
+      "type": "timeseries",
+      "targets": [
+        {
+          "expr": "sum(argus_allocation_rate_bytes_per_second{namespace=~\"$namespace\",deployment=~\"$deployment\",pod=~\"$pod\",instance=~\"$instance\"})",
+          "legendFormat": "Allocation rate"
+        },
+        {
+          "expr": "rate(argus_allocation_bytes_total{namespace=~\"$namespace\",deployment=~\"$deployment\",pod=~\"$pod\",instance=~\"$instance\"}[5m])",
+          "legendFormat": "Bytes allocated rate"
+        }
+      ],
+      "links": [
+        {
+          "title": "Fleet",
+          "url": "/fleet.html",
+          "targetBlank": true
+        },
+        {
+          "title": "Selected pod dashboard",
+          "url": "/?pod=${__field.labels.pod}",
+          "targetBlank": true
+        },
+        {
+          "title": "Profiles CPU",
+          "url": "/profiles.html?pod=${__field.labels.pod}&event=cpu&range=3600",
+          "targetBlank": true
+        },
+        {
+          "title": "Profiles allocation",
+          "url": "/profiles.html?pod=${__field.labels.pod}&event=alloc&range=3600",
+          "targetBlank": true
+        },
+        {
+          "title": "Console",
+          "url": "/console.html?pod=${__field.labels.pod}",
+          "targetBlank": true
+        },
+        {
+          "title": "Prometheus scrape",
+          "url": "/prometheus",
+          "targetBlank": true
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 8,
+        "y": 83
+      },
+      "id": 234,
+      "options": {
+        "showHeader": true,
+        "footer": {
+          "show": false
+        }
+      },
+      "title": "Top Allocating Classes",
+      "type": "table",
+      "targets": [
+        {
+          "expr": "topk(10, argus_allocation_class_bytes{namespace=~\"$namespace\",deployment=~\"$deployment\",pod=~\"$pod\",instance=~\"$instance\"})",
+          "format": "table",
+          "instant": true,
+          "legendFormat": ""
+        }
+      ],
+      "links": [
+        {
+          "title": "Fleet",
+          "url": "/fleet.html",
+          "targetBlank": true
+        },
+        {
+          "title": "Selected pod dashboard",
+          "url": "/?pod=${__field.labels.pod}",
+          "targetBlank": true
+        },
+        {
+          "title": "Profiles CPU",
+          "url": "/profiles.html?pod=${__field.labels.pod}&event=cpu&range=3600",
+          "targetBlank": true
+        },
+        {
+          "title": "Profiles allocation",
+          "url": "/profiles.html?pod=${__field.labels.pod}&event=alloc&range=3600",
+          "targetBlank": true
+        },
+        {
+          "title": "Console",
+          "url": "/console.html?pod=${__field.labels.pod}",
+          "targetBlank": true
+        },
+        {
+          "title": "Prometheus scrape",
+          "url": "/prometheus",
+          "targetBlank": true
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "custom": {
+            "fillOpacity": 10,
+            "lineWidth": 2,
+            "showPoints": "never"
+          },
+          "color": {
+            "mode": "palette-classic"
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 16,
+        "y": 83
+      },
+      "id": 235,
+      "options": {
+        "tooltip": {
+          "mode": "multi"
+        },
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        }
+      },
+      "title": "Contention Events & Time",
+      "type": "timeseries",
+      "targets": [
+        {
+          "expr": "sum(rate(argus_contention_events_total{namespace=~\"$namespace\",deployment=~\"$deployment\",pod=~\"$pod\",instance=~\"$instance\"}[5m]))",
+          "legendFormat": "events/s"
+        },
+        {
+          "expr": "sum(rate(argus_contention_time_seconds_total{namespace=~\"$namespace\",deployment=~\"$deployment\",pod=~\"$pod\",instance=~\"$instance\"}[5m]))",
+          "legendFormat": "seconds/s"
+        }
+      ],
+      "links": [
+        {
+          "title": "Fleet",
+          "url": "/fleet.html",
+          "targetBlank": true
+        },
+        {
+          "title": "Selected pod dashboard",
+          "url": "/?pod=${__field.labels.pod}",
+          "targetBlank": true
+        },
+        {
+          "title": "Profiles CPU",
+          "url": "/profiles.html?pod=${__field.labels.pod}&event=cpu&range=3600",
+          "targetBlank": true
+        },
+        {
+          "title": "Profiles allocation",
+          "url": "/profiles.html?pod=${__field.labels.pod}&event=alloc&range=3600",
+          "targetBlank": true
+        },
+        {
+          "title": "Console",
+          "url": "/console.html?pod=${__field.labels.pod}",
+          "targetBlank": true
+        },
+        {
+          "title": "Prometheus scrape",
+          "url": "/prometheus",
+          "targetBlank": true
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 0,
+        "y": 90
+      },
+      "id": 236,
+      "options": {
+        "showHeader": true,
+        "footer": {
+          "show": false
+        }
+      },
+      "title": "Top Contention Hotspots",
+      "type": "table",
+      "targets": [
+        {
+          "expr": "topk(10, argus_contention_hotspot_events{namespace=~\"$namespace\",deployment=~\"$deployment\",pod=~\"$pod\",instance=~\"$instance\"})",
+          "format": "table",
+          "instant": true,
+          "legendFormat": ""
+        }
+      ],
+      "links": [
+        {
+          "title": "Fleet",
+          "url": "/fleet.html",
+          "targetBlank": true
+        },
+        {
+          "title": "Selected pod dashboard",
+          "url": "/?pod=${__field.labels.pod}",
+          "targetBlank": true
+        },
+        {
+          "title": "Profiles CPU",
+          "url": "/profiles.html?pod=${__field.labels.pod}&event=cpu&range=3600",
+          "targetBlank": true
+        },
+        {
+          "title": "Profiles allocation",
+          "url": "/profiles.html?pod=${__field.labels.pod}&event=alloc&range=3600",
+          "targetBlank": true
+        },
+        {
+          "title": "Console",
+          "url": "/console.html?pod=${__field.labels.pod}",
+          "targetBlank": true
+        },
+        {
+          "title": "Prometheus scrape",
+          "url": "/prometheus",
+          "targetBlank": true
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "fillOpacity": 10,
+            "lineWidth": 2,
+            "showPoints": "never"
+          },
+          "color": {
+            "mode": "palette-classic"
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 8,
+        "y": 90
+      },
+      "id": 237,
+      "options": {
+        "tooltip": {
+          "mode": "multi"
+        },
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        }
+      },
+      "title": "Profiling Sample Rate",
+      "type": "timeseries",
+      "targets": [
+        {
+          "expr": "sum(rate(argus_profiling_samples_total{namespace=~\"$namespace\",deployment=~\"$deployment\",pod=~\"$pod\",instance=~\"$instance\"}[5m]))",
+          "legendFormat": "samples/s"
+        }
+      ],
+      "links": [
+        {
+          "title": "Fleet",
+          "url": "/fleet.html",
+          "targetBlank": true
+        },
+        {
+          "title": "Selected pod dashboard",
+          "url": "/?pod=${__field.labels.pod}",
+          "targetBlank": true
+        },
+        {
+          "title": "Profiles CPU",
+          "url": "/profiles.html?pod=${__field.labels.pod}&event=cpu&range=3600",
+          "targetBlank": true
+        },
+        {
+          "title": "Profiles allocation",
+          "url": "/profiles.html?pod=${__field.labels.pod}&event=alloc&range=3600",
+          "targetBlank": true
+        },
+        {
+          "title": "Console",
+          "url": "/console.html?pod=${__field.labels.pod}",
+          "targetBlank": true
+        },
+        {
+          "title": "Prometheus scrape",
+          "url": "/prometheus",
+          "targetBlank": true
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 16,
+        "y": 90
+      },
+      "id": 238,
+      "options": {
+        "showHeader": true,
+        "footer": {
+          "show": false
+        }
+      },
+      "title": "Top Profiled Methods",
+      "type": "table",
+      "targets": [
+        {
+          "expr": "topk(10, argus_profiling_method_samples{namespace=~\"$namespace\",deployment=~\"$deployment\",pod=~\"$pod\",instance=~\"$instance\"})",
+          "format": "table",
+          "instant": true,
+          "legendFormat": ""
+        }
+      ],
+      "links": [
+        {
+          "title": "Fleet",
+          "url": "/fleet.html",
+          "targetBlank": true
+        },
+        {
+          "title": "Selected pod dashboard",
+          "url": "/?pod=${__field.labels.pod}",
+          "targetBlank": true
+        },
+        {
+          "title": "Profiles CPU",
+          "url": "/profiles.html?pod=${__field.labels.pod}&event=cpu&range=3600",
+          "targetBlank": true
+        },
+        {
+          "title": "Profiles allocation",
+          "url": "/profiles.html?pod=${__field.labels.pod}&event=alloc&range=3600",
+          "targetBlank": true
+        },
+        {
+          "title": "Console",
+          "url": "/console.html?pod=${__field.labels.pod}",
+          "targetBlank": true
+        },
+        {
+          "title": "Prometheus scrape",
+          "url": "/prometheus",
+          "targetBlank": true
         }
       ]
     }
@@ -2274,6 +3956,106 @@
         "regex": "",
         "skipUrlSync": false,
         "type": "datasource"
+      },
+      {
+        "allValue": ".*",
+        "current": {
+          "selected": false,
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${datasource}"
+        },
+        "definition": "label_values(argus_build_info, namespace)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Namespace",
+        "multi": true,
+        "name": "namespace",
+        "options": [],
+        "query": "label_values(argus_build_info, namespace)",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "allValue": ".*",
+        "current": {
+          "selected": false,
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${datasource}"
+        },
+        "definition": "label_values(argus_build_info{namespace=~\"$namespace\"}, deployment)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Deployment",
+        "multi": true,
+        "name": "deployment",
+        "options": [],
+        "query": "label_values(argus_build_info{namespace=~\"$namespace\"}, deployment)",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "allValue": ".*",
+        "current": {
+          "selected": false,
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${datasource}"
+        },
+        "definition": "label_values(argus_build_info{namespace=~\"$namespace\",deployment=~\"$deployment\"}, pod)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Pod",
+        "multi": true,
+        "name": "pod",
+        "options": [],
+        "query": "label_values(argus_build_info{namespace=~\"$namespace\",deployment=~\"$deployment\"}, pod)",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "allValue": ".*",
+        "current": {
+          "selected": false,
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${datasource}"
+        },
+        "definition": "label_values(argus_build_info{namespace=~\"$namespace\",deployment=~\"$deployment\",pod=~\"$pod\"}, instance)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Instance",
+        "multi": true,
+        "name": "instance",
+        "options": [],
+        "query": "label_values(argus_build_info{namespace=~\"$namespace\",deployment=~\"$deployment\",pod=~\"$pod\"}, instance)",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "type": "query"
       }
     ]
   },

--- a/docs/kubernetes.md
+++ b/docs/kubernetes.md
@@ -248,15 +248,47 @@ When `grafana.dashboards.enabled=true` in the Helm chart, Argus auto-provisions 
 
 The dashboard includes:
 
-- Virtual thread active count and start/end rate
-- GC pause time (max, avg, total) and heap usage
+- Incident triage row for GC warnings, heap saturation, pinning, allocation, contention, and scrape duration
+- Virtual thread active count, start/end rate, and pinning rate
+- GC pause time (max, avg, total), p50/p95/p99 pause histograms, collector/cause breakdown, and heap usage
 - CPU usage (JVM user, JVM system, machine total)
 - Metaspace usage and class count
 - Lock contention top-10 hotspots
 - Allocation rate and top-10 allocating classes
 - Method profiling top-20 hot methods
+- Drilldown links to Fleet, selected-pod Dashboard, Profiles, Console, `/prometheus`, and this setup guide
 
-To import the dashboard manually, load `deploy/grafana-dashboard.json` from the Argus repository into Grafana via **Dashboards → Import**.
+To import the dashboard manually, load `docs/grafana-dashboard.json` from the Argus repository into Grafana via **Dashboards → Import**.
+
+Dashboard variables:
+
+| Variable | Purpose | Local mode behavior |
+|---|---|---|
+| `$datasource` | Select the Prometheus datasource | Required |
+| `$namespace` | Filter fleet views by Kubernetes namespace | `All` remains valid when labels are absent |
+| `$deployment` | Filter by deployment | `All` remains valid when labels are absent |
+| `$pod` | Select a pod for drilldown links | Empty/local scrapes still render unfiltered panels |
+| `$instance` | Filter by Prometheus scrape target | Optional |
+
+Drilldown links preserve selected pod context:
+
+| Link | Target |
+|---|---|
+| Fleet | `/fleet.html` |
+| Selected pod Dashboard | `/?pod=<pod-id>` |
+| CPU profile | `/profiles.html?pod=<pod-id>&event=cpu&range=3600` |
+| Allocation profile | `/profiles.html?pod=<pod-id>&event=alloc&range=3600` |
+| Console | `/console.html?pod=<pod-id>` |
+
+Recommended alert rules to provision in your Prometheus stack:
+
+| Signal | Suggested threshold | Duration |
+|---|---:|---:|
+| GC overhead | `argus_gc_overhead_ratio > 0.10` | 5m |
+| Heap usage | `argus_heap_usage_ratio > 0.90` | 10m |
+| Pinning rate | `rate(argus_virtual_threads_pinned_total[5m]) > 0` | 5m |
+| Scrape duration | `argus_scrape_duration_seconds > 1` | 5m |
+| Allocation spike | Compare `argus_allocation_rate_bytes_per_second` to a 30m baseline | 5m |
 
 ---
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -97,6 +97,29 @@ open http://localhost:9202/
 
 Access `/console.html` from the dashboard header to run diagnostic commands directly in the browser. Commands execute on the attached JVM using MXBeans — no separate CLI needed.
 
+### Dashboard Modes
+
+The local web UI has two operational modes:
+
+| Mode | URL | Data source | Status shown |
+|---|---|---|---|
+| Standalone JVM | `/` on an attached Argus agent | WebSocket events plus REST snapshots | `Live stream: connected/disconnected` |
+| Cluster selected pod | `/` served by the aggregator with `?pod=<pod-id>` | REST snapshot polling through `/pod/{id}` | `Snapshot polling: selected pod, scrape status, last scrape` |
+
+The Fleet, Profiles, Console, and Dashboard pages share the selected pod with the
+`argus.console.pod` browser storage key and with query params where useful:
+
+| Page | Context params |
+|---|---|
+| Dashboard | `?pod=<pod-id>` |
+| Profiles | `?pod=<pod-id>&event=cpu|alloc|lock|wall&range=<seconds>` |
+| Console | `?pod=<pod-id>` |
+| Fleet | `#pod/<pod-id>` |
+
+The Dashboard's incident synopsis ranks current heap, GC, CPU, pinning,
+contention, allocation, and scrape signals so the first screen explains why a
+pod or JVM looks unhealthy before the detailed charts.
+
 ### Configuration
 
 All settings are passed as `-D` system properties:
@@ -298,7 +321,7 @@ argus profile-gate before.json after.json --threshold=5 --annotate=github
 
 ## Monitoring Stack (Prometheus / OTLP / Docker)
 
-Native Prometheus + Grafana integration. Deploy to Kubernetes with the included Helm chart.
+Native Prometheus + Grafana integration. Deploy to Kubernetes with the included Helm chart or import `docs/grafana-dashboard.json` directly into Grafana.
 
 ```bash
 # Prometheus scrape endpoint (no extra config needed)
@@ -314,6 +337,10 @@ java -javaagent:~/.argus/argus-agent.jar \
 docker run --pid=host ghcr.io/rlaope/argus doctor
 docker run --pid=host ghcr.io/rlaope/argus watch
 ```
+
+The Grafana dashboard provides datasource, namespace, deployment, pod, and
+instance variables, incident-first rows, GC pause percentiles, and local
+drilldown links back to Fleet, Dashboard, Profiles, and Console.
 
 > Helm chart, Grafana dashboard JSON, and K8s setup: [docs/kubernetes.md](kubernetes.md)
 


### PR DESCRIPTION
## Summary

- Refresh Grafana into an incident-first dashboard with datasource/fleet variables, PromQL label filters, drilldown links, GC percentiles, allocation/contention/profiling panels, and Helm dashboard parity.
- Add a shared dashboard contract plus regression tests that validate metric references, label matchers, panel shape, drilldowns, and chart/docs dashboard sync.
- Strengthen the local dashboard/Fleet/Profiles/Console selected-pod flow with a shared `pod-context.js`, incident synopsis, Fleet top reasons, and preserved pod/profile/console links.

## Verification

- `./gradlew test`
- `./gradlew :argus-server:test --tests io.argus.server.metrics.GrafanaDashboardMetricReferencesTest --tests io.argus.server.metrics.DashboardStaticAssetsSmokeTest`
- `node --check` on changed dashboard JS files
- Grafana JSON parse, panel-shape, PromQL selector, and Helm parity script: 68 panels, 74 filtered expressions
- `git diff --check`
- Local HTTP smoke for `/`, `/fleet.html`, `/profiles.html?pod=...`, `/console.html?pod=...`, and `/js/pod-context.js`

## Quality Gate

- ai-slop-cleaner scoped pass: passed; no masking fallback slop in changed scope.
- Independent code-reviewer lane: APPROVE, zero CRITICAL/HIGH/MEDIUM/LOW findings after fixes.
- Independent architect lane: CLEAR after Fleet initial selection moved into shared `ArgusPodContext`.
